### PR TITLE
Debug and fix Docker errors

### DIFF
--- a/docker/DOCKER_FIX_NOTES.md
+++ b/docker/DOCKER_FIX_NOTES.md
@@ -1,0 +1,129 @@
+# Docker 404 Error Fixes
+
+## Issues Identified
+
+The 404 errors you were experiencing were caused by three main configuration problems:
+
+### 1. Missing mcp-config.json in Container
+**Problem**: The `mcp-config.json` file was not being copied into the Docker container, so the @typingmind/mcp connector couldn't find the server configurations.
+
+**Fix**: Updated both Dockerfiles to copy the configuration file:
+- `docker/Dockerfile.mcp-connector` - line 27
+- `docker/Dockerfile.connector-http-sse` - line 26
+
+### 2. HTTP/SSE Port Not Exposed
+**Problem**: The HTTP/SSE server runs on port 3000 internally but this port was not exposed in `docker-compose.connector-http-sse.yml`, preventing external connections.
+
+**Fix**: Updated `docker/docker-compose.connector-http-sse.yml` to expose port 3000:
+```yaml
+ports:
+  - "${MCP_CONNECTOR_PORT:-50880}:${MCP_CONNECTOR_PORT:-50880}"
+  - "${HTTP_SSE_PORT:-3000}:${HTTP_SSE_PORT:-3000}"
+```
+
+### 3. Connector Not Using Config File
+**Problem**: The entrypoint scripts were starting the @typingmind/mcp connector without specifying the config file path.
+
+**Fix**: Updated both entrypoint scripts to pass the config file path:
+- `docker/connector-http-sse-entrypoint.sh` - line 72
+- `docker/docker-entrypoint.sh` - line 72
+
+## How to Apply the Fixes
+
+1. **Rebuild the Docker images**:
+   ```bash
+   cd docker
+   docker-compose -f docker-compose.connector-http-sse.yml build --no-cache
+   ```
+
+2. **Restart the containers**:
+   ```bash
+   docker-compose -f docker-compose.connector-http-sse.yml down
+   docker-compose -f docker-compose.connector-http-sse.yml up -d
+   ```
+
+3. **Verify the fix**:
+   ```bash
+   # Check container logs
+   docker logs mcp-writing-system
+
+   # Test HTTP/SSE endpoints
+   curl http://localhost:3000/health
+   curl http://localhost:3000/
+
+   # Test individual server endpoints
+   curl http://localhost:3000/book-planning/health
+   curl http://localhost:3000/series-planning/health
+   ```
+
+## Expected Behavior After Fix
+
+1. **No more 404 errors** - The connector will successfully connect to all configured servers
+2. **HTTP/SSE endpoints accessible** - You can access the SSE endpoints at `http://localhost:3000/<server-name>`
+3. **Connector runs smoothly** - The @typingmind/mcp connector will properly load server configurations from mcp-config.json
+
+## Architecture Overview
+
+```
+TypingMind Client
+    ↓ (connects to)
+MCP Connector (port 50880)
+    ↓ (forwards requests to)
+HTTP/SSE Server (port 3000)
+    ↓ (manages)
+Individual MCP Servers
+    ↓ (connect to)
+PostgreSQL Database (port 5432)
+```
+
+## Available Endpoints
+
+Once fixed, the following endpoints will be available:
+
+- **Root**: `http://localhost:3000/` - Lists all servers
+- **Health**: `http://localhost:3000/health` - Global health check
+- **Server SSE**: `http://localhost:3000/<server-name>` - SSE endpoint for each server
+- **Server Health**: `http://localhost:3000/<server-name>/health` - Individual server health
+- **Server Info**: `http://localhost:3000/<server-name>/info` - Server information and tools
+
+### Available Servers:
+- book-planning
+- series-planning
+- chapter-planning
+- character-planning
+- scene
+- core-continuity
+- review
+- reporting
+
+## Troubleshooting
+
+If you still see errors after applying these fixes:
+
+1. **Check environment variables**:
+   ```bash
+   docker exec mcp-writing-system env | grep -E 'MCP|POSTGRES|HTTP'
+   ```
+
+2. **Verify mcp-config.json is in container**:
+   ```bash
+   docker exec mcp-writing-system cat /app/mcp-config.json
+   ```
+
+3. **Check if HTTP/SSE server is running**:
+   ```bash
+   docker exec mcp-writing-system ps aux | grep node
+   ```
+
+4. **Test database connection**:
+   ```bash
+   docker exec mcp-writing-system psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_DB -c '\q'
+   ```
+
+## Configuration Files Modified
+
+1. `docker/Dockerfile.mcp-connector`
+2. `docker/Dockerfile.connector-http-sse`
+3. `docker/docker-compose.connector-http-sse.yml`
+4. `docker/connector-http-sse-entrypoint.sh`
+5. `docker/docker-entrypoint.sh`

--- a/docker/Dockerfile.connector-http-sse
+++ b/docker/Dockerfile.connector-http-sse
@@ -22,6 +22,9 @@ RUN npm ci --only=production
 # Copy MCP server source code
 COPY src/ ./src/
 
+# Copy MCP configuration file
+COPY docker/mcp-config.json ./mcp-config.json
+
 # Copy entrypoint script
 COPY docker/connector-http-sse-entrypoint.sh /usr/local/bin/connector-http-sse-entrypoint.sh
 RUN sed -i 's/\r$//' /usr/local/bin/connector-http-sse-entrypoint.sh && \

--- a/docker/Dockerfile.mcp-connector
+++ b/docker/Dockerfile.mcp-connector
@@ -23,6 +23,9 @@ RUN npm ci --only=production
 # Copy MCP server source code
 COPY src/ ./src/
 
+# Copy MCP configuration file
+COPY docker/mcp-config.json ./mcp-config.json
+
 # Copy entrypoint script and ensure proper Unix line endings
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && \

--- a/docker/connector-http-sse-entrypoint.sh
+++ b/docker/connector-http-sse-entrypoint.sh
@@ -67,9 +67,9 @@ start_mcp_connector() {
     echo "   etc."
     echo ""
 
-    # Start the MCP Connector
+    # Start the MCP Connector with mcp-config.json
     # It will forward TypingMind requests to our HTTP/SSE endpoints
-    exec npx @typingmind/mcp@latest "$MCP_AUTH_TOKEN"
+    exec npx @typingmind/mcp@latest "$MCP_AUTH_TOKEN" /app/mcp-config.json
 }
 
 # Main execution

--- a/docker/docker-compose.connector-http-sse.yml
+++ b/docker/docker-compose.connector-http-sse.yml
@@ -76,8 +76,9 @@ services:
       NODE_ENV: ${NODE_ENV:-production}
       MCP_STDIO_MODE: "false"
     ports:
-      # Only expose connector port (HTTP/SSE server is internal)
+      # Expose both connector port and HTTP/SSE server port
       - "${MCP_CONNECTOR_PORT:-50880}:${MCP_CONNECTOR_PORT:-50880}"
+      - "${HTTP_SSE_PORT:-3000}:${HTTP_SSE_PORT:-3000}"
     volumes:
       # Preserve node_modules in container
       - /app/node_modules

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -67,9 +67,9 @@ start_mcp_connector() {
     echo "   Database: $POSTGRES_DB @ $POSTGRES_HOST"
     echo ""
 
-    # Start the MCP Connector with the auth token
+    # Start the MCP Connector with the auth token and config file
     # The connector will discover and run all MCP servers
-    exec npx @typingmind/mcp@latest "$MCP_AUTH_TOKEN"
+    exec npx @typingmind/mcp@latest "$MCP_AUTH_TOKEN" /app/mcp-config.json
 }
 
 # Main execution


### PR DESCRIPTION
Resolved three critical configuration issues causing 404 errors when connecting to MCP servers via SSE:

1. Added mcp-config.json to Docker containers
   - Updated Dockerfile.mcp-connector to copy config file
   - Updated Dockerfile.connector-http-sse to copy config file

2. Exposed HTTP/SSE server port 3000
   - Updated docker-compose.connector-http-sse.yml to expose port 3000
   - Allows external connections to SSE endpoints

3. Configured connector to use mcp-config.json
   - Updated connector-http-sse-entrypoint.sh to pass config file path
   - Updated docker-entrypoint.sh to pass config file path
   - Connector now properly loads server configurations

Added comprehensive documentation in DOCKER_FIX_NOTES.md explaining:
- Root causes of the 404 errors
- How to apply the fixes
- Architecture overview
- Troubleshooting steps

Fixes #404 SSE connection errors for author-server and other MCP servers