### PR TITLE
Fix port 3000 conflict between typing-mind-web and HTTP/SSE server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ MCP_AUTH_TOKEN=change-this-to-a-secure-random-token-32-chars-minimum
 # MCP Connector port (Typing Mind standard)
 MCP_CONNECTOR_PORT=50880
 
+# HTTP/SSE Server port (for connector-http-sse mode)
+# Separate from Typing Mind web UI port to avoid conflicts
+HTTP_SSE_PORT=3001
+
 # Include optional author server from mcps/ directory
 INCLUDE_AUTHOR_SERVER=true
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ docker-compose -f docker-compose.connector-http-sse.yml up -d
 
 Then in TypingMind:
 1. Connect to: `http://localhost:50880` (with your `MCP_AUTH_TOKEN` from `.env`)
-2. Configure servers with URLs: `http://localhost:3000/book-planning`, etc.
+2. Configure servers with URLs: `http://localhost:3001/book-planning`, etc.
 
 **See: [`TYPINGMIND-SETUP-FINAL.md`](TYPINGMIND-SETUP-FINAL.md) for complete instructions.**
 
@@ -36,11 +36,11 @@ Then in TypingMind:
 
 ```
 TypingMind → @typingmind/mcp Connector → HTTP/SSE Server → MCP Servers → PostgreSQL
-             Port 50880 (HTTP API)        Port 3000 (SSE)
+             Port 50880 (HTTP API)        Port 3001 (SSE)
 ```
 
 **How it works:**
-1. **HTTP/SSE Server** runs all 8 MCP servers with SSE endpoints (internal port 3000)
+1. **HTTP/SSE Server** runs all 8 MCP servers with SSE endpoints (internal port 3001)
 2. **Connector** bridges TypingMind to SSE endpoints (exposed port 50880)
 3. **TypingMind** connects to connector and configures servers using URLs
 
@@ -52,14 +52,14 @@ Once running, you have 8 MCP servers:
 
 | Server | URL (for TypingMind config) |
 |--------|------------------------------|
-| Book Planning | `http://localhost:3000/book-planning` |
-| Series Planning | `http://localhost:3000/series-planning` |
-| Chapter Planning | `http://localhost:3000/chapter-planning` |
-| Character Planning | `http://localhost:3000/character-planning` |
-| Scene | `http://localhost:3000/scene` |
-| Core Continuity | `http://localhost:3000/core-continuity` |
-| Review | `http://localhost:3000/review` |
-| Reporting | `http://localhost:3000/reporting` |
+| Book Planning | `http://localhost:3001/book-planning` |
+| Series Planning | `http://localhost:3001/series-planning` |
+| Chapter Planning | `http://localhost:3001/chapter-planning` |
+| Character Planning | `http://localhost:3001/character-planning` |
+| Scene | `http://localhost:3001/scene` |
+| Core Continuity | `http://localhost:3001/core-continuity` |
+| Review | `http://localhost:3001/review` |
+| Reporting | `http://localhost:3001/reporting` |
 
 ---
 
@@ -95,7 +95,7 @@ docker ps
 docker logs mcp-writing-system -f
 
 # Test endpoints
-docker exec mcp-writing-system curl http://localhost:3000/health
+docker exec mcp-writing-system curl http://localhost:3001/health
 curl http://localhost:50880/health
 ```
 
@@ -106,7 +106,7 @@ See [`TYPINGMIND-SETUP-FINAL.md`](TYPINGMIND-SETUP-FINAL.md) for detailed instru
 **Quick version:**
 - Connector URL: `http://localhost:50880`
 - Auth Token: (from your `.env` file)
-- Server configs: Use URLs like `http://localhost:3000/book-planning`
+- Server configs: Use URLs like `http://localhost:3001/book-planning`
 
 ---
 
@@ -167,9 +167,9 @@ docker-compose -f docker-compose.connector-http-sse.yml down -v
 
 ```bash
 # Test HTTP/SSE server (inside container)
-docker exec mcp-writing-system curl http://localhost:3000/
-docker exec mcp-writing-system curl http://localhost:3000/health
-docker exec mcp-writing-system curl http://localhost:3000/book-planning/info
+docker exec mcp-writing-system curl http://localhost:3001/
+docker exec mcp-writing-system curl http://localhost:3001/health
+docker exec mcp-writing-system curl http://localhost:3001/book-planning/info
 
 # Test connector (from host)
 curl http://localhost:50880/health
@@ -213,7 +213,7 @@ docker exec mcp-writing-system env | grep -E "(DATABASE|POSTGRES)"
 
 **No tools showing in TypingMind:**
 - Check logs: `docker logs mcp-writing-system -f`
-- Verify HTTP/SSE endpoints: `docker exec mcp-writing-system curl http://localhost:3000/`
+- Verify HTTP/SSE endpoints: `docker exec mcp-writing-system curl http://localhost:3001/`
 - Check server configuration in TypingMind (must use URLs, not commands)
 
 See [`TYPINGMIND-SETUP-FINAL.md`](TYPINGMIND-SETUP-FINAL.md) for detailed troubleshooting.

--- a/docker/TYPINGMIND-SETUP-FINAL.md
+++ b/docker/TYPINGMIND-SETUP-FINAL.md
@@ -13,7 +13,7 @@ TypingMind (Web) → @typingmind/mcp Connector → HTTP/SSE Server → MCP Serve
 **Key Points:**
 - ✅ TypingMind connects to the connector at `localhost:50880`
 - ✅ Connector uses HTTP/SSE to communicate with MCP servers (NOT stdio)
-- ✅ Each MCP server has an SSE endpoint at `localhost:3000/<server-name>`
+- ✅ Each MCP server has an SSE endpoint at `localhost:3001/<server-name>`
 - ✅ Configure servers in TypingMind with **URLs** (not commands)
 
 ---
@@ -44,11 +44,11 @@ docker logs mcp-writing-system -f
 🚀 Starting MCP Connector...
    Port: 50880
    Auth Token: abc12345****
-   HTTP/SSE Backend: http://localhost:3000
+   HTTP/SSE Backend: http://localhost:3001
 
 ℹ️  Configure servers in TypingMind UI with URLs like:
-   http://localhost:3000/book-planning
-   http://localhost:3000/series-planning
+   http://localhost:3001/book-planning
+   http://localhost:3001/series-planning
 ```
 
 ---
@@ -76,7 +76,7 @@ After connecting to the connector, configure each MCP server using **URL format*
 #### Important Notes
 
 - **Use URLs, not commands!** This is HTTP/SSE mode, not stdio mode
-- **URLs are internal to Docker:** Use `http://localhost:3000/<server-name>`
+- **URLs are internal to Docker:** Use `http://localhost:3001/<server-name>`
 - **No DATABASE_URL needed** - servers inherit connection from Docker environment
 - **No MCP_STDIO_MODE** - servers run in HTTP/SSE mode automatically
 
@@ -92,7 +92,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "book-planning": {
-    "url": "http://localhost:3000/book-planning"
+    "url": "http://localhost:3001/book-planning"
   }
 }
 ```
@@ -101,7 +101,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "series-planning": {
-    "url": "http://localhost:3000/series-planning"
+    "url": "http://localhost:3001/series-planning"
   }
 }
 ```
@@ -110,7 +110,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "chapter-planning": {
-    "url": "http://localhost:3000/chapter-planning"
+    "url": "http://localhost:3001/chapter-planning"
   }
 }
 ```
@@ -119,7 +119,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "character-planning": {
-    "url": "http://localhost:3000/character-planning"
+    "url": "http://localhost:3001/character-planning"
   }
 }
 ```
@@ -128,7 +128,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "scene": {
-    "url": "http://localhost:3000/scene"
+    "url": "http://localhost:3001/scene"
   }
 }
 ```
@@ -137,7 +137,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "core-continuity": {
-    "url": "http://localhost:3000/core-continuity"
+    "url": "http://localhost:3001/core-continuity"
   }
 }
 ```
@@ -146,7 +146,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "review": {
-    "url": "http://localhost:3000/review"
+    "url": "http://localhost:3001/review"
   }
 }
 ```
@@ -155,7 +155,7 @@ Copy these configurations into TypingMind's MCP server settings:
 ```json
 {
   "reporting": {
-    "url": "http://localhost:3000/reporting"
+    "url": "http://localhost:3001/reporting"
   }
 }
 ```
@@ -170,28 +170,28 @@ If TypingMind allows pasting all servers at once:
 {
   "mcpServers": {
     "book-planning": {
-      "url": "http://localhost:3000/book-planning"
+      "url": "http://localhost:3001/book-planning"
     },
     "series-planning": {
-      "url": "http://localhost:3000/series-planning"
+      "url": "http://localhost:3001/series-planning"
     },
     "chapter-planning": {
-      "url": "http://localhost:3000/chapter-planning"
+      "url": "http://localhost:3001/chapter-planning"
     },
     "character-planning": {
-      "url": "http://localhost:3000/character-planning"
+      "url": "http://localhost:3001/character-planning"
     },
     "scene": {
-      "url": "http://localhost:3000/scene"
+      "url": "http://localhost:3001/scene"
     },
     "core-continuity": {
-      "url": "http://localhost:3000/core-continuity"
+      "url": "http://localhost:3001/core-continuity"
     },
     "review": {
-      "url": "http://localhost:3000/review"
+      "url": "http://localhost:3001/review"
     },
     "reporting": {
-      "url": "http://localhost:3000/reporting"
+      "url": "http://localhost:3001/reporting"
     }
   }
 }
@@ -207,7 +207,7 @@ From your host machine:
 
 ```bash
 # Test the HTTP/SSE server directly (inside Docker)
-docker exec mcp-writing-system curl http://localhost:3000/health
+docker exec mcp-writing-system curl http://localhost:3001/health
 
 # Should return:
 # {"status":"healthy","serverCount":8,"timestamp":"..."}
@@ -216,7 +216,7 @@ docker exec mcp-writing-system curl http://localhost:3000/health
 ### Test 2: List All Available Servers
 
 ```bash
-docker exec mcp-writing-system curl http://localhost:3000/
+docker exec mcp-writing-system curl http://localhost:3001/
 
 # Returns JSON with all available servers and their endpoints
 ```
@@ -224,7 +224,7 @@ docker exec mcp-writing-system curl http://localhost:3000/
 ### Test 3: Check a Specific Server's Tools
 
 ```bash
-docker exec mcp-writing-system curl http://localhost:3000/book-planning/info
+docker exec mcp-writing-system curl http://localhost:3001/book-planning/info
 
 # Returns:
 # {
@@ -250,7 +250,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:50880/clients
 
 ```bash
 # Test SSE endpoint (will stream events)
-docker exec mcp-writing-system curl -N http://localhost:3000/book-planning
+docker exec mcp-writing-system curl -N http://localhost:3001/book-planning
 ```
 
 ---
@@ -341,13 +341,13 @@ curl http://localhost:50880/health
 
 **Verify HTTP/SSE server is running:**
 ```bash
-docker exec mcp-writing-system curl http://localhost:3000/
+docker exec mcp-writing-system curl http://localhost:3001/
 # Should list all 8 servers
 ```
 
 **Check specific server:**
 ```bash
-docker exec mcp-writing-system curl http://localhost:3000/book-planning/info
+docker exec mcp-writing-system curl http://localhost:3001/book-planning/info
 # Should show server info and tools
 ```
 
@@ -454,7 +454,7 @@ openssl rand -hex 32
 
 1. ✅ Start Docker: `docker-compose -f docker-compose.connector-http-sse.yml up -d`
 2. ✅ Connect TypingMind to connector: `http://localhost:50880` with your auth token
-3. ✅ Configure servers in TypingMind with **URLs**: `http://localhost:3000/<server-name>`
+3. ✅ Configure servers in TypingMind with **URLs**: `http://localhost:3001/<server-name>`
 4. ✅ Start using your MCP writing tools!
 
 ---
@@ -473,7 +473,7 @@ If you encounter issues:
 
 1. Check Docker logs: `docker logs mcp-writing-system -f`
 2. Check database: `docker logs mcp-writing-db`
-3. Test HTTP/SSE endpoints: `docker exec mcp-writing-system curl http://localhost:3000/`
+3. Test HTTP/SSE endpoints: `docker exec mcp-writing-system curl http://localhost:3001/`
 4. Test connector: `curl http://localhost:50880/health`
 5. Verify environment variables in `.env`
 

--- a/docker/docker-compose.connector-http-sse.yml
+++ b/docker/docker-compose.connector-http-sse.yml
@@ -36,13 +36,13 @@ services:
   # MCP Writing System (Connector + HTTP/SSE)
   # ========================================
   # Combined container running:
-  # 1. HTTP/SSE Server (port 3000) - SSE endpoints for each MCP server
+  # 1. HTTP/SSE Server (port 3001) - SSE endpoints for each MCP server
   # 2. @typingmind/mcp Connector (port 50880) - TypingMind integration
   #
   # TypingMind connects to: http://localhost:50880
   # Configure servers in TypingMind with URLs like:
-  #   http://localhost:3000/book-planning
-  #   http://localhost:3000/series-planning
+  #   http://localhost:3001/book-planning
+  #   http://localhost:3001/series-planning
   #   etc.
   mcp-writing-system:
     build:
@@ -65,7 +65,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
 
       # HTTP/SSE server configuration
-      HTTP_SSE_PORT: ${HTTP_SSE_PORT:-3000}
+      HTTP_SSE_PORT: ${HTTP_SSE_PORT:-3001}
 
       # Connector configuration
       MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN}
@@ -78,7 +78,7 @@ services:
     ports:
       # Expose both connector port and HTTP/SSE server port
       - "${MCP_CONNECTOR_PORT:-50880}:${MCP_CONNECTOR_PORT:-50880}"
-      - "${HTTP_SSE_PORT:-3000}:${HTTP_SSE_PORT:-3000}"
+      - "${HTTP_SSE_PORT:-3001}:${HTTP_SSE_PORT:-3001}"
     volumes:
       # Preserve node_modules in container
       - /app/node_modules

--- a/docker/mcp-config.json
+++ b/docker/mcp-config.json
@@ -1,28 +1,28 @@
 {
   "mcpServers": {
     "book-planning": {
-      "url": "http://localhost:3000/book-planning"
+      "url": "http://localhost:3001/book-planning"
     },
     "series-planning": {
-      "url": "http://localhost:3000/series-planning"
+      "url": "http://localhost:3001/series-planning"
     },
     "chapter-planning": {
-      "url": "http://localhost:3000/chapter-planning"
+      "url": "http://localhost:3001/chapter-planning"
     },
     "character-planning": {
-      "url": "http://localhost:3000/character-planning"
+      "url": "http://localhost:3001/character-planning"
     },
     "scene": {
-      "url": "http://localhost:3000/scene"
+      "url": "http://localhost:3001/scene"
     },
     "core-continuity": {
-      "url": "http://localhost:3000/core-continuity"
+      "url": "http://localhost:3001/core-continuity"
     },
     "review": {
-      "url": "http://localhost:3000/review"
+      "url": "http://localhost:3001/review"
     },
     "reporting": {
-      "url": "http://localhost:3000/reporting"
+      "url": "http://localhost:3001/reporting"
     }
   }
 }


### PR DESCRIPTION
Changes HTTP/SSE server port from 3000 to 3001 to prevent conflict with the typing-mind-web nginx container, which also uses port 3000 by default.

This resolves the Docker error:
"Bind for 0.0.0.0:3000 failed: port is already allocated"

Changes:
- docker-compose.connector-http-sse.yml: Change HTTP_SSE_PORT default from 3000 to 3001
- .env.example: Add HTTP_SSE_PORT=3001 configuration with documentation
- docker/README.md: Update all references to HTTP/SSE port from 3000 to 3001
- docker/TYPINGMIND-SETUP-FINAL.md: Update all localhost:3000 URLs to localhost:3001

This allows both services to run simultaneously:
- typing-mind-web (nginx): Port 3000
- HTTP/SSE server: Port 3001
- MCP Connector: Port 50880

🤖 Generated with [Claude Code](https://claude.com/claude-code)