### PR TITLE
Fix GPT5 parameter requirement detection bug

### DIFF
--- a/src/config-mcps/reporting-server/schemas/reporting-tools-schema.js
+++ b/src/config-mcps/reporting-server/schemas/reporting-tools-schema.js
@@ -10,23 +10,23 @@ export const reportingToolsSchema = [
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'The ID of the series to generate report for'
+                    description: 'The ID of the series to generate report for?'
                 },
                 book_id: {
                     type: 'integer',
-                    description: 'The ID of the book to generate report for'
+                    description: 'The ID of the book to generate report for?'
                 },
                 series_name: {
                     type: 'string',
-                    description: 'The name of the series to generate report for (will search for matching series)'
+                    description: 'The name of the series to generate report for (will search for matching series)?'
                 },
                 book_name: {
                     type: 'string',
-                    description: 'The name of the book to generate report for (will search for matching book)'
+                    description: 'The name of the book to generate report for (will search for matching book)?'
                 },
                 include_sections: {
                     type: 'array',
-                    description: 'Optional: Specific sections to include. If not provided, includes all sections.',
+                    description: 'Optional: Specific sections to include. If not provided, includes all sections?',
                     items: {
                         type: 'string',
                         enum: [

--- a/src/mcps/author-server/schemas/author-tools-schema.js
+++ b/src/mcps/author-server/schemas/author-tools-schema.js
@@ -33,9 +33,9 @@ export const authorToolsSchema = [
             type: 'object',
             properties: {
                 name: { type: 'string', description: 'Author name' },
-                email: { type: 'string', description: 'Email' },
-                bio: { type: 'string', description: 'Bio' },
-                birth_year: { type: 'integer', description: 'Birth year' }
+                email: { type: 'string', description: 'Email?' },
+                bio: { type: 'string', description: 'Bio?' },
+                birth_year: { type: 'integer', description: 'Birth year?' }
             },
             required: ['name']
         }
@@ -47,9 +47,9 @@ export const authorToolsSchema = [
             type: 'object',
             properties: {
                 author_id: { type: 'integer', description: 'Author ID' },
-                name: { type: 'string', description: 'Author name' },
-                bio: { type: 'string', description: 'Bio' },
-                birth_year: { type: 'integer', description: 'Birth year' }
+                name: { type: 'string', description: 'Author name?' },
+                bio: { type: 'string', description: 'Bio?' },
+                birth_year: { type: 'integer', description: 'Birth year?' }
             },
             required: ['author_id']
         }

--- a/src/mcps/book-server/schemas/book-planning-schemas.js
+++ b/src/mcps/book-server/schemas/book-planning-schemas.js
@@ -30,41 +30,41 @@ export const bookPlanningSchemas = {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
                     default: 'planned',
-                    description: 'Status'
+                    description: 'Status?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 actual_word_count: {
                     type: 'integer',
                     default: 0,
-                    description: 'Current word count'
+                    description: 'Current word count?'
                 },
                 publication_year: {
                     type: 'integer',
-                    description: 'Pub year'
+                    description: 'Pub year?'
                 },
                 description: {
                     type: 'string',
-                    description: 'Description'
+                    description: 'Description?'
                 },
                 isbn: {
                     type: 'string',
-                    description: 'ISBN'
+                    description: 'ISBN?'
                 },
                 page_count: {
                     type: 'integer',
-                    description: 'Pages'
+                    description: 'Pages?'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'Cover URL'
+                    description: 'Cover URL?'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names'
+                    description: 'Genre names?'
                 }
             },
             required: ['title', 'series_id', 'book_number']
@@ -83,49 +83,49 @@ export const bookPlanningSchemas = {
                 },
                 title: {
                     type: 'string',
-                    description: 'Title'
+                    description: 'Title?'
                 },
                 book_number: {
                     type: 'integer',
-                    description: 'Series position'
+                    description: 'Series position?'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Status'
+                    description: 'Status?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 actual_word_count: {
                     type: 'integer',
-                    description: 'Current word count'
+                    description: 'Current word count?'
                 },
                 publication_year: {
                     type: 'integer',
-                    description: 'Pub year'
+                    description: 'Pub year?'
                 },
                 isbn: {
                     type: 'string',
-                    description: 'ISBN'
+                    description: 'ISBN?'
                 },
                 page_count: {
                     type: 'integer',
-                    description: 'Pages'
+                    description: 'Pages?'
                 },
                 description: {
                     type: 'string',
-                    description: 'Description'
+                    description: 'Description?'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'Cover URL'
+                    description: 'Cover URL?'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names'
+                    description: 'Genre names?'
                 }
             },
             required: ['book_id']
@@ -145,7 +145,7 @@ export const bookPlanningSchemas = {
                 include_chapters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include chapters'
+                    description: 'Include chapters?'
                 }
             },
             required: ['book_id']
@@ -160,17 +160,17 @@ export const bookPlanningSchemas = {
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID filter'
+                    description: 'Series ID filter?'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Status filter'
+                    description: 'Status filter?'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include stats'
+                    description: 'Include stats?'
                 }
             },
             required: []

--- a/src/mcps/book-server/schemas/book-tools-schema.js
+++ b/src/mcps/book-server/schemas/book-tools-schema.js
@@ -14,17 +14,17 @@ export const bookToolsSchema = [
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID filter'
+                    description: 'Series ID filter?'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Status filter'
+                    description: 'Status filter?'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include stats'
+                    description: 'Include stats?'
                 }
             },
             required: []
@@ -43,7 +43,7 @@ export const bookToolsSchema = [
                 include_chapters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include chapters'
+                    description: 'Include chapters?'
                 }
             },
             required: ['book_id']
@@ -71,41 +71,41 @@ export const bookToolsSchema = [
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
                     default: 'planned',
-                    description: 'Status'
+                    description: 'Status?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 actual_word_count: {
                     type: 'integer',
                     default: 0,
-                    description: 'Current word count'
+                    description: 'Current word count?'
                 },
                 publication_year: {
                     type: 'integer',
-                    description: 'Pub year'
+                    description: 'Pub year?'
                 },
                 description: {
                     type: 'string',
-                    description: 'Description'
+                    description: 'Description?'
                 },
                 isbn: {
                     type: 'string',
-                    description: 'ISBN'
+                    description: 'ISBN?'
                 },
                 page_count: {
                     type: 'integer',
-                    description: 'Pages'
+                    description: 'Pages?'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'Cover URL'
+                    description: 'Cover URL?'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names'
+                    description: 'Genre names?'
                 }
             },
             required: ['title', 'series_id', 'book_number']
@@ -123,49 +123,49 @@ export const bookToolsSchema = [
                 },
                 title: {
                     type: 'string',
-                    description: 'Title'
+                    description: 'Title?'
                 },
                 book_number: {
                     type: 'integer',
-                    description: 'Series position'
+                    description: 'Series position?'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Status'
+                    description: 'Status?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 actual_word_count: {
                     type: 'integer',
-                    description: 'Current word count'
+                    description: 'Current word count?'
                 },
                 publication_year: {
                     type: 'integer',
-                    description: 'Pub year'
+                    description: 'Pub year?'
                 },
                 isbn: {
                     type: 'string',
-                    description: 'ISBN'
+                    description: 'ISBN?'
                 },
                 page_count: {
                     type: 'integer',
-                    description: 'Pages'
+                    description: 'Pages?'
                 },
                 description: {
                     type: 'string',
-                    description: 'Description'
+                    description: 'Description?'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'Cover URL'
+                    description: 'Cover URL?'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names'
+                    description: 'Genre names?'
                 }
             },
             required: ['book_id']
@@ -211,49 +211,49 @@ export const chapterToolsSchema = [
                 },
                 title: {
                     type: 'string',
-                    description: 'Title'
+                    description: 'Title?'
                 },
                 subtitle: {
                     type: 'string',
-                    description: 'Subtitle'
+                    description: 'Subtitle?'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Summary'
+                    description: 'Summary?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
                     default: 'planned',
-                    description: 'Writing status'
+                    description: 'Writing status?'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'POV character ID'
+                    description: 'POV character ID?'
                 },
                 primary_location: {
                     type: 'string',
-                    description: 'Main setting'
+                    description: 'Main setting?'
                 },
                 story_time_start: {
                     type: 'string',
-                    description: 'Start time (e.g., "Day 1, 3pm")'
+                    description: 'Start time (e.g., "Day 1, 3pm")?'
                 },
                 story_time_end: {
                     type: 'string',
-                    description: 'End time'
+                    description: 'End time?'
                 },
                 story_duration: {
                     type: 'string',
-                    description: 'Duration (e.g., "2 hours")'
+                    description: 'Duration (e.g., "2 hours")?'
                 },
                 author_notes: {
                     type: 'string',
-                    description: 'Planning notes'
+                    description: 'Planning notes?'
                 }
             },
             required: ['book_id', 'chapter_number']
@@ -271,56 +271,56 @@ export const chapterToolsSchema = [
                 },
                 title: {
                     type: 'string',
-                    description: 'Title'
+                    description: 'Title?'
                 },
                 subtitle: {
                     type: 'string',
-                    description: 'Subtitle'
+                    description: 'Subtitle?'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Summary'
+                    description: 'Summary?'
                 },
                 word_count: {
                     type: 'integer',
-                    description: 'Current word count'
+                    description: 'Current word count?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Writing status'
+                    description: 'Writing status?'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'POV character ID'
+                    description: 'POV character ID?'
                 },
                 primary_location: {
                     type: 'string',
-                    description: 'Main setting'
+                    description: 'Main setting?'
                 },
                 story_time_start: {
                     type: 'string',
-                    description: 'Start time'
+                    description: 'Start time?'
                 },
                 story_time_end: {
                     type: 'string',
-                    description: 'End time'
+                    description: 'End time?'
                 },
                 story_duration: {
                     type: 'string',
-                    description: 'Duration'
+                    description: 'Duration?'
                 },
                 author_notes: {
                     type: 'string',
-                    description: 'Author notes'
+                    description: 'Author notes?'
                 },
                 writing_notes: {
                     type: 'string',
-                    description: 'Writing notes'
+                    description: 'Writing notes?'
                 }
             },
             required: ['chapter_id']
@@ -339,12 +339,12 @@ export const chapterToolsSchema = [
                 include_scenes: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include scenes'
+                    description: 'Include scenes?'
                 },
                 include_characters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character presence'
+                    description: 'Include character presence?'
                 }
             },
             required: ['chapter_id']
@@ -363,12 +363,12 @@ export const chapterToolsSchema = [
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Status filter'
+                    description: 'Status filter?'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include stats'
+                    description: 'Include stats?'
                 }
             },
             required: ['book_id']
@@ -441,71 +441,71 @@ export const sceneToolsSchema = [
                 },
                 scene_title: {
                     type: 'string',
-                    description: 'Title'
+                    description: 'Title?'
                 },
                 scene_purpose: {
                     type: 'string',
                     enum: ['action', 'dialogue', 'description', 'transition', 'exposition', 'conflict', 'resolution'],
-                    description: 'Purpose'
+                    description: 'Purpose?'
                 },
                 scene_type: {
                     type: 'string',
                     enum: ['dramatic', 'comedic', 'action', 'romance', 'mystery', 'horror', 'slice_of_life'],
-                    description: 'Tone/genre'
+                    description: 'Tone/genre?'
                 },
                 location: {
                     type: 'string',
-                    description: 'Location'
+                    description: 'Location?'
                 },
                 time_of_day: {
                     type: 'string',
-                    description: 'Time (morning, afternoon, night, etc.)'
+                    description: 'Time (morning, afternoon, night, etc.)?'
                 },
                 duration: {
                     type: 'string',
-                    description: 'Duration (5 minutes, 2 hours, etc.)'
+                    description: 'Duration (5 minutes, 2 hours, etc.)?'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Summary'
+                    description: 'Summary?'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'POV character ID'
+                    description: 'POV character ID?'
                 },
                 scene_participants: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Character IDs in scene'
+                    description: 'Character IDs in scene?'
                 },
                 writing_status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
                     default: 'planned',
-                    description: 'Writing status'
+                    description: 'Writing status?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 intensity_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Intensity (1=low, 10=max)'
+                    description: 'Intensity (1=low, 10=max)?'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Element tags (tropes, themes, moods)'
+                    description: 'Element tags (tropes, themes, moods)?'
                 },
                 implementation_notes: {
                     type: 'string',
-                    description: 'Implementation notes'
+                    description: 'Implementation notes?'
                 },
                 notes: {
                     type: 'string',
-                    description: 'Author notes'
+                    description: 'Author notes?'
                 }
             },
             required: ['chapter_id', 'scene_number']
@@ -523,74 +523,74 @@ export const sceneToolsSchema = [
                 },
                 scene_title: {
                     type: 'string',
-                    description: 'Title'
+                    description: 'Title?'
                 },
                 scene_purpose: {
                     type: 'string',
                     enum: ['action', 'dialogue', 'description', 'transition', 'exposition', 'conflict', 'resolution'],
-                    description: 'Purpose'
+                    description: 'Purpose?'
                 },
                 scene_type: {
                     type: 'string',
                     enum: ['dramatic', 'comedic', 'action', 'romance', 'mystery', 'horror', 'slice_of_life'],
-                    description: 'Tone/genre'
+                    description: 'Tone/genre?'
                 },
                 location: {
                     type: 'string',
-                    description: 'Location'
+                    description: 'Location?'
                 },
                 time_of_day: {
                     type: 'string',
-                    description: 'Time of day'
+                    description: 'Time of day?'
                 },
                 duration: {
                     type: 'string',
-                    description: 'Duration'
+                    description: 'Duration?'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Summary'
+                    description: 'Summary?'
                 },
                 word_count: {
                     type: 'integer',
-                    description: 'Current word count'
+                    description: 'Current word count?'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count'
+                    description: 'Target word count?'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'POV character ID'
+                    description: 'POV character ID?'
                 },
                 scene_participants: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Character IDs in scene'
+                    description: 'Character IDs in scene?'
                 },
                 writing_status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Writing status'
+                    description: 'Writing status?'
                 },
                 intensity_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Intensity (1=low, 10=max)'
+                    description: 'Intensity (1=low, 10=max)?'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Element tags (tropes, themes, moods)'
+                    description: 'Element tags (tropes, themes, moods)?'
                 },
                 implementation_notes: {
                     type: 'string',
-                    description: 'Implementation notes'
+                    description: 'Implementation notes?'
                 },
                 notes: {
                     type: 'string',
-                    description: 'Scene notes'
+                    description: 'Scene notes?'
                 }
             },
             required: ['scene_id']
@@ -609,7 +609,7 @@ export const sceneToolsSchema = [
                 include_characters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character details'
+                    description: 'Include character details?'
                 }
             },
             required: ['scene_id']
@@ -628,17 +628,17 @@ export const sceneToolsSchema = [
                 scene_type: {
                     type: 'string',
                     enum: ['dramatic', 'comedic', 'action', 'romance', 'mystery', 'horror', 'slice_of_life'],
-                    description: 'Scene type filter'
+                    description: 'Scene type filter?'
                 },
                 writing_status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Status filter'
+                    description: 'Status filter?'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include stats'
+                    description: 'Include stats?'
                 },
                 intensity_filter: {
                     type: 'object',
@@ -646,12 +646,12 @@ export const sceneToolsSchema = [
                         min_intensity: { type: 'integer', minimum: 1, maximum: 10 },
                         max_intensity: { type: 'integer', minimum: 1, maximum: 10 }
                     },
-                    description: 'Intensity range filter'
+                    description: 'Intensity range filter?'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Element filter'
+                    description: 'Element filter?'
                 }
             },
             required: ['chapter_id']
@@ -715,12 +715,12 @@ export const sceneToolsSchema = [
                     type: 'string',
                     enum: ['intensity_flow', 'element_distribution', 'character_presence', 'scene_balance'],
                     default: 'intensity_flow',
-                    description: 'Analysis type'
+                    description: 'Analysis type?'
                 },
                 include_suggestions: {
                     type: 'boolean',
                     default: true,
-                    description: 'Include suggestions'
+                    description: 'Include suggestions?'
                 }
             },
             required: ['chapter_id']
@@ -746,12 +746,12 @@ export const analysisToolsSchema = [
                 include_scene_details: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include scene details'
+                    description: 'Include scene details?'
                 },
                 include_character_info: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character presence'
+                    description: 'Include character presence?'
                 }
             },
             required: ['book_id']
@@ -770,12 +770,12 @@ export const analysisToolsSchema = [
                 include_projections: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include completion projections'
+                    description: 'Include completion projections?'
                 },
                 include_recommendations: {
                     type: 'boolean',
                     default: true,
-                    description: 'Include recommendations'
+                    description: 'Include recommendations?'
                 }
             },
             required: ['book_id']
@@ -794,23 +794,23 @@ export const analysisToolsSchema = [
                 check_chapter_numbering: {
                     type: 'boolean',
                     default: true,
-                    description: 'Check chapter numbering'
+                    description: 'Check chapter numbering?'
                 },
                 check_word_counts: {
                     type: 'boolean',
                     default: true,
-                    description: 'Check word counts'
+                    description: 'Check word counts?'
                 },
                 check_character_continuity: {
                     type: 'boolean',
                     default: false,
-                    description: 'Check character continuity (needs character server)'
+                    description: 'Check character continuity (needs character server)?'
                 },
                 severity_level: {
                     type: 'string',
                     enum: ['all', 'warnings_and_errors', 'errors_only'],
                     default: 'all',
-                    description: 'Issue severity filter'
+                    description: 'Issue severity filter?'
                 }
             },
             required: ['book_id']

--- a/src/mcps/character-server/schemas/character-tools-schema.js
+++ b/src/mcps/character-server/schemas/character-tools-schema.js
@@ -16,12 +16,12 @@ export const characterToolsSchema = [
                 character_type: {
                     type: 'string',
                     enum: ['main', 'supporting', 'minor', 'antagonist'],
-                    description: 'Type filter'
+                    description: 'Type filter?'
                 },
                 status: {
                     type: 'string',
                     enum: ['alive', 'dead', 'missing', 'unknown'],
-                    description: 'Status filter'
+                    description: 'Status filter?'
                 }
             },
             required: ['series_id']
@@ -46,22 +46,22 @@ export const characterToolsSchema = [
             properties: {
                 series_id: { type: 'integer', description: 'Series ID' },
                 name: { type: 'string', description: 'Primary name' },
-                full_name: { type: 'string', description: 'Full name' },
+                full_name: { type: 'string', description: 'Full name?' },
                 aliases: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Alt names/nicknames'
+                    description: 'Alt names/nicknames?'
                 },
                 character_type: {
                     type: 'string',
                     enum: ['main', 'supporting', 'minor', 'antagonist'],
-                    description: 'Importance level'
+                    description: 'Importance level?'
                 },
-                first_appearance_book_id: { type: 'integer', description: 'First appearance book ID' },
+                first_appearance_book_id: { type: 'integer', description: 'First appearance book ID?' },
                 status: {
                     type: 'string',
                     enum: ['alive', 'dead', 'missing', 'unknown'],
-                    description: 'Status'
+                    description: 'Status?'
                 }
             },
             required: ['series_id', 'name']
@@ -74,17 +74,17 @@ export const characterToolsSchema = [
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
-                name: { type: 'string', description: 'Primary name' },
-                full_name: { type: 'string', description: 'Full name' },
+                name: { type: 'string', description: 'Primary name?' },
+                full_name: { type: 'string', description: 'Full name?' },
                 character_type: {
                     type: 'string',
                     enum: ['main', 'supporting', 'minor', 'antagonist'],
-                    description: 'Importance level'
+                    description: 'Importance level?'
                 },
                 status: {
                     type: 'string',
                     enum: ['alive', 'dead', 'missing', 'unknown'],
-                    description: 'Status'
+                    description: 'Status?'
                 }
             },
             required: ['character_id']
@@ -112,11 +112,11 @@ export const characterDetailToolsSchema = [
                     description: 'Attribute (eye_color/height/temperament)'
                 },
                 value: { type: 'string', description: 'Value' },
-                source_book_id: { type: 'integer', description: 'Source book ID' },
+                source_book_id: { type: 'integer', description: 'Source book ID?' },
                 confidence_level: {
                     type: 'string',
                     enum: ['established', 'mentioned', 'implied'],
-                    description: 'Confidence level'
+                    description: 'Confidence level?'
                 }
             },
             required: ['character_id', 'category', 'attribute', 'value']
@@ -131,7 +131,7 @@ export const characterDetailToolsSchema = [
                 character_id: { type: 'integer', description: 'Character ID' },
                 category: {
                     type: 'string',
-                    description: 'Category filter'
+                    description: 'Category filter?'
                 }
             },
             required: ['character_id']
@@ -153,11 +153,11 @@ export const characterDetailToolsSchema = [
                     description: 'Attribute to update'
                 },
                 value: { type: 'string', description: 'New value' },
-                source_book_id: { type: 'integer', description: 'Source book ID' },
+                source_book_id: { type: 'integer', description: 'Source book ID?' },
                 confidence_level: {
                     type: 'string',
                     enum: ['established', 'mentioned', 'implied'],
-                    description: 'Confidence level'
+                    description: 'Confidence level?'
                 }
             },
             required: ['character_id', 'category', 'attribute', 'value']
@@ -206,12 +206,12 @@ export const characterKnowledgeToolsSchema = [
                 knowledge_level: {
                     type: 'string',
                     enum: ['knows', 'suspects', 'unaware', 'forgot'],
-                    description: 'Knowledge level'
+                    description: 'Knowledge level?'
                 },
-                learned_book_id: { type: 'integer', description: 'Book learned in' },
+                learned_book_id: { type: 'integer', description: 'Book learned in?' },
                 learned_context: {
                     type: 'string',
-                    description: 'How/when learned'
+                    description: 'How/when learned?'
                 }
             },
             required: ['character_id', 'knowledge_category', 'knowledge_item']
@@ -235,14 +235,14 @@ export const characterKnowledgeToolsSchema = [
                 knowledge_level: {
                     type: 'string',
                     enum: ['knows', 'suspects', 'unaware', 'forgot'],
-                    description: 'Knowledge level',
+                    description: 'Knowledge level?',
                     default: 'knows'
                 },
                 learned_chapter_id: { type: 'integer', description: 'Chapter learned in' },
-                learned_scene: { type: 'integer', description: 'Scene number' },
+                learned_scene: { type: 'integer', description: 'Scene number?' },
                 learned_context: {
                     type: 'string',
-                    description: 'How/when learned'
+                    description: 'How/when learned?'
                 }
             },
             required: ['character_id', 'knowledge_category', 'knowledge_item', 'learned_chapter_id']
@@ -257,11 +257,11 @@ export const characterKnowledgeToolsSchema = [
                 character_id: { type: 'integer', description: 'Character ID' },
                 knowledge_item: {
                     type: 'string',
-                    description: 'Item to check (partial match)'
+                    description: 'Item to check (partial match)?'
                 },
                 knowledge_category: {
                     type: 'string',
-                    description: 'Category filter'
+                    description: 'Category filter?'
                 }
             },
             required: ['character_id']
@@ -281,7 +281,7 @@ export const characterKnowledgeToolsSchema = [
                 knowledge_level: {
                     type: 'string',
                     enum: ['knows', 'suspects', 'unaware', 'forgot'],
-                    description: 'Level filter'
+                    description: 'Level filter?'
                 }
             },
             required: ['series_id', 'knowledge_item']
@@ -301,7 +301,7 @@ export const characterTimelineToolsSchema = [
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 chapter_id: { type: 'integer', description: 'Chapter ID' },
-                scene_id: { type: 'integer', description: 'Scene ID' },
+                scene_id: { type: 'integer', description: 'Scene ID?' },
                 presence_type: {
                     type: 'string',
                     enum: ['present', 'mentioned', 'flashback', 'dream', 'phone_call'],
@@ -310,23 +310,23 @@ export const characterTimelineToolsSchema = [
                 importance_level: {
                     type: 'string',
                     enum: ['major', 'minor', 'cameo', 'background'],
-                    description: 'Importance'
+                    description: 'Importance?'
                 },
-                physical_state: { type: 'string', description: 'Physical state' },
-                emotional_state: { type: 'string', description: 'Emotional state' },
-                enters_at_scene: { type: 'integer', description: 'Entry scene #' },
-                exits_at_scene: { type: 'integer', description: 'Exit scene #' },
+                physical_state: { type: 'string', description: 'Physical state?' },
+                emotional_state: { type: 'string', description: 'Emotional state?' },
+                enters_at_scene: { type: 'integer', description: 'Entry scene #?' },
+                exits_at_scene: { type: 'integer', description: 'Exit scene #?' },
                 learns_this_chapter: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Info learned'
+                    description: 'Info learned?'
                 },
                 reveals_this_chapter: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Secrets revealed'
+                    description: 'Secrets revealed?'
                 },
-                character_growth: { type: 'string', description: 'Character changes' }
+                character_growth: { type: 'string', description: 'Character changes?' }
             },
             required: ['character_id', 'chapter_id', 'presence_type']
         }
@@ -338,10 +338,10 @@ export const characterTimelineToolsSchema = [
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
-                book_id: { type: 'integer', description: 'Book ID' },
-                include_scenes: { type: 'boolean', description: 'Include scenes', default: false },
-                include_knowledge: { type: 'boolean', description: 'Include knowledge', default: true },
-                include_relationships: { type: 'boolean', description: 'Include relationships', default: false }
+                book_id: { type: 'integer', description: 'Book ID?' },
+                include_scenes: { type: 'boolean', description: 'Include scenes?', default: false },
+                include_knowledge: { type: 'boolean', description: 'Include knowledge?', default: true },
+                include_relationships: { type: 'boolean', description: 'Include relationships?', default: false }
             },
             required: ['character_id']
         }
@@ -358,7 +358,7 @@ export const characterTimelineToolsSchema = [
                 check_type: {
                     type: 'string',
                     enum: ['physical_state', 'emotional_state', 'knowledge', 'location', 'all'],
-                    description: 'Check type',
+                    description: 'Check type?',
                     default: 'all'
                 }
             },
@@ -372,16 +372,16 @@ export const characterTimelineToolsSchema = [
             type: 'object',
             properties: {
                 chapter_id: { type: 'integer', description: 'Chapter ID' },
-                scene_number: { type: 'integer', description: 'Scene # filter' },
+                scene_number: { type: 'integer', description: 'Scene # filter?' },
                 presence_type: {
                     type: 'string',
                     enum: ['present', 'mentioned', 'flashback', 'dream', 'phone_call'],
-                    description: 'Presence filter'
+                    description: 'Presence filter?'
                 },
                 importance_level: {
                     type: 'string',
                     enum: ['major', 'minor', 'cameo', 'background'],
-                    description: 'Importance filter'
+                    description: 'Importance filter?'
                 }
             },
             required: ['chapter_id']

--- a/src/mcps/metadata-server/schemas/lookup-tools-schema.js
+++ b/src/mcps/metadata-server/schemas/lookup-tools-schema.js
@@ -15,12 +15,12 @@ export const lookupSystemToolsSchema = [
                 },
                 genre_filter: {
                     type: 'string',
-                    description: 'Genre name filter'
+                    description: 'Genre name filter?'
                 },
                 active_only: {
                     type: 'boolean',
                     default: true,
-                    description: 'Active options only'
+                    description: 'Active options only?'
                 }
             },
             required: ['option_type']
@@ -48,7 +48,7 @@ export const lookupSystemToolsSchema = [
                 is_active: {
                     type: 'boolean',
                     default: true,
-                    description: 'Active immediately'
+                    description: 'Active immediately?'
                 }
             },
             required: ['option_type', 'name', 'description']
@@ -71,15 +71,15 @@ export const lookupSystemToolsSchema = [
                 },
                 name: {
                     type: 'string',
-                    description: 'Updated name'
+                    description: 'Updated name?'
                 },
                 description: {
                     type: 'string',
-                    description: 'Updated description'
+                    description: 'Updated description?'
                 },
                 is_active: {
                     type: 'boolean',
-                    description: 'Active status'
+                    description: 'Active status?'
                 }
             },
             required: ['option_type', 'option_id']
@@ -103,7 +103,7 @@ export const lookupSystemToolsSchema = [
                 permanent: {
                     type: 'boolean',
                     default: false,
-                    description: 'True=permanent delete (caution), false=soft delete'
+                    description: 'True=permanent delete (caution), false=soft delete?'
                 }
             },
             required: ['option_type', 'option_id']

--- a/src/mcps/plot-server/schemas/plot-tools-schema.js
+++ b/src/mcps/plot-server/schemas/plot-tools-schema.js
@@ -23,23 +23,23 @@ export const plotThreadToolsSchema = [
                     minimum: 1,
                     maximum: 10,
                     default: 5,
-                    description: 'Importance (1-10)'
+                    description: 'Importance (1-10)?'
                 },
                 complexity_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
                     default: 5,
-                    description: 'Complexity (1-10)'
+                    description: 'Complexity (1-10)?'
                 },
-                start_book: { type: 'integer', description: 'Start book #' },
-                end_book: { type: 'integer', description: 'End book #' },
+                start_book: { type: 'integer', description: 'Start book #?' },
+                end_book: { type: 'integer', description: 'End book #?' },
                 related_characters: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Related character IDs'
+                    description: 'Related character IDs?'
                 },
-                parent_thread_id: { type: 'integer', description: 'Parent thread ID' }
+                parent_thread_id: { type: 'integer', description: 'Parent thread ID?' }
             },
             required: ['series_id', 'title', 'description', 'thread_type']
         }
@@ -51,16 +51,16 @@ export const plotThreadToolsSchema = [
             type: 'object',
             properties: {
                 thread_id: { type: 'integer', description: 'Thread ID' },
-                title: { type: 'string', description: 'Title' },
-                description: { type: 'string', description: 'Description' },
+                title: { type: 'string', description: 'Title?' },
+                description: { type: 'string', description: 'Description?' },
                 current_status: {
                     type: 'string',
                     enum: ['active', 'resolved', 'on_hold', 'abandoned'],
-                    description: 'Status'
+                    description: 'Status?'
                 },
-                end_book: { type: 'integer', description: 'End book #' },
-                resolution_notes: { type: 'string', description: 'Resolution details' },
-                resolution_book: { type: 'integer', description: 'Resolution book #' }
+                end_book: { type: 'integer', description: 'End book #?' },
+                resolution_notes: { type: 'string', description: 'Resolution details?' },
+                resolution_book: { type: 'integer', description: 'Resolution book #?' }
             },
             required: ['thread_id']
         }
@@ -72,10 +72,10 @@ export const plotThreadToolsSchema = [
             type: 'object',
             properties: {
                 series_id: { type: 'integer', description: 'Series ID' },
-                thread_type: { type: 'string', description: 'Type filter' },
-                current_status: { type: 'string', description: 'Status filter' },
-                book_number: { type: 'integer', description: 'Book # filter' },
-                importance_min: { type: 'integer', description: 'Min importance' }
+                thread_type: { type: 'string', description: 'Type filter?' },
+                current_status: { type: 'string', description: 'Status filter?' },
+                book_number: { type: 'integer', description: 'Book # filter?' },
+                importance_min: { type: 'integer', description: 'Min importance?' }
             },
             required: ['series_id']
         }
@@ -161,20 +161,20 @@ export const genreExtensionToolsSchema = [
                 affects_characters: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Character IDs who learn this'
+                    description: 'Character IDs who learn this?'
                 },
                 revealed_in_chapter: {
                     type: 'integer',
-                    description: 'Reveal chapter ID'
+                    description: 'Reveal chapter ID?'
                 },
                 consequences: {
                     type: 'string',
-                    description: 'Consequences'
+                    description: 'Consequences?'
                 },
                 foreshadowing_chapters: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Foreshadowing chapter IDs'
+                    description: 'Foreshadowing chapter IDs?'
                 }
             },
             required: ['plot_thread_id', 'reveal_type', 'information_content', 'reveal_method', 'significance_level']
@@ -210,12 +210,12 @@ export const genreExtensionToolsSchema = [
                 limitations: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Constraints & limitations'
+                    description: 'Constraints & limitations?'
                 },
                 system_rules: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Rules & principles'
+                    description: 'Rules & principles?'
                 },
                 power_scaling: {
                     type: 'object',
@@ -224,7 +224,7 @@ export const genreExtensionToolsSchema = [
                         highest_level: { type: 'string' },
                         progression_method: { type: 'string' }
                     },
-                    description: 'Power levels'
+                    description: 'Power levels?'
                 }
             },
             required: ['series_id', 'system_name', 'system_type', 'power_source', 'access_method']
@@ -251,16 +251,16 @@ export const genreExtensionToolsSchema = [
                 },
                 discovered_by: {
                     type: 'integer',
-                    description: 'Discoverer character ID'
+                    description: 'Discoverer character ID?'
                 },
                 discovery_chapter: {
                     type: 'integer',
-                    description: 'Discovery chapter ID'
+                    description: 'Discovery chapter ID?'
                 },
                 significance: {
                     type: 'string',
                     enum: ['critical', 'important', 'supporting', 'red_herring'],
-                    description: 'Significance'
+                    description: 'Significance?'
                 }
             },
             required: ['reveal_id', 'evidence_type', 'evidence_description']
@@ -286,7 +286,7 @@ export const genreExtensionToolsSchema = [
                 },
                 chapter_id: {
                     type: 'integer',
-                    description: 'Chapter ID'
+                    description: 'Chapter ID?'
                 },
                 current_power_level: {
                     type: 'integer',
@@ -296,11 +296,11 @@ export const genreExtensionToolsSchema = [
                 },
                 progression_method: {
                     type: 'string',
-                    description: 'Progression method'
+                    description: 'Progression method?'
                 },
                 cost_or_sacrifice: {
                     type: 'string',
-                    description: 'Cost/sacrifice'
+                    description: 'Cost/sacrifice?'
                 }
             },
             required: ['character_id', 'system_id', 'book_id', 'current_power_level']

--- a/src/mcps/relationship-server/handlers/relationship-handlers.js
+++ b/src/mcps/relationship-server/handlers/relationship-handlers.js
@@ -20,7 +20,7 @@ export class RelationshipHandlers {
                         },
                         arc_name: {
                             type: 'string',
-                            description: 'Arc name'
+                            description: 'Arc name?'
                         },
                         participants: {
                             type: 'array',
@@ -36,27 +36,27 @@ export class RelationshipHandlers {
                                 },
                                 required: ['character_id', 'role_in_relationship']
                             },
-                            description: 'Characters (2+, flexible roles)'
+                            description: 'Characters (2+, flexible roles)?'
                         },
                         relationship_type: {
                             type: 'string',
                             enum: ['romantic', 'family', 'friendship', 'professional', 'antagonistic', 'mentor', 'alliance'],
-                            description: 'Relationship type'
+                            description: 'Relationship type?'
                         },
                         current_dynamic: {
                             type: 'string',
-                            description: 'Current dynamic/stage'
+                            description: 'Current dynamic/stage?'
                         },
                         development_factors: {
                             type: 'array',
                             items: { type: 'string' },
-                            description: 'Development drivers'
+                            description: 'Development drivers?'
                         },
                         complexity_level: {
                             type: 'integer',
                             minimum: 1,
                             maximum: 10,
-                            description: 'Complexity (1-10)'
+                            description: 'Complexity (1-10)?'
                         }
                     },
                     required: ['plot_thread_id', 'arc_name', 'participants', 'relationship_type']
@@ -74,7 +74,7 @@ export class RelationshipHandlers {
                         },
                         arc_name: {
                             type: 'string',
-                            description: 'Arc name'
+                            description: 'Arc name?'
                         },
                         participants: {
                             type: 'array',
@@ -90,27 +90,27 @@ export class RelationshipHandlers {
                                 },
                                 required: ['character_id', 'role_in_relationship']
                             },
-                            description: 'Characters (2+, flexible roles)'
+                            description: 'Characters (2+, flexible roles)?'
                         },
                         relationship_type: {
                             type: 'string',
                             enum: ['romantic', 'family', 'friendship', 'professional', 'antagonistic', 'mentor', 'alliance'],
-                            description: 'Relationship type'
+                            description: 'Relationship type?'
                         },
                         current_dynamic: {
                             type: 'string',
-                            description: 'Current dynamic/stage'
+                            description: 'Current dynamic/stage?'
                         },
                         development_factors: {
                             type: 'array',
                             items: { type: 'string' },
-                            description: 'Development drivers'
+                            description: 'Development drivers?'
                         },
                         complexity_level: {
                             type: 'integer',
                             minimum: 1,
                             maximum: 10,
-                            description: 'Complexity (1-10)'
+                            description: 'Complexity (1-10)?'
                         }
                     },
                     required: ['arc_id']
@@ -128,11 +128,11 @@ export class RelationshipHandlers {
                         },
                         chapter_id: {
                             type: 'integer',
-                            description: 'Chapter ID'
+                            description: 'Chapter ID?'
                         },
                         scene_id: {
                             type: 'integer',
-                            description: 'Scene ID'
+                            description: 'Scene ID?'
                         },
                         dynamic_change: {
                             type: 'string',
@@ -142,7 +142,7 @@ export class RelationshipHandlers {
                             type: 'integer',
                             minimum: -10,
                             maximum: 10,
-                            description: 'Tension change (-10 to +10)'
+                            description: 'Tension change (-10 to +10)?'
                         },
                         change_type: {
                             type: 'string',
@@ -151,7 +151,7 @@ export class RelationshipHandlers {
                         },
                         trigger_event: {
                             type: 'string',
-                            description: 'Change trigger'
+                            description: 'Change trigger?'
                         }
                     },
                     required: ['arc_id', 'dynamic_change', 'change_type']
@@ -179,12 +179,12 @@ export class RelationshipHandlers {
                     properties: {
                         plot_thread_id: {
                             type: 'integer',
-                            description: 'Plot thread filter'
+                            description: 'Plot thread filter?'
                         },
                         relationship_type: {
                             type: 'string',
                             enum: ['romantic', 'family', 'friendship', 'professional', 'antagonistic', 'mentor', 'alliance'],
-                            description: 'Type filter'
+                            description: 'Type filter?'
                         }
                     }
                 }

--- a/src/mcps/series-server/schemas/series-tools-schema.js
+++ b/src/mcps/series-server/schemas/series-tools-schema.js
@@ -19,10 +19,10 @@ export const seriesToolsSchema = [
             properties: {
                 title: { type: 'string', description: 'Title' },
                 author_id: { type: 'integer', description: 'Author ID' },
-                description: { type: 'string', description: 'Description' },
-                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Genre IDs' },
-                start_year: { type: 'integer', description: 'Start year' },
-                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Status' }
+                description: { type: 'string', description: 'Description?' },
+                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Genre IDs?' },
+                start_year: { type: 'integer', description: 'Start year?' },
+                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Status?' }
             },
             required: ['title', 'author_id']
         }
@@ -45,11 +45,11 @@ export const seriesToolsSchema = [
             type: 'object',
             properties: {
                 series_id: { type: 'integer', description: 'Series ID' },
-                title: { type: 'string', description: 'Title' },
-                description: { type: 'string', description: 'Description' },
-                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Genre IDs (replaces all)' },
-                start_year: { type: 'integer', description: 'Start year' },
-                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Status' }
+                title: { type: 'string', description: 'Title?' },
+                description: { type: 'string', description: 'Description?' },
+                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Genre IDs (replaces all)?' },
+                start_year: { type: 'integer', description: 'Start year?' },
+                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Status?' }
             },
             required: ['series_id']
         }

--- a/src/mcps/story-analysis-server/schemas/story-analysis-tools-schema.js
+++ b/src/mcps/story-analysis-server/schemas/story-analysis-tools-schema.js
@@ -15,23 +15,23 @@ export const storyAnalysisToolsSchema = [
                 book_id: { type: 'integer', description: 'Book ID' },
                 story_concern: {
                     type: 'string',
-                    description: 'Overall story focus (use metadata-server get_available_options w/ option_type="story_concerns")'
+                    description: 'Overall story focus (use metadata-server get_available_options w/ option_type="story_concerns")?'
                 },
-                main_character_problem: { type: 'string', description: 'Protagonist issues' },
-                influence_character_impact: { type: 'string', description: 'How others challenge MC' },
+                main_character_problem: { type: 'string', description: 'Protagonist issues?' },
+                influence_character_impact: { type: 'string', description: 'How others challenge MC?' },
                 story_outcome: {
                     type: 'string',
-                    description: 'Goal achieved? (use metadata-server get_available_options w/ option_type="story_outcomes")'
+                    description: 'Goal achieved? (use metadata-server get_available_options w/ option_type="story_outcomes")?'
                 },
                 story_judgment: {
                     type: 'string',
-                    description: 'Outcome satisfaction (use metadata-server get_available_options w/ option_type="story_judgments")'
+                    description: 'Outcome satisfaction (use metadata-server get_available_options w/ option_type="story_judgments")?'
                 },
                 thematic_elements: {
                     type: 'object',
-                    description: 'Conflicting themes/values'
+                    description: 'Conflicting themes/values?'
                 },
-                analysis_notes: { type: 'string', description: 'Additional notes' }
+                analysis_notes: { type: 'string', description: 'Additional notes?' }
             },
             required: ['book_id']
         }
@@ -49,9 +49,9 @@ export const storyAnalysisToolsSchema = [
                     enum: ['main_character', 'influence_character', 'relationship', 'objective_story'],
                     description: 'Throughline type'
                 },
-                character_problem: { type: 'string', description: 'Core problem' },
-                character_solution: { type: 'string', description: 'Problem approach' },
-                character_arc: { type: 'string', description: 'Development arc' }
+                character_problem: { type: 'string', description: 'Core problem?' },
+                character_solution: { type: 'string', description: 'Problem approach?' },
+                character_arc: { type: 'string', description: 'Development arc?' }
             },
             required: ['book_id', 'character_id', 'throughline_type']
         }
@@ -65,12 +65,12 @@ export const storyAnalysisToolsSchema = [
                 book_id: { type: 'integer', description: 'Book ID' },
                 appreciation_type: { type: 'string', description: 'Appreciation type' },
                 appreciation_value: { type: 'string', description: 'Appreciation value' },
-                supporting_evidence: { type: 'string', description: 'Story evidence' },
+                supporting_evidence: { type: 'string', description: 'Story evidence?' },
                 confidence_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Confidence (1-10)'
+                    description: 'Confidence (1-10)?'
                 }
             },
             required: ['book_id', 'appreciation_type', 'appreciation_value']
@@ -93,7 +93,7 @@ export const storyAnalysisToolsSchema = [
                 effectiveness: {
                     type: 'string',
                     enum: ['solves', 'complicates', 'redirects', 'unknown'],
-                    description: 'Solution effectiveness'
+                    description: 'Solution effectiveness?'
                 }
             },
             required: ['book_id', 'problem', 'solution', 'problem_level']

--- a/src/mcps/timeline-server/schemas/timeline-chapter-mapping-schema.js
+++ b/src/mcps/timeline-server/schemas/timeline-chapter-mapping-schema.js
@@ -11,21 +11,21 @@ export const eventChapterMappingSchemas = [
             properties: {
                 event_id: { type: 'integer', description: 'Event ID' },
                 chapter_id: { type: 'integer', description: 'Chapter ID' },
-                scene_number: { type: 'integer', description: 'Scene # in chapter' },
+                scene_number: { type: 'integer', description: 'Scene # in chapter?' },
                 presentation_type: {
                     type: 'string',
                     enum: ['direct_scene', 'flashback', 'memory', 'reference', 'foreshadowing', 'dream', 'retelling'],
-                    description: 'How event is presented'
+                    description: 'How event is presented?'
                 },
-                pov_character_id: { type: 'integer', description: 'POV character ID' },
-                event_aspect: { type: 'string', description: 'Part/perspective shown' },
+                pov_character_id: { type: 'integer', description: 'POV character ID?' },
+                event_aspect: { type: 'string', description: 'Part/perspective shown?' },
                 completeness: {
                     type: 'string',
                     enum: ['full', 'partial', 'glimpse'],
-                    description: 'Completeness level',
+                    description: 'Completeness level?',
                     default: 'full'
                 },
-                narrative_function: { type: 'string', description: 'Purpose in narrative' }
+                narrative_function: { type: 'string', description: 'Purpose in narrative?' }
             }
         }
     },
@@ -50,11 +50,11 @@ export const eventChapterMappingSchemas = [
                 chapter_id: { type: 'integer', description: 'Chapter ID' },
                 presentation_type: {
                     type: 'string',
-                    description: 'Presentation type filter'
+                    description: 'Presentation type filter?'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'POV character filter'
+                    description: 'POV character filter?'
                 }
             }
         }
@@ -67,20 +67,20 @@ export const eventChapterMappingSchemas = [
             required: ['mapping_id'],
             properties: {
                 mapping_id: { type: 'integer', description: 'Mapping ID' },
-                scene_number: { type: 'integer', description: 'Scene # in chapter' },
+                scene_number: { type: 'integer', description: 'Scene # in chapter?' },
                 presentation_type: {
                     type: 'string',
                     enum: ['direct_scene', 'flashback', 'memory', 'reference', 'foreshadowing', 'dream', 'retelling'],
-                    description: 'How event is presented'
+                    description: 'How event is presented?'
                 },
-                pov_character_id: { type: 'integer', description: 'POV character ID' },
-                event_aspect: { type: 'string', description: 'Part shown' },
+                pov_character_id: { type: 'integer', description: 'POV character ID?' },
+                event_aspect: { type: 'string', description: 'Part shown?' },
                 completeness: {
                     type: 'string',
                     enum: ['full', 'partial', 'glimpse'],
-                    description: 'Completeness level'
+                    description: 'Completeness level?'
                 },
-                narrative_function: { type: 'string', description: 'Purpose in narrative' }
+                narrative_function: { type: 'string', description: 'Purpose in narrative?' }
             }
         }
     },
@@ -106,7 +106,7 @@ export const eventChapterMappingSchemas = [
                 analysis_type: {
                     type: 'string',
                     enum: ['linearity', 'pov_distribution', 'event_coverage', 'all'],
-                    description: 'Analysis type',
+                    description: 'Analysis type?',
                     default: 'all'
                 }
             }

--- a/src/mcps/trope-server/schemas/trope-tools-schema.js
+++ b/src/mcps/trope-server/schemas/trope-tools-schema.js
@@ -22,9 +22,9 @@ export const tropeToolsSchema = [
                 common_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Common elements'
+                    description: 'Common elements?'
                 },
-                typical_trajectory: { type: 'string', description: 'Typical story trajectory' },
+                typical_trajectory: { type: 'string', description: 'Typical story trajectory?' },
                 scene_types: {
                     type: 'array',
                     items: {
@@ -61,12 +61,12 @@ export const tropeToolsSchema = [
             properties: {
                 trope_id: { type: 'integer', description: 'Trope ID' },
                 book_id: { type: 'integer', description: 'Book ID' },
-                instance_notes: { type: 'string', description: 'Implementation notes' },
-                subversion_notes: { type: 'string', description: 'How this varies/subverts trope' },
+                instance_notes: { type: 'string', description: 'Implementation notes?' },
+                subversion_notes: { type: 'string', description: 'How this varies/subverts trope?' },
                 completion_status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'complete', 'subverted'],
-                    description: 'Implementation status'
+                    description: 'Implementation status?'
                 }
             },
             required: ['trope_id', 'book_id']
@@ -79,7 +79,7 @@ export const tropeToolsSchema = [
             type: 'object',
             properties: {
                 trope_id: { type: 'integer', description: 'Trope ID' },
-                include_scene_types: { type: 'boolean', description: 'Include scene types', default: true }
+                include_scene_types: { type: 'boolean', description: 'Include scene types?', default: true }
             },
             required: ['trope_id']
         }
@@ -90,8 +90,8 @@ export const tropeToolsSchema = [
         inputSchema: {
             type: 'object',
             properties: {
-                series_id: { type: 'integer', description: 'Series filter' },
-                trope_category: { type: 'string', description: 'Category filter' }
+                series_id: { type: 'integer', description: 'Series filter?' },
+                trope_category: { type: 'string', description: 'Category filter?' }
             }
         }
     },
@@ -102,7 +102,7 @@ export const tropeToolsSchema = [
             type: 'object',
             properties: {
                 instance_id: { type: 'integer', description: 'Instance ID' },
-                include_scenes: { type: 'boolean', description: 'Include scenes', default: true }
+                include_scenes: { type: 'boolean', description: 'Include scenes?', default: true }
             },
             required: ['instance_id']
         }
@@ -117,7 +117,7 @@ export const tropeToolsSchema = [
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'complete', 'subverted'],
-                    description: 'Status filter'
+                    description: 'Status filter?'
                 }
             },
             required: ['book_id']
@@ -131,24 +131,24 @@ export const tropeToolsSchema = [
             properties: {
                 trope_instance_id: { type: 'integer', description: 'Instance ID' },
                 scene_type_id: { type: 'integer', description: 'Scene type ID' },
-                scene_id: { type: 'integer', description: 'Actual scene ID in chapter_scenes' },
-                chapter_id: { type: 'integer', description: 'Chapter ID' },
-                scene_number: { type: 'integer', description: 'Scene # in chapter' },
+                scene_id: { type: 'integer', description: 'Actual scene ID in chapter_scenes?' },
+                chapter_id: { type: 'integer', description: 'Chapter ID?' },
+                scene_number: { type: 'integer', description: 'Scene # in chapter?' },
                 scene_summary: { type: 'string', description: 'What happens in scene' },
                 effectiveness_rating: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Effectiveness (1-10)',
+                    description: 'Effectiveness (1-10)?',
                     default: 7
                 },
-                variation_notes: { type: 'string', description: 'Variations from typical' },
+                variation_notes: { type: 'string', description: 'Variations from typical?' },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre elements featured'
+                    description: 'Genre elements featured?'
                 },
-                implementation_notes: { type: 'string', description: 'Implementation details' }
+                implementation_notes: { type: 'string', description: 'Implementation details?' }
             },
             required: ['trope_instance_id', 'scene_type_id', 'scene_summary']
         }
@@ -159,22 +159,22 @@ export const tropeToolsSchema = [
         inputSchema: {
             type: 'object',
             properties: {
-                instance_id: { type: 'integer', description: 'Instance filter' },
-                series_id: { type: 'integer', description: 'Series filter' },
-                trope_category: { type: 'string', description: 'Category filter' },
+                instance_id: { type: 'integer', description: 'Instance filter?' },
+                series_id: { type: 'integer', description: 'Series filter?' },
+                trope_category: { type: 'string', description: 'Category filter?' },
                 kinks_filter: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre elements filter'
+                    description: 'Genre elements filter?'
                 },
                 written_only: {
                     type: 'boolean',
-                    description: 'Only scenes w/ scene_id',
+                    description: 'Only scenes w/ scene_id?',
                     default: false
                 },
                 unwritten_only: {
                     type: 'boolean',
-                    description: 'Only planned scenes w/o scene_id',
+                    description: 'Only planned scenes w/o scene_id?',
                     default: false
                 }
             }
@@ -187,7 +187,7 @@ export const tropeToolsSchema = [
             type: 'object',
             properties: {
                 book_id: { type: 'integer', description: 'Book ID' },
-                trope_id: { type: 'integer', description: 'Trope filter' }
+                trope_id: { type: 'integer', description: 'Trope filter?' }
             },
             required: ['book_id']
         }
@@ -202,12 +202,12 @@ export const tropeToolsSchema = [
                 trope_category: {
                     type: 'string',
                     enum: ['romance_trope', 'character_trope', 'plot_trope'],
-                    description: 'Category filter'
+                    description: 'Category filter?'
                 },
                 analysis_type: {
                     type: 'string',
                     enum: ['frequency', 'subversion', 'effectiveness'],
-                    description: 'Analysis type'
+                    description: 'Analysis type?'
                 }
             },
             required: ['series_id']

--- a/src/mcps/world-server/schemas/world-management-schema.js
+++ b/src/mcps/world-server/schemas/world-management-schema.js
@@ -14,11 +14,11 @@ export const worldManagementSchemas = [
                 },
                 check_type: {
                     type: 'string',
-                    description: 'Check type: all, locations, elements, organizations, relationships'
+                    description: 'Check type: all, locations, elements, organizations, relationships?'
                 },
                 severity_threshold: {
                     type: 'string',
-                    description: 'Min severity: info, warning, error'
+                    description: 'Min severity: info, warning, error?'
                 }
             },
             required: ['series_id']
@@ -36,15 +36,15 @@ export const worldManagementSchemas = [
                 },
                 guide_type: {
                     type: 'string',
-                    description: 'Guide type: complete, locations_only, elements_only, organizations_only, summary'
+                    description: 'Guide type: complete, locations_only, elements_only, organizations_only, summary?'
                 },
                 include_usage_stats: {
                     type: 'boolean',
-                    description: 'Include usage stats'
+                    description: 'Include usage stats?'
                 },
                 format: {
                     type: 'string',
-                    description: 'Format: text, structured, reference_sheet'
+                    description: 'Format: text, structured, reference_sheet?'
                 }
             },
             required: ['series_id']
@@ -62,7 +62,7 @@ export const worldManagementSchemas = [
                 },
                 analysis_focus: {
                     type: 'string',
-                    description: 'Focus: overall, power_structures, magic_systems, geography, relationships'
+                    description: 'Focus: overall, power_structures, magic_systems, geography, relationships?'
                 }
             },
             required: ['series_id']
@@ -80,7 +80,7 @@ export const worldManagementSchemas = [
                 },
                 gap_type: {
                     type: 'string',
-                    description: 'Gap type: unused_locations, weak_organizations, underused_elements, missing_connections'
+                    description: 'Gap type: unused_locations, weak_organizations, underused_elements, missing_connections?'
                 }
             },
             required: ['series_id']
@@ -98,7 +98,7 @@ export const worldManagementSchemas = [
                 },
                 relationship_type: {
                     type: 'string',
-                    description: 'Type: all, location_hierarchies, org_alliances, element_interactions'
+                    description: 'Type: all, location_hierarchies, org_alliances, element_interactions?'
                 }
             },
             required: ['series_id']
@@ -116,7 +116,7 @@ export const worldManagementSchemas = [
                 },
                 include_stats: {
                     type: 'boolean',
-                    description: 'Include stats',
+                    description: 'Include stats?',
                     default: true
                 }
             },
@@ -135,7 +135,7 @@ export const worldManagementSchemas = [
                 },
                 element_type: {
                     type: 'string',
-                    description: 'Element type: location, world_element, organization, all',
+                    description: 'Element type: location, world_element, organization, all?',
                     default: 'all'
                 }
             },

--- a/src/mcps/writing-server/handlers/export-handlers.js
+++ b/src/mcps/writing-server/handlers/export-handlers.js
@@ -21,23 +21,23 @@ export class ExportHandlers {
                             type: 'string',
                             enum: ['txt', 'md', 'rtf', 'standard_manuscript'],
                             default: 'txt',
-                            description: 'Export format'
+                            description: 'Export format?'
                         },
                         include_metadata: {
                             type: 'boolean',
                             default: true,
-                            description: 'Include metadata'
+                            description: 'Include metadata?'
                         },
                         chapters_to_include: {
                             type: 'array',
                             items: { type: 'integer' },
-                            description: 'Chapter IDs (all if omitted)'
+                            description: 'Chapter IDs (all if omitted)?'
                         },
                         export_purpose: {
                             type: 'string',
                             enum: ['submission', 'beta_review', 'backup', 'publication'],
                             default: 'backup',
-                            description: 'Export purpose'
+                            description: 'Export purpose?'
                         }
                     },
                     required: ['book_id']
@@ -57,17 +57,17 @@ export class ExportHandlers {
                             type: 'string',
                             enum: ['book', 'chapter', 'scene', 'detailed'],
                             default: 'chapter',
-                            description: 'Detail level'
+                            description: 'Detail level?'
                         },
                         include_history: {
                             type: 'boolean',
                             default: false,
-                            description: 'Include history'
+                            description: 'Include history?'
                         },
                         calculate_targets: {
                             type: 'boolean',
                             default: true,
-                            description: 'Calc vs targets'
+                            description: 'Calc vs targets?'
                         }
                     },
                     required: ['book_id']

--- a/src/mcps/writing-server/handlers/session-handlers.js
+++ b/src/mcps/writing-server/handlers/session-handlers.js
@@ -20,7 +20,7 @@ export class SessionHandlers {
                         chapter_ids: {
                             type: 'array',
                             items: { type: 'integer' },
-                            description: 'Chapter IDs worked on'
+                            description: 'Chapter IDs worked on?'
                         },
                         session_date: {
                             type: 'string',
@@ -28,11 +28,11 @@ export class SessionHandlers {
                         },
                         start_time: {
                             type: 'string',
-                            description: 'Start (HH:MM)'
+                            description: 'Start (HH:MM)?'
                         },
                         end_time: {
                             type: 'string',
-                            description: 'End (HH:MM)'
+                            description: 'End (HH:MM)?'
                         },
                         words_written: {
                             type: 'integer',
@@ -40,18 +40,18 @@ export class SessionHandlers {
                         },
                         words_edited: {
                             type: 'integer',
-                            description: 'Edited words',
+                            description: 'Edited words?',
                             default: 0
                         },
                         session_notes: {
                             type: 'string',
-                            description: 'Session notes'
+                            description: 'Session notes?'
                         },
                         mood_rating: {
                             type: 'integer',
                             minimum: 1,
                             maximum: 10,
-                            description: 'Mood/energy (1-10)'
+                            description: 'Mood/energy (1-10)?'
                         }
                     },
                     required: ['book_id', 'session_date', 'words_written']
@@ -71,12 +71,12 @@ export class SessionHandlers {
                             type: 'string',
                             enum: ['week', 'month', 'quarter', 'all_time'],
                             default: 'month',
-                            description: 'Time period'
+                            description: 'Time period?'
                         },
                         include_analytics: {
                             type: 'boolean',
                             default: true,
-                            description: 'Include details'
+                            description: 'Include details?'
                         }
                     },
                     required: ['book_id']
@@ -107,7 +107,7 @@ export class SessionHandlers {
                         },
                         description: {
                             type: 'string',
-                            description: 'Goal description'
+                            description: 'Goal description?'
                         }
                     },
                     required: ['book_id', 'goal_type', 'target_value', 'target_date']
@@ -127,7 +127,7 @@ export class SessionHandlers {
                             type: 'string',
                             enum: ['daily_patterns', 'weekly_trends', 'goal_progress', 'productivity_factors'],
                             default: 'daily_patterns',
-                            description: 'Analysis type'
+                            description: 'Analysis type?'
                         },
                         date_range: {
                             type: 'object',
@@ -135,7 +135,7 @@ export class SessionHandlers {
                                 start_date: { type: 'string' },
                                 end_date: { type: 'string' }
                             },
-                            description: 'Date range'
+                            description: 'Date range?'
                         }
                     },
                     required: ['book_id']

--- a/src/mcps/writing-server/handlers/validation-handlers.js
+++ b/src/mcps/writing-server/handlers/validation-handlers.js
@@ -20,13 +20,13 @@ export class ValidationHandlers {
                         chapter_ids: {
                             type: 'array',
                             items: { type: 'integer' },
-                            description: 'Chapter IDs (validates all if omitted)'
+                            description: 'Chapter IDs (validates all if omitted)?'
                         },
                         validation_level: {
                             type: 'string',
                             enum: ['basic', 'detailed', 'comprehensive'],
                             default: 'detailed',
-                            description: 'Check depth'
+                            description: 'Check depth?'
                         }
                     },
                     required: ['book_id']
@@ -46,12 +46,12 @@ export class ValidationHandlers {
                             type: 'string',
                             enum: ['pacing', 'character_arcs', 'plot_threads', 'emotional_beats'],
                             default: 'pacing',
-                            description: 'Analysis type'
+                            description: 'Analysis type?'
                         },
                         flexible_guidelines: {
                             type: 'boolean',
                             default: true,
-                            description: 'Flexible vs rigid rules'
+                            description: 'Flexible vs rigid rules?'
                         }
                     },
                     required: ['book_id']
@@ -74,13 +74,13 @@ export class ValidationHandlers {
                                 enum: ['character_continuity', 'timeline_consistency', 'pov_consistency', 'location_consistency', 'plot_holes']
                             },
                             default: ['character_continuity', 'timeline_consistency', 'pov_consistency'],
-                            description: 'Violation types'
+                            description: 'Violation types?'
                         },
                         severity_threshold: {
                             type: 'string',
                             enum: ['info', 'warning', 'error'],
                             default: 'warning',
-                            description: 'Min severity'
+                            description: 'Min severity?'
                         }
                     },
                     required: ['book_id']


### PR DESCRIPTION
…iptions

Updated all MCP tool schemas to append ? to optional parameter descriptions. This ensures GPT5 correctly interprets optional parameters in Typing Mind.

Changes:
- Updated 16 files across all MCP servers
- Modified 35+ tool definitions
- Added ? suffix to 90+ optional parameter descriptions

Files updated:
- reporting-server, author-server, series-server
- book-server (tools and planning schemas)
- character-server, plot-server, metadata-server
- world-server, trope-server, story-analysis-server
- timeline-server, relationship-server
- writing-server handlers (session, validation, export)

All parameters not in the 'required' array now have ? in their description.