### PR TITLE
Add server orchestrator with child process management

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node src/http-sse-server.js",
     "start:stdio": "node src/stdio-server.js",
+    "start:orchestrator": "node server.js",
     "dev": "node --watch src/http-sse-server.js"
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+// server.js
+// MCP Server Orchestrator - Manages all 9 MCP servers as child processes
+// Provides centralized logging, process management, and graceful shutdown
+
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Server configurations
+const servers = [
+    { name: 'book-planning', port: 3001 },
+    { name: 'series-planning', port: 3002 },
+    { name: 'chapter-planning', port: 3003 },
+    { name: 'character-planning', port: 3004 },
+    { name: 'scene', port: 3005 },
+    { name: 'core-continuity', port: 3006 },
+    { name: 'review', port: 3007 },
+    { name: 'reporting', port: 3008 },
+    { name: 'author', port: 3009 }
+];
+
+// Store child process references
+const childProcesses = new Map();
+
+// Track server startup status
+const serverStatus = new Map();
+
+// ANSI color codes for better logging
+const colors = {
+    reset: '\x1b[0m',
+    bright: '\x1b[1m',
+    dim: '\x1b[2m',
+    red: '\x1b[31m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    blue: '\x1b[34m',
+    magenta: '\x1b[35m',
+    cyan: '\x1b[36m',
+    white: '\x1b[37m'
+};
+
+// Unified logging with color-coded server names
+function log(serverName, message, level = 'info') {
+    const timestamp = new Date().toISOString();
+    const colorMap = {
+        'book-planning': colors.blue,
+        'series-planning': colors.magenta,
+        'chapter-planning': colors.cyan,
+        'character-planning': colors.green,
+        'scene': colors.yellow,
+        'core-continuity': colors.red,
+        'review': colors.blue,
+        'reporting': colors.magenta,
+        'author': colors.cyan,
+        'orchestrator': colors.bright + colors.white
+    };
+
+    const color = colorMap[serverName] || colors.white;
+    const levelSymbol = {
+        'info': 'ℹ',
+        'error': '✗',
+        'success': '✓',
+        'warn': '⚠'
+    }[level] || 'ℹ';
+
+    console.error(`${colors.dim}${timestamp}${colors.reset} ${color}[${serverName.padEnd(20)}]${colors.reset} ${levelSymbol} ${message}`);
+}
+
+// Display startup banner
+function displayBanner() {
+    const width = 80;
+    console.error('\n' + '═'.repeat(width));
+    console.error('  MCP Writing System - Server Orchestrator');
+    console.error('═'.repeat(width));
+    console.error('  Architecture: Child Process Management');
+    console.error('  Process Isolation: Each server runs in separate Node.js process');
+    console.error('  Fault Tolerance: Individual server failures trigger orchestrator exit');
+    console.error('═'.repeat(width));
+    console.error('');
+}
+
+// Display server table after all servers start
+function displayServerTable() {
+    console.error('\n' + '═'.repeat(80));
+    console.error('  🚀 All Servers Running\n');
+    console.error('  ┌─────────────────────┬──────┬─────────┬──────────────────────────────────┐');
+    console.error('  │ Server              │ Port │ PID     │ Status                           │');
+    console.error('  ├─────────────────────┼──────┼─────────┼──────────────────────────────────┤');
+
+    servers.forEach(server => {
+        const status = serverStatus.get(server.name);
+        const process = childProcesses.get(server.name);
+        const pid = process ? process.pid.toString() : 'N/A';
+        const statusText = status ? '✓ Running' : '✗ Failed';
+
+        const nameCol = `  │ ${server.name.padEnd(19)}`;
+        const portCol = ` │ ${server.port.toString().padEnd(4)}`;
+        const pidCol = ` │ ${pid.padEnd(7)}`;
+        const statusCol = ` │ ${statusText.padEnd(32)} │`;
+        console.error(nameCol + portCol + pidCol + statusCol);
+    });
+
+    console.error('  └─────────────────────┴──────┴─────────┴──────────────────────────────────┘\n');
+    console.error('  📋 Endpoints: http://localhost:{PORT}/ (SSE), /health, /info\n');
+    console.error('═'.repeat(80));
+    console.error('');
+}
+
+// Spawn a single server as child process
+function spawnServer(serverConfig) {
+    const { name, port } = serverConfig;
+
+    log('orchestrator', `Starting ${name} on port ${port}...`, 'info');
+
+    const runnerPath = join(__dirname, 'src', 'single-server-runner.js');
+    const child = spawn('node', [runnerPath, name, port.toString()], {
+        stdio: ['ignore', 'ignore', 'pipe'], // Capture stderr for logging
+        env: { ...process.env }
+    });
+
+    childProcesses.set(name, child);
+    serverStatus.set(name, false); // Initially not started
+
+    // Capture and forward stderr (where server logs go)
+    child.stderr.on('data', (data) => {
+        const lines = data.toString().split('\n').filter(line => line.trim());
+        lines.forEach(line => {
+            // Check if server successfully started
+            if (line.includes('Server started on port')) {
+                serverStatus.set(name, true);
+                log(name, `Ready on port ${port}`, 'success');
+
+                // Check if all servers are now running
+                const allStarted = Array.from(serverStatus.values()).every(status => status === true);
+                if (allStarted && serverStatus.size === servers.length) {
+                    displayServerTable();
+                }
+            } else {
+                // Forward other logs with server name prefix
+                log(name, line, 'info');
+            }
+        });
+    });
+
+    // Handle process exit
+    child.on('exit', (code, signal) => {
+        if (code !== 0 && code !== null) {
+            log('orchestrator', `Server ${name} exited with code ${code}`, 'error');
+            log('orchestrator', 'Shutting down all servers due to failure...', 'error');
+            shutdown(1);
+        } else if (signal) {
+            log('orchestrator', `Server ${name} killed by signal ${signal}`, 'warn');
+        }
+    });
+
+    // Handle errors
+    child.on('error', (error) => {
+        log('orchestrator', `Failed to start ${name}: ${error.message}`, 'error');
+        shutdown(1);
+    });
+
+    return child;
+}
+
+// Start all servers
+async function startAllServers() {
+    displayBanner();
+    log('orchestrator', `Launching ${servers.length} MCP servers...`, 'info');
+
+    // Spawn all servers
+    for (const server of servers) {
+        spawnServer(server);
+        // Small delay between spawns to avoid overwhelming the system
+        await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    log('orchestrator', 'All server processes spawned', 'success');
+}
+
+// Graceful shutdown handler
+function shutdown(exitCode = 0) {
+    if (shutdown.inProgress) {
+        return; // Prevent multiple shutdown attempts
+    }
+    shutdown.inProgress = true;
+
+    log('orchestrator', '\n🛑 Initiating graceful shutdown...', 'warn');
+
+    // Kill all child processes
+    let shutdownCount = 0;
+    const totalServers = childProcesses.size;
+
+    if (totalServers === 0) {
+        log('orchestrator', 'No servers to shut down', 'info');
+        process.exit(exitCode);
+        return;
+    }
+
+    childProcesses.forEach((child, name) => {
+        if (child && !child.killed) {
+            log('orchestrator', `Sending SIGTERM to ${name}...`, 'info');
+
+            child.on('exit', () => {
+                shutdownCount++;
+                log('orchestrator', `${name} shut down (${shutdownCount}/${totalServers})`, 'success');
+
+                if (shutdownCount === totalServers) {
+                    log('orchestrator', '✅ All servers shut down gracefully\n', 'success');
+                    process.exit(exitCode);
+                }
+            });
+
+            child.kill('SIGTERM');
+        } else {
+            shutdownCount++;
+        }
+    });
+
+    // Force exit after 10 seconds if graceful shutdown fails
+    setTimeout(() => {
+        log('orchestrator', '⚠️  Forcing shutdown after timeout', 'warn');
+
+        childProcesses.forEach((child, name) => {
+            if (child && !child.killed) {
+                log('orchestrator', `Force killing ${name}...`, 'warn');
+                child.kill('SIGKILL');
+            }
+        });
+
+        setTimeout(() => {
+            process.exit(exitCode);
+        }, 1000);
+    }, 10000);
+}
+
+// Register signal handlers
+process.on('SIGINT', () => {
+    log('orchestrator', '\nReceived SIGINT (Ctrl+C)', 'warn');
+    shutdown(0);
+});
+
+process.on('SIGTERM', () => {
+    log('orchestrator', 'Received SIGTERM', 'warn');
+    shutdown(0);
+});
+
+// Handle uncaught errors
+process.on('uncaughtException', (error) => {
+    log('orchestrator', `Uncaught exception: ${error.message}`, 'error');
+    console.error(error.stack);
+    shutdown(1);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+    log('orchestrator', `Unhandled rejection: ${reason}`, 'error');
+    shutdown(1);
+});
+
+// Start the orchestrator
+log('orchestrator', 'MCP Server Orchestrator starting...', 'info');
+startAllServers().catch(error => {
+    log('orchestrator', `Fatal error: ${error.message}`, 'error');
+    console.error(error.stack);
+    shutdown(1);
+});

--- a/src/single-server-runner.js
+++ b/src/single-server-runner.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// src/single-server-runner.js
+// Runs a single MCP server on specified port - designed to be spawned as child process
+
+import express from 'express';
+import cors from 'cors';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import dotenv from 'dotenv';
+import { randomUUID } from 'crypto';
+
+// Load environment variables
+dotenv.config();
+
+// Get server configuration from command line arguments or environment variables
+const serverName = process.argv[2] || process.env.SERVER_NAME;
+const port = parseInt(process.argv[3] || process.env.SERVER_PORT || '3000');
+
+if (!serverName || !port) {
+    console.error('❌ ERROR: Missing required arguments');
+    console.error('Usage: node single-server-runner.js <server-name> <port>');
+    console.error('Example: node single-server-runner.js book-planning 3001');
+    process.exit(1);
+}
+
+// Server configuration mapping
+const serverConfigs = {
+    'book-planning': { path: './config-mcps/book-planning-server/index.js', className: 'BookPlanningMCPServer' },
+    'series-planning': { path: './config-mcps/series-planning-server/index.js', className: 'SeriesPlanningMCPServer' },
+    'chapter-planning': { path: './config-mcps/chapter-planning-server/index.js', className: 'ChapterPlanningMCPServer' },
+    'character-planning': { path: './config-mcps/character-planning-server/index.js', className: 'CharacterPlanningMCPServer' },
+    'scene': { path: './config-mcps/scene-server/index.js', className: 'SceneWritingMCPServer' },
+    'core-continuity': { path: './config-mcps/core-continuity-server/index.js', className: 'CoreContinuityMCPServer' },
+    'review': { path: './config-mcps/review-server/index.js', className: 'ReviewMCPServer' },
+    'reporting': { path: './config-mcps/reporting-server/index.js', className: 'ReportingMCPServer' },
+    'author': { path: './mcps/author-server/index.js', className: 'AuthorMCPServer' }
+};
+
+// Active SSE transports Map
+const activeTransports = new Map();
+
+async function startServer() {
+    const config = serverConfigs[serverName];
+
+    if (!config) {
+        console.error(`❌ ERROR: Unknown server name: ${serverName}`);
+        console.error(`Available servers: ${Object.keys(serverConfigs).join(', ')}`);
+        process.exit(1);
+    }
+
+    try {
+        // Dynamically import the server class
+        const module = await import(config.path);
+        const ServerClass = module[config.className];
+
+        if (!ServerClass) {
+            throw new Error(`Server class ${config.className} not found in ${config.path}`);
+        }
+
+        // Create Express app
+        const app = express();
+
+        // Middleware
+        app.use(cors({
+            origin: '*',
+            credentials: true
+        }));
+
+        app.use((req, res, next) => {
+            res.setHeader('Cache-Control', 'no-cache');
+            res.setHeader('X-Accel-Buffering', 'no');
+            next();
+        });
+
+        // Root SSE endpoint - GET creates SSE stream, POST handles messages
+        app.get('/', async (req, res) => {
+            const sessionId = randomUUID();
+            console.error(`[${serverName}:${port}] New SSE connection - Session: ${sessionId}`);
+
+            try {
+                // Create a new instance of the MCP server
+                const mcpServer = new ServerClass();
+
+                // Create SSE transport with session endpoint
+                const transport = new SSEServerTransport(`/${sessionId}`, res);
+
+                // Store in active transports map
+                activeTransports.set(sessionId, { transport, mcpServer });
+
+                // Connect the MCP server to the transport
+                await mcpServer.server.connect(transport);
+
+                console.error(`[${serverName}:${port}] MCP server connected - Session: ${sessionId}`);
+
+                // Handle client disconnect
+                req.on('close', () => {
+                    console.error(`[${serverName}:${port}] SSE connection closed - Session: ${sessionId}`);
+                    activeTransports.delete(sessionId);
+                });
+
+            } catch (error) {
+                console.error(`[${serverName}:${port}] Error setting up SSE connection:`, error);
+                if (!res.headersSent) {
+                    res.status(500).json({ error: 'Failed to initialize MCP server' });
+                }
+            }
+        });
+
+        // POST endpoint for SSE message handling
+        app.post('/:sessionId', express.json(), async (req, res) => {
+            const sessionId = req.params.sessionId;
+
+            try {
+                const session = activeTransports.get(sessionId);
+                if (!session) {
+                    return res.status(404).json({
+                        error: 'Session not found',
+                        message: `No active session with id: ${sessionId}`
+                    });
+                }
+
+                // Let the transport handle the incoming message
+                await session.transport.handlePostMessage(req, res, req.body);
+
+            } catch (error) {
+                console.error(`[${serverName}:${port}] Error handling POST:`, error);
+                if (!res.headersSent) {
+                    res.status(500).json({ error: error.message });
+                }
+            }
+        });
+
+        // Health check endpoint
+        app.get('/health', async (req, res) => {
+            try {
+                const mcpServer = new ServerClass();
+                const health = await mcpServer.db.healthCheck();
+                res.json({
+                    server: serverName,
+                    port: port,
+                    status: 'healthy',
+                    database: health,
+                    activeSessions: activeTransports.size,
+                    timestamp: new Date().toISOString()
+                });
+            } catch (error) {
+                res.status(500).json({
+                    server: serverName,
+                    port: port,
+                    status: 'unhealthy',
+                    error: error.message,
+                    timestamp: new Date().toISOString()
+                });
+            }
+        });
+
+        // Info endpoint
+        app.get('/info', async (req, res) => {
+            try {
+                const mcpServer = new ServerClass();
+                res.json({
+                    server: serverName,
+                    port: port,
+                    version: mcpServer.serverVersion,
+                    tools: mcpServer.tools.map(tool => ({
+                        name: tool.name,
+                        description: tool.description
+                    })),
+                    endpoints: {
+                        sse: `http://localhost:${port}/`,
+                        health: `http://localhost:${port}/health`,
+                        info: `http://localhost:${port}/info`
+                    }
+                });
+            } catch (error) {
+                res.status(500).json({
+                    error: 'Failed to get server info',
+                    message: error.message
+                });
+            }
+        });
+
+        // Start listening
+        const serverInstance = app.listen(port, () => {
+            console.error(`✅ [${serverName}] Server started on port ${port}`);
+            console.error(`   SSE Endpoint: http://localhost:${port}/`);
+            console.error(`   Health Check: http://localhost:${port}/health`);
+        });
+
+        // Graceful shutdown
+        const shutdown = () => {
+            console.error(`\n🛑 [${serverName}:${port}] Shutting down...`);
+
+            // Close active transports
+            activeTransports.clear();
+
+            // Close server
+            serverInstance.close(() => {
+                console.error(`✅ [${serverName}:${port}] Server closed gracefully`);
+                process.exit(0);
+            });
+
+            // Force exit after 5 seconds
+            setTimeout(() => {
+                console.error(`⚠️  [${serverName}:${port}] Forcing shutdown after timeout`);
+                process.exit(1);
+            }, 5000);
+        };
+
+        // Register shutdown handlers
+        process.on('SIGINT', shutdown);
+        process.on('SIGTERM', shutdown);
+
+        // Handle uncaught errors
+        process.on('uncaughtException', (error) => {
+            console.error(`💥 [${serverName}:${port}] Uncaught exception:`, error);
+            process.exit(1);
+        });
+
+        process.on('unhandledRejection', (reason, promise) => {
+            console.error(`💥 [${serverName}:${port}] Unhandled rejection:`, reason);
+            process.exit(1);
+        });
+
+    } catch (error) {
+        console.error(`❌ [${serverName}:${port}] Failed to start server:`, error);
+        process.exit(1);
+    }
+}
+
+// Start the server
+startServer();


### PR DESCRIPTION
Implements issue #26 requirements:
- Created server.js orchestrator in repository root
- Launches all 9 MCP servers as child processes (ports 3001-3009)
- Implements graceful shutdown handling (SIGTERM/SIGINT)
- Provides unified, color-coded logging for all processes
- Exits orchestrator if any server fails
- Added single-server-runner.js for individual server processes
- Updated package.json with start:orchestrator script

Architecture:
- Each server runs in isolated Node.js process for fault tolerance
- Child process management with proper signal handling
- Centralized logging with timestamp and server identification
- Health check and info endpoints for each server

Servers managed:
1. book-planning (3001)
2. series-planning (3002)
3. chapter-planning (3003)
4. character-planning (3004)
5. scene (3005)
6. core-continuity (3006)
7. review (3007)
8. reporting (3008)
9. author (3009)

Usage: npm run start:orchestrator