### PR TITLE
Code Review and Cleanup Task

### DIFF
--- a/MCP-STDIO-ADAPTER.md
+++ b/MCP-STDIO-ADAPTER.md
@@ -1,0 +1,375 @@
+# MCP Stdio Adapter
+
+## Overview
+
+The `mcp-stdio-adapter.js` bridges Claude Desktop's stdio protocol with HTTP-based MCP servers, enabling communication between Claude Desktop and Dockerized MCP Writing Servers.
+
+## Architecture
+
+```
+┌─────────────────┐      stdin/stdout      ┌──────────────────┐
+│                 │ ◄──────────────────────► │                  │
+│ Claude Desktop  │      JSON-RPC 2.0       │  Stdio Adapter   │
+│                 │                          │                  │
+└─────────────────┘                          └────────┬─────────┘
+                                                      │ HTTP POST
+                                                      │ /mcp endpoint
+                                             ┌────────▼─────────┐
+                                             │   MCP Servers    │
+                                             │  ports 3001-3009 │
+                                             │                  │
+                                             │ • book-planning  │
+                                             │ • series-planning│
+                                             │ • chapter-planning│
+                                             │ • character-planning│
+                                             │ • scene          │
+                                             │ • core-continuity│
+                                             │ • review         │
+                                             │ • reporting      │
+                                             │ • author         │
+                                             └──────────────────┘
+```
+
+## Features
+
+- ✅ **Stdin/Stdout Communication**: Reads JSON-RPC messages from stdin, writes responses to stdout
+- ✅ **HTTP Forwarding**: Routes requests to appropriate MCP servers via HTTP POST to `/mcp` endpoint
+- ✅ **Tool Discovery**: Automatically discovers and maps tools from all 9 MCP servers
+- ✅ **Intelligent Routing**: Routes tool calls to the correct server based on tool name
+- ✅ **Error Handling**: Comprehensive error handling with proper JSON-RPC error responses
+- ✅ **Stderr Logging**: All logs go to stderr, preserving stdout for JSON-RPC communication
+- ✅ **Graceful Shutdown**: Handles SIGTERM/SIGINT signals cleanly
+
+## Prerequisites
+
+1. **MCP Servers Running**: All 9 MCP servers must be running on ports 3001-3009
+   ```bash
+   npm run start:orchestrator
+   ```
+
+2. **Node.js**: Version 18 or higher (for native fetch support)
+
+## Usage
+
+### Starting the Adapter
+
+```bash
+# Using npm script
+npm run start:adapter
+
+# Or directly
+node mcp-stdio-adapter.js
+```
+
+### Configuration for Claude Desktop
+
+Add to your Claude Desktop configuration (typically `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "writing-servers": {
+      "command": "node",
+      "args": ["/path/to/MCP-Writing-Servers/mcp-stdio-adapter.js"]
+    }
+  }
+}
+```
+
+**Important**: Replace `/path/to/MCP-Writing-Servers` with the actual absolute path to your repository.
+
+### Docker Configuration
+
+If running in Docker, ensure the adapter can reach the servers:
+
+```json
+{
+  "mcpServers": {
+    "writing-servers": {
+      "command": "docker",
+      "args": [
+        "exec",
+        "mcp-writing-servers",
+        "node",
+        "/app/mcp-stdio-adapter.js"
+      ]
+    }
+  }
+}
+```
+
+## Supported JSON-RPC Methods
+
+### 1. `initialize`
+
+Initializes the adapter connection.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {}
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {
+      "tools": {}
+    },
+    "serverInfo": {
+      "name": "mcp-stdio-adapter",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+### 2. `tools/list`
+
+Lists all available tools from all MCP servers.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list",
+  "params": {}
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        "name": "create_series",
+        "description": "Create a new series",
+        "inputSchema": { ... }
+      },
+      ...
+    ]
+  }
+}
+```
+
+### 3. `tools/call`
+
+Executes a specific tool. The adapter automatically routes to the correct server.
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "create_series",
+    "arguments": {
+      "name": "My Fantasy Series",
+      "genre": "Fantasy"
+    }
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Series created successfully"
+      }
+    ]
+  }
+}
+```
+
+## Error Handling
+
+The adapter returns standard JSON-RPC 2.0 error codes:
+
+- `-32700`: Parse error (invalid JSON)
+- `-32600`: Invalid Request (not valid JSON-RPC 2.0)
+- `-32601`: Method not found
+- `-32602`: Invalid params
+- `-32603`: Internal error
+- `-32000`: Server error (tool execution failed)
+
+**Example Error Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "error": {
+    "code": -32601,
+    "message": "Unknown tool: invalid_tool_name",
+    "data": {
+      "tool": "invalid_tool_name",
+      "availableTools": ["create_series", "create_book", ...]
+    }
+  }
+}
+```
+
+## Logging
+
+All logs are written to **stderr** to keep stdout clean for JSON-RPC communication.
+
+**Log Format:**
+```json
+{
+  "timestamp": "2024-01-15T10:30:00.000Z",
+  "level": "info",
+  "message": "Tool create_series executed successfully",
+  "data": { ... }
+}
+```
+
+**Log Levels:**
+- `debug`: Detailed request/response information
+- `info`: Normal operation logs
+- `warn`: Non-critical issues (server unavailable, duplicate tools)
+- `error`: Error conditions
+
+**Example Log Output:**
+```
+{"timestamp":"2024-01-15T10:30:00.000Z","level":"info","message":"Initializing stdio adapter..."}
+{"timestamp":"2024-01-15T10:30:00.123Z","level":"info","message":"Discovered 45 tools from book-planning","data":{"server":"book-planning","port":3001,"toolCount":45}}
+{"timestamp":"2024-01-15T10:30:01.456Z","level":"info","message":"Initialization complete. Mapped 312 tools across 9/9 servers"}
+```
+
+## Testing
+
+### Manual Testing
+
+1. Start the servers:
+   ```bash
+   npm run start:orchestrator
+   ```
+
+2. In another terminal, start the adapter:
+   ```bash
+   npm run start:adapter
+   ```
+
+3. Type JSON-RPC messages and press Enter:
+   ```bash
+   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+   {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+   ```
+
+### Automated Testing
+
+Run the test script:
+```bash
+./test-stdio-adapter.sh
+```
+
+## Troubleshooting
+
+### Adapter Can't Connect to Servers
+
+**Symptom:** Errors like `Failed to connect to book-planning:3001`
+
+**Solution:**
+1. Ensure servers are running: `npm run start:orchestrator`
+2. Check that ports 3001-3009 are not blocked by firewall
+3. Verify servers are healthy: `curl http://localhost:3001/health`
+
+### No Tools Available
+
+**Symptom:** `tools/list` returns empty array
+
+**Solution:**
+1. Check server logs for errors
+2. Verify database connection is working
+3. Restart the orchestrator
+
+### Claude Desktop Can't Find Adapter
+
+**Symptom:** Error in Claude Desktop about missing executable
+
+**Solution:**
+1. Use absolute path in configuration
+2. Ensure `mcp-stdio-adapter.js` is executable: `chmod +x mcp-stdio-adapter.js`
+3. Test manually first: `node /absolute/path/to/mcp-stdio-adapter.js`
+
+### Duplicate Tool Names
+
+**Symptom:** Warning about duplicate tools in logs
+
+**Solution:**
+- This is expected if multiple servers expose the same tool name
+- The adapter uses the first occurrence
+- Check server configurations to ensure tools are unique
+
+## Server Mapping
+
+The adapter routes to these servers:
+
+| Server              | Port | Purpose                          |
+|---------------------|------|----------------------------------|
+| book-planning       | 3001 | Book planning and management     |
+| series-planning     | 3002 | Series planning and management   |
+| chapter-planning    | 3003 | Chapter planning and structure   |
+| character-planning  | 3004 | Character development            |
+| scene               | 3005 | Scene writing and management     |
+| core-continuity     | 3006 | Continuity tracking              |
+| review              | 3007 | Review and validation            |
+| reporting           | 3008 | Analytics and reporting          |
+| author              | 3009 | Author and metadata management   |
+
+## Development
+
+### Adding New Servers
+
+To add a new server:
+
+1. Add to the `SERVERS` array in `mcp-stdio-adapter.js`:
+   ```javascript
+   const SERVERS = [
+       // ... existing servers
+       { name: 'new-server', port: 3010 }
+   ];
+   ```
+
+2. Ensure the server exposes the `/mcp` endpoint
+
+3. Restart the adapter
+
+### Modifying the /mcp Endpoint
+
+The `/mcp` endpoint is defined in `src/single-server-runner.js`. It handles:
+- `initialize`: Returns server info
+- `tools/list`: Returns available tools
+- `tools/call`: Executes a tool
+
+## Related Documentation
+
+- [MCP Protocol Specification](https://modelcontextprotocol.io)
+- [Server Orchestrator Documentation](./server.js)
+- [Individual Server Documentation](./src/config-mcps/README.md)
+
+## License
+
+ISC
+
+## Contributing
+
+Issues and pull requests are welcome at: https://github.com/RLRyals/MCP-Writing-Servers/issues

--- a/mcp-stdio-adapter.js
+++ b/mcp-stdio-adapter.js
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+// mcp-stdio-adapter.js
+// Bridges Claude Desktop's stdio protocol with HTTP-based MCP servers
+// Reads JSON-RPC from stdin, forwards to HTTP servers, writes responses to stdout
+
+import { createInterface } from 'readline';
+import { stdin, stdout, stderr } from 'process';
+
+// Server configuration - matches orchestrator setup
+const SERVERS = [
+    { name: 'book-planning', port: 3001 },
+    { name: 'series-planning', port: 3002 },
+    { name: 'chapter-planning', port: 3003 },
+    { name: 'character-planning', port: 3004 },
+    { name: 'scene', port: 3005 },
+    { name: 'core-continuity', port: 3006 },
+    { name: 'review', port: 3007 },
+    { name: 'reporting', port: 3008 },
+    { name: 'author', port: 3009 }
+];
+
+// Tool routing map: tool name -> server port
+const toolToServerMap = new Map();
+
+// Track initialization state
+let isInitialized = false;
+let initializationPromise = null;
+
+// Logging utility (stderr only to preserve stdout for JSON-RPC)
+function log(level, message, data = null) {
+    const timestamp = new Date().toISOString();
+    const logEntry = {
+        timestamp,
+        level,
+        message,
+        ...(data && { data })
+    };
+    stderr.write(JSON.stringify(logEntry) + '\n');
+}
+
+// Initialize adapter by querying all servers for their tools
+async function initialize() {
+    if (isInitialized) {
+        return;
+    }
+
+    if (initializationPromise) {
+        return initializationPromise;
+    }
+
+    initializationPromise = (async () => {
+        log('info', 'Initializing stdio adapter...');
+        log('info', `Discovering tools from ${SERVERS.length} MCP servers`);
+
+        const errors = [];
+
+        for (const server of SERVERS) {
+            try {
+                const response = await fetch(`http://localhost:${server.port}/mcp`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        jsonrpc: '2.0',
+                        id: `init-${server.name}`,
+                        method: 'tools/list',
+                        params: {}
+                    })
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                }
+
+                const result = await response.json();
+
+                if (result.error) {
+                    throw new Error(result.error.message);
+                }
+
+                const tools = result.result?.tools || [];
+                log('info', `Discovered ${tools.length} tools from ${server.name}`, {
+                    server: server.name,
+                    port: server.port,
+                    toolCount: tools.length
+                });
+
+                // Map each tool to this server
+                for (const tool of tools) {
+                    if (toolToServerMap.has(tool.name)) {
+                        log('warn', `Duplicate tool name: ${tool.name} (using first occurrence)`);
+                    } else {
+                        toolToServerMap.set(tool.name, server.port);
+                    }
+                }
+
+            } catch (error) {
+                errors.push({
+                    server: server.name,
+                    port: server.port,
+                    error: error.message
+                });
+                log('error', `Failed to connect to ${server.name}:${server.port}`, {
+                    server: server.name,
+                    port: server.port,
+                    error: error.message
+                });
+            }
+        }
+
+        isInitialized = true;
+        log('info', `Initialization complete. Mapped ${toolToServerMap.size} tools across ${SERVERS.length - errors.length}/${SERVERS.length} servers`);
+
+        if (errors.length > 0) {
+            log('warn', `${errors.length} server(s) failed to initialize`, { errors });
+        }
+    })();
+
+    return initializationPromise;
+}
+
+// Forward JSON-RPC request to appropriate HTTP server
+async function forwardRequest(request) {
+    const { jsonrpc, id, method, params } = request;
+
+    log('debug', `Processing request: ${method}`, { id, method });
+
+    // Ensure initialization is complete
+    await initialize();
+
+    // Handle initialize method
+    if (method === 'initialize') {
+        log('info', 'Handling initialize request');
+        return {
+            jsonrpc: '2.0',
+            id,
+            result: {
+                protocolVersion: '2024-11-05',
+                capabilities: {
+                    tools: {}
+                },
+                serverInfo: {
+                    name: 'mcp-stdio-adapter',
+                    version: '1.0.0'
+                }
+            }
+        };
+    }
+
+    // Handle tools/list - aggregate from all servers
+    if (method === 'tools/list') {
+        log('info', 'Aggregating tools from all servers');
+        const allTools = [];
+
+        for (const server of SERVERS) {
+            try {
+                const response = await fetch(`http://localhost:${server.port}/mcp`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        jsonrpc: '2.0',
+                        id: `list-${server.name}`,
+                        method: 'tools/list',
+                        params: {}
+                    })
+                });
+
+                const result = await response.json();
+                if (result.result?.tools) {
+                    allTools.push(...result.result.tools);
+                }
+            } catch (error) {
+                log('warn', `Failed to get tools from ${server.name}`, { error: error.message });
+            }
+        }
+
+        log('info', `Returning ${allTools.length} tools total`);
+        return {
+            jsonrpc: '2.0',
+            id,
+            result: {
+                tools: allTools
+            }
+        };
+    }
+
+    // Handle tools/call - route to specific server
+    if (method === 'tools/call') {
+        const toolName = params?.name;
+
+        if (!toolName) {
+            return {
+                jsonrpc: '2.0',
+                id,
+                error: {
+                    code: -32602,
+                    message: 'Invalid params: tool name is required'
+                }
+            };
+        }
+
+        const serverPort = toolToServerMap.get(toolName);
+
+        if (!serverPort) {
+            log('error', `Unknown tool: ${toolName}`);
+            return {
+                jsonrpc: '2.0',
+                id,
+                error: {
+                    code: -32601,
+                    message: `Unknown tool: ${toolName}`,
+                    data: {
+                        tool: toolName,
+                        availableTools: Array.from(toolToServerMap.keys())
+                    }
+                }
+            };
+        }
+
+        log('info', `Routing tool ${toolName} to server on port ${serverPort}`);
+
+        try {
+            const response = await fetch(`http://localhost:${serverPort}/mcp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(request)
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            const result = await response.json();
+            log('info', `Tool ${toolName} executed successfully`);
+            return result;
+
+        } catch (error) {
+            log('error', `Failed to execute tool ${toolName}`, {
+                tool: toolName,
+                port: serverPort,
+                error: error.message
+            });
+
+            return {
+                jsonrpc: '2.0',
+                id,
+                error: {
+                    code: -32000,
+                    message: `Failed to execute tool: ${error.message}`,
+                    data: {
+                        tool: toolName,
+                        port: serverPort,
+                        error: error.message
+                    }
+                }
+            };
+        }
+    }
+
+    // Unknown method
+    return {
+        jsonrpc: '2.0',
+        id,
+        error: {
+            code: -32601,
+            message: `Method not found: ${method}`
+        }
+    };
+}
+
+// Write JSON-RPC response to stdout
+function writeResponse(response) {
+    const responseStr = JSON.stringify(response);
+    stdout.write(responseStr + '\n');
+    log('debug', 'Response written to stdout', { id: response.id });
+}
+
+// Process incoming JSON-RPC message from stdin
+async function processMessage(line) {
+    if (!line.trim()) {
+        return;
+    }
+
+    try {
+        const request = JSON.parse(line);
+        log('info', `Received request: ${request.method}`, {
+            id: request.id,
+            method: request.method
+        });
+
+        const response = await forwardRequest(request);
+        writeResponse(response);
+
+    } catch (error) {
+        log('error', 'Failed to process message', {
+            error: error.message,
+            line: line.substring(0, 100) // Log first 100 chars
+        });
+
+        // Send error response if possible
+        try {
+            const partialRequest = JSON.parse(line);
+            writeResponse({
+                jsonrpc: '2.0',
+                id: partialRequest.id || null,
+                error: {
+                    code: -32603,
+                    message: 'Internal error',
+                    data: {
+                        error: error.message
+                    }
+                }
+            });
+        } catch {
+            // Cannot parse request, send generic error
+            writeResponse({
+                jsonrpc: '2.0',
+                id: null,
+                error: {
+                    code: -32700,
+                    message: 'Parse error'
+                }
+            });
+        }
+    }
+}
+
+// Graceful shutdown handler
+function shutdown(signal) {
+    log('info', `Received ${signal}, shutting down gracefully...`);
+
+    // Close stdin
+    stdin.pause();
+
+    // Give time for any pending writes to complete
+    setTimeout(() => {
+        log('info', 'Stdio adapter shut down');
+        process.exit(0);
+    }, 100);
+}
+
+// Main function
+async function main() {
+    log('info', '='.repeat(80));
+    log('info', 'MCP Stdio Adapter - Bridging Claude Desktop to HTTP MCP Servers');
+    log('info', '='.repeat(80));
+    log('info', `Configured for ${SERVERS.length} servers on ports 3001-3009`);
+    log('info', 'Starting adapter...');
+
+    // Register signal handlers for graceful shutdown
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+    // Handle uncaught errors
+    process.on('uncaughtException', (error) => {
+        log('error', 'Uncaught exception', {
+            error: error.message,
+            stack: error.stack
+        });
+        process.exit(1);
+    });
+
+    process.on('unhandledRejection', (reason, promise) => {
+        log('error', 'Unhandled rejection', {
+            reason: reason instanceof Error ? reason.message : String(reason)
+        });
+        process.exit(1);
+    });
+
+    // Set up readline interface for stdin
+    const rl = createInterface({
+        input: stdin,
+        output: null, // Don't echo to stdout
+        terminal: false
+    });
+
+    log('info', 'Listening for JSON-RPC messages on stdin...');
+    log('info', 'Adapter ready');
+
+    // Process each line from stdin
+    rl.on('line', async (line) => {
+        await processMessage(line);
+    });
+
+    // Handle stdin close
+    rl.on('close', () => {
+        log('info', 'Stdin closed, shutting down...');
+        process.exit(0);
+    });
+
+    // Pre-initialize to discover tools
+    try {
+        await initialize();
+    } catch (error) {
+        log('error', 'Initialization failed', { error: error.message });
+        // Continue anyway - will retry on first request
+    }
+}
+
+// Start the adapter
+main().catch((error) => {
+    log('error', 'Fatal error in main', {
+        error: error.message,
+        stack: error.stack
+    });
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node src/http-sse-server.js",
     "start:stdio": "node src/stdio-server.js",
     "start:orchestrator": "node server.js",
+    "start:adapter": "node mcp-stdio-adapter.js",
     "dev": "node --watch src/http-sse-server.js"
   },
   "repository": {

--- a/test-stdio-adapter.sh
+++ b/test-stdio-adapter.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# test-stdio-adapter.sh
+# Test script for mcp-stdio-adapter.js
+# Prerequisites: MCP servers must be running (npm run start:orchestrator)
+
+echo "Testing MCP Stdio Adapter"
+echo "=========================="
+echo ""
+
+# Check if servers are running
+echo "Checking if MCP servers are running..."
+if ! curl -s http://localhost:3001/health > /dev/null 2>&1; then
+    echo "❌ Error: MCP servers are not running"
+    echo "Please start the servers first with: npm run start:orchestrator"
+    exit 1
+fi
+echo "✓ Servers are running"
+echo ""
+
+# Test 1: Initialize
+echo "Test 1: Initialize request"
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | node mcp-stdio-adapter.js &
+ADAPTER_PID=$!
+sleep 2
+kill $ADAPTER_PID 2>/dev/null
+echo ""
+
+# Test 2: List tools (with running adapter)
+echo "Test 2: List tools request"
+(
+    sleep 0.5
+    echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+    sleep 1
+    echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+    sleep 2
+    kill $ADAPTER_PID 2>/dev/null
+) | node mcp-stdio-adapter.js 2>/dev/null | head -20
+echo ""
+
+echo "=========================="
+echo "Basic tests complete!"
+echo ""
+echo "For interactive testing:"
+echo "1. Start the orchestrator: npm run start:orchestrator"
+echo "2. In another terminal, run: node mcp-stdio-adapter.js"
+echo "3. Type JSON-RPC messages and press Enter"
+echo ""
+echo "Example messages:"
+echo '  {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+echo '  {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+echo ""


### PR DESCRIPTION
Implements issue #27 by creating a Node.js adapter that bridges Claude Desktop's stdio protocol with HTTP-based MCP servers running on ports 3001-3009.

Key features:
- Reads JSON-RPC messages from stdin, forwards to HTTP servers, writes to stdout
- Supports all 9 MCP server types (book-planning, series-planning, chapter-planning, character-planning, scene, core-continuity, review, reporting, author)
- Intelligent tool discovery and routing based on tool names
- Comprehensive error handling with proper JSON-RPC error responses
- All logging goes to stderr to preserve stdout for RPC communication
- Graceful shutdown via SIGTERM/SIGINT signals

Changes:
- Add mcp-stdio-adapter.js: Main stdio bridge implementation
- Add /mcp endpoint to single-server-runner.js for JSON-RPC handling
- Add start:adapter script to package.json
- Add comprehensive documentation in MCP-STDIO-ADAPTER.md
- Add test-stdio-adapter.sh for basic testing

The adapter enables Claude Desktop to communicate with Dockerized MCP servers, serving as the foundation for the stdio Bridge Service (issue #92 in MCP-Electron-App).