### PR TITLE
S11 kanban plugin: migration 042_kanban_tables.sql + kanban-server MCP (port 3015)

### DIFF
--- a/mcp-config/mcp-config.json
+++ b/mcp-config/mcp-config.json
@@ -29,6 +29,9 @@
     },
     "outline": {
       "url": "http://mcp-writing-servers:3013/"
+    },
+    "kanban": {
+      "url": "http://mcp-writing-servers:3015/"
     }
   }
 }

--- a/migrations/042_kanban_tables.sql
+++ b/migrations/042_kanban_tables.sql
@@ -1,0 +1,270 @@
+-- Migration: 042_kanban_tables
+-- Description: Kanban board plugin (S11) — boards, columns, cards, card links,
+-- comments, and an append-only activity log. All tables live in schema
+-- `fictionlab`, prefixed `kanban_`. Seeds the single `dev-backlog` board + its
+-- 8 columns (idempotent).
+--
+-- Numbered 042 (not 041): 041 is reserved for S9 model-testing
+-- (041_model_testing_tables.sql, not yet on disk at the time this migration
+-- was written) — see GH issue #58 / S11-kanban-plugin.md §1. Re-scan
+-- migrations/ for the true next free number if that has changed by the time
+-- this is applied, and keep the filename + the guard string in sync.
+--
+-- Card lifecycle status: backlog -> ready -> claimed -> in_progress -> review
+-- -> done -> archived, with `blocked` as a side state. `kanban_cards.status`
+-- is the single source of truth for "where a card is" — `kanban_columns` is
+-- display config keyed 1:1 to a status (no column_id FK on the card, no
+-- dual-write to keep the two in sync).
+--
+-- review_policy (§11.5 resolution, an addition on top of the original §3a
+-- column table): per-card, risk-based review gate. Defaulted by the
+-- `create_card` handler (not by the DB column default alone, since the DB
+-- can't inspect card content/labels to pick a risk class) to 'review-required'
+-- unless the caller/handler determines the card is docs/specs/reports/
+-- analysis-only, in which case 'auto-done'. Agents may escalate a card to
+-- review-required but must never downgrade it themselves.
+--
+-- kanban_enforce_human_reserve is belt-and-suspenders: a card with
+-- assignee='rebecca' can NEVER be agent-claimable regardless of what the
+-- caller passed. claim_card's WHERE clause independently checks the same
+-- condition (defense in depth, not redundant — see kanban-server
+-- claim-handlers.js).
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM migrations WHERE filename = '042_kanban_tables.sql') THEN
+        RAISE NOTICE 'Migration 042_kanban_tables.sql already applied, skipping.';
+        RETURN;
+    END IF;
+
+    CREATE SCHEMA IF NOT EXISTS fictionlab;
+
+    -- =========================================================
+    -- 1. kanban_boards
+    -- =========================================================
+    CREATE TABLE IF NOT EXISTS fictionlab.kanban_boards (
+        id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        board_key   VARCHAR(100) UNIQUE NOT NULL,
+        name        VARCHAR(255) NOT NULL,
+        description TEXT,
+        is_archived BOOLEAN DEFAULT FALSE,
+        created_at  TIMESTAMPTZ DEFAULT NOW(),
+        updated_at  TIMESTAMPTZ DEFAULT NOW(),
+        created_by  VARCHAR(100) DEFAULT 'rebecca',
+        metadata    JSONB DEFAULT '{}'::jsonb
+    );
+
+    COMMENT ON TABLE fictionlab.kanban_boards IS 'Kanban boards. v1 seeds exactly one (dev-backlog); schema supports many.';
+
+    RAISE NOTICE 'Created fictionlab.kanban_boards';
+
+    -- =========================================================
+    -- 2. kanban_columns — ordered display lanes, 1:1 with a card status
+    -- =========================================================
+    CREATE TABLE IF NOT EXISTS fictionlab.kanban_columns (
+        id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        board_id         UUID NOT NULL REFERENCES fictionlab.kanban_boards(id) ON DELETE CASCADE,
+        status_key       VARCHAR(50) NOT NULL,
+        name             VARCHAR(255) NOT NULL,
+        position         INTEGER NOT NULL DEFAULT 0,
+        color            VARCHAR(20),
+        wip_limit        INTEGER,
+        is_agent_pickup  BOOLEAN DEFAULT FALSE,
+        created_at       TIMESTAMPTZ DEFAULT NOW(),
+        UNIQUE (board_id, status_key)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_kanban_columns_board_position
+        ON fictionlab.kanban_columns(board_id, position);
+
+    COMMENT ON TABLE fictionlab.kanban_columns IS 'Display lanes keyed 1:1 to kanban_cards.status. No column_id FK on the card — move_card only ever touches kanban_cards.status.';
+    COMMENT ON COLUMN fictionlab.kanban_columns.is_agent_pickup IS 'TRUE only on the ready lane — cards here are the agent pool.';
+
+    RAISE NOTICE 'Created fictionlab.kanban_columns';
+
+    -- =========================================================
+    -- 3. kanban_cards
+    -- =========================================================
+    CREATE TABLE IF NOT EXISTS fictionlab.kanban_cards (
+        id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        board_id              UUID NOT NULL REFERENCES fictionlab.kanban_boards(id) ON DELETE CASCADE,
+        title                 VARCHAR(500) NOT NULL,
+        body                  TEXT,
+        status                VARCHAR(50) NOT NULL DEFAULT 'backlog'
+            CHECK (status IN ('backlog','ready','claimed','in_progress','review','blocked','done','archived')),
+        assignee              VARCHAR(100),
+        agent_claimable       BOOLEAN NOT NULL DEFAULT TRUE,
+        priority              VARCHAR(20) DEFAULT 'normal'
+            CHECK (priority IN ('low','normal','high','urgent')),
+        labels                TEXT[] DEFAULT '{}',
+        position              INTEGER DEFAULT 0,
+        claimed_by            VARCHAR(100),
+        claimed_at            TIMESTAMPTZ,
+        workflow_registry_id  UUID REFERENCES fictionlab.active_workflows(id)
+            ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED,
+        spec_ref              VARCHAR(500),
+        issue_ref             VARCHAR(500),
+        review_policy         VARCHAR(20) NOT NULL DEFAULT 'review-required'
+            CHECK (review_policy IN ('auto-done','review-required')),
+        created_at            TIMESTAMPTZ DEFAULT NOW(),
+        updated_at            TIMESTAMPTZ DEFAULT NOW(),
+        created_by            VARCHAR(100) DEFAULT 'rebecca',
+        metadata              JSONB DEFAULT '{}'::jsonb
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_kanban_cards_board_status ON fictionlab.kanban_cards(board_id, status);
+    CREATE INDEX IF NOT EXISTS idx_kanban_cards_assignee ON fictionlab.kanban_cards(assignee);
+    CREATE INDEX IF NOT EXISTS idx_kanban_cards_status ON fictionlab.kanban_cards(status);
+    CREATE INDEX IF NOT EXISTS idx_kanban_cards_labels ON fictionlab.kanban_cards USING GIN(labels);
+    CREATE INDEX IF NOT EXISTS idx_kanban_cards_workflow_registry ON fictionlab.kanban_cards(workflow_registry_id);
+    CREATE INDEX IF NOT EXISTS idx_kanban_cards_ready_pool
+        ON fictionlab.kanban_cards(board_id, position)
+        WHERE status = 'ready' AND agent_claimable;
+
+    COMMENT ON TABLE fictionlab.kanban_cards IS 'A kanban card — the detailed issue spec (file:line, plan, acceptance criteria) lives in body.';
+    COMMENT ON COLUMN fictionlab.kanban_cards.agent_claimable IS 'Set FALSE by trigger when assignee=''rebecca''; the hard gate for agent claims.';
+    COMMENT ON COLUMN fictionlab.kanban_cards.review_policy IS 'auto-done | review-required. Defaulted by risk class at create_card time (handler-level, not just this column default). Agents may escalate, never downgrade.';
+
+    RAISE NOTICE 'Created fictionlab.kanban_cards';
+
+    -- =========================================================
+    -- 4. kanban_card_links — 0..n typed links beyond the two inline refs
+    -- =========================================================
+    CREATE TABLE IF NOT EXISTS fictionlab.kanban_card_links (
+        id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        card_id    UUID NOT NULL REFERENCES fictionlab.kanban_cards(id) ON DELETE CASCADE,
+        link_type  VARCHAR(30) NOT NULL
+            CHECK (link_type IN ('spec','github_issue','workflow_run','file','url','card')),
+        ref        TEXT NOT NULL,
+        label      VARCHAR(255),
+        created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_kanban_card_links_card ON fictionlab.kanban_card_links(card_id);
+
+    RAISE NOTICE 'Created fictionlab.kanban_card_links';
+
+    -- =========================================================
+    -- 5. kanban_comments — comment thread
+    -- =========================================================
+    CREATE TABLE IF NOT EXISTS fictionlab.kanban_comments (
+        id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        card_id    UUID NOT NULL REFERENCES fictionlab.kanban_cards(id) ON DELETE CASCADE,
+        author     VARCHAR(100) NOT NULL,
+        body       TEXT NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        metadata   JSONB DEFAULT '{}'::jsonb
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_kanban_comments_card_created ON fictionlab.kanban_comments(card_id, created_at);
+
+    RAISE NOTICE 'Created fictionlab.kanban_comments';
+
+    -- =========================================================
+    -- 6. kanban_activity — append-only audit / activity log
+    -- =========================================================
+    CREATE TABLE IF NOT EXISTS fictionlab.kanban_activity (
+        id          BIGSERIAL PRIMARY KEY,
+        board_id    UUID REFERENCES fictionlab.kanban_boards(id) ON DELETE CASCADE,
+        card_id     UUID REFERENCES fictionlab.kanban_cards(id) ON DELETE CASCADE,
+        actor       VARCHAR(100) NOT NULL,
+        action      VARCHAR(50) NOT NULL,
+        from_status VARCHAR(50),
+        to_status   VARCHAR(50),
+        detail      JSONB DEFAULT '{}'::jsonb,
+        created_at  TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_kanban_activity_board_created ON fictionlab.kanban_activity(board_id, created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_kanban_activity_card_created ON fictionlab.kanban_activity(card_id, created_at DESC);
+
+    COMMENT ON TABLE fictionlab.kanban_activity IS 'Append-only audit feed. action IN (created, claimed, claim_denied, moved, assigned, commented, updated, linked, archived).';
+
+    RAISE NOTICE 'Created fictionlab.kanban_activity';
+
+    -- =========================================================
+    -- Triggers
+    -- =========================================================
+
+    -- BEFORE UPDATE timestamp trigger, shared by kanban_boards + kanban_cards
+    CREATE OR REPLACE FUNCTION fictionlab.kanban_update_timestamp()
+    RETURNS TRIGGER AS $func$
+    BEGIN
+        NEW.updated_at = NOW();
+        RETURN NEW;
+    END;
+    $func$ LANGUAGE plpgsql;
+
+    DROP TRIGGER IF EXISTS trigger_kanban_boards_update_timestamp ON fictionlab.kanban_boards;
+    CREATE TRIGGER trigger_kanban_boards_update_timestamp
+        BEFORE UPDATE ON fictionlab.kanban_boards
+        FOR EACH ROW
+        EXECUTE FUNCTION fictionlab.kanban_update_timestamp();
+
+    DROP TRIGGER IF EXISTS trigger_kanban_cards_update_timestamp ON fictionlab.kanban_cards;
+    CREATE TRIGGER trigger_kanban_cards_update_timestamp
+        BEFORE UPDATE ON fictionlab.kanban_cards
+        FOR EACH ROW
+        EXECUTE FUNCTION fictionlab.kanban_update_timestamp();
+
+    -- Human-reserve guard: a card assigned to rebecca is NEVER agent-claimable,
+    -- no matter what the caller passed for agent_claimable.
+    CREATE OR REPLACE FUNCTION fictionlab.kanban_enforce_human_reserve()
+    RETURNS TRIGGER AS $func$
+    BEGIN
+        IF NEW.assignee = 'rebecca' THEN
+            NEW.agent_claimable := FALSE;
+        END IF;
+        RETURN NEW;
+    END;
+    $func$ LANGUAGE plpgsql;
+
+    DROP TRIGGER IF EXISTS trigger_kanban_cards_enforce_human_reserve ON fictionlab.kanban_cards;
+    CREATE TRIGGER trigger_kanban_cards_enforce_human_reserve
+        BEFORE INSERT OR UPDATE ON fictionlab.kanban_cards
+        FOR EACH ROW
+        EXECUTE FUNCTION fictionlab.kanban_enforce_human_reserve();
+
+    RAISE NOTICE 'Created kanban_update_timestamp + kanban_enforce_human_reserve triggers';
+
+    -- =========================================================
+    -- Seed: the ONE board + its 8 columns (idempotent)
+    -- =========================================================
+    INSERT INTO fictionlab.kanban_boards (board_key, name, description)
+    VALUES (
+        'dev-backlog',
+        'Development backlog',
+        'Live pipeline dev + personal task board. Archive/history: WORKFLOW-FIXES.md.'
+    )
+    ON CONFLICT (board_key) DO NOTHING;
+
+    INSERT INTO fictionlab.kanban_columns (board_id, status_key, name, position, is_agent_pickup)
+    SELECT b.id, c.status_key, c.name, c.position, c.is_agent_pickup
+    FROM fictionlab.kanban_boards b
+    CROSS JOIN (VALUES
+        ('backlog',     'Backlog',              0, FALSE),
+        ('ready',       'Ready to work',         1, TRUE),
+        ('in_progress', 'In progress',           2, FALSE),
+        ('review',      'In review',             3, FALSE),
+        ('blocked',     'Blocked / decision',    4, FALSE),
+        ('done',        'Done',                  5, FALSE),
+        ('archived',    'Archived',              6, FALSE),
+        ('claimed',     'Claimed',                7, FALSE)
+    ) AS c(status_key, name, position, is_agent_pickup)
+    WHERE b.board_key = 'dev-backlog'
+    ON CONFLICT (board_id, status_key) DO NOTHING;
+
+    RAISE NOTICE 'Seeded dev-backlog board + 8 columns';
+
+    INSERT INTO migrations (filename) VALUES ('042_kanban_tables.sql')
+    ON CONFLICT (filename) DO NOTHING;
+
+    RAISE NOTICE '=================================================================';
+    RAISE NOTICE 'Migration 042_kanban_tables.sql completed successfully';
+    RAISE NOTICE '=================================================================';
+    RAISE NOTICE 'Created 6 tables in schema fictionlab: kanban_boards, kanban_columns,';
+    RAISE NOTICE 'kanban_cards, kanban_card_links, kanban_comments, kanban_activity';
+    RAISE NOTICE 'Created 2 trigger functions: kanban_update_timestamp, kanban_enforce_human_reserve';
+    RAISE NOTICE 'Seeded board: dev-backlog (8 columns)';
+    RAISE NOTICE '=================================================================';
+END $$;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "mcp-writing-servers",
+  "name": "@fictionlab/db",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-writing-servers",
+      "name": "@fictionlab/db",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "UNLICENSED",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "cors": "^2.8.5",
@@ -15,6 +15,9 @@
         "express": "^5.1.0",
         "helmet": "^8.1.0",
         "pg": "^8.16.3"
+      },
+      "peerDependencies": {
+        "pg": "^8"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/src/http-sse-server.js
+++ b/src/http-sse-server.js
@@ -215,7 +215,21 @@ async function loadServers() {
         console.error('✗ Failed to load Outline Server:', error.message);
     }
 
-    console.error(`\n✅ Successfully loaded ${servers.length}/12 servers\n`);
+    try {
+        // Kanban Server (S11 kanban board plugin, GH issue #58)
+        const { KanbanMCPServer } = await import('./mcps/kanban-server/index.js');
+        servers.push({
+            name: 'kanban',
+            path: '/kanban',
+            serverClass: KanbanMCPServer,
+            port: 3015
+        });
+        console.error('✓ Kanban Server loaded');
+    } catch (error) {
+        console.error('✗ Failed to load Kanban Server:', error.message);
+    }
+
+    console.error(`\n✅ Successfully loaded ${servers.length}/13 servers\n`);
     return servers;
 }
 

--- a/src/mcps/kanban-server/handlers/board-handlers.js
+++ b/src/mcps/kanban-server/handlers/board-handlers.js
@@ -1,0 +1,80 @@
+// src/mcps/kanban-server/handlers/board-handlers.js
+// Board-level read tools: get_board (the board-render call) and the
+// supporting list_boards.
+
+export class BoardHandlers {
+    constructor(db) {
+        this.db = db;
+    }
+
+    /**
+     * get_board — board + its columns + per-column card counts.
+     * One of board_key|board_id is required.
+     */
+    async handleGetBoard(args) {
+        const { board_key, board_id } = args || {};
+
+        if (!board_id && !board_key) {
+            throw new Error('board_key or board_id is required');
+        }
+
+        const boardResult = await this.db.query(
+            board_id
+                ? 'SELECT * FROM fictionlab.kanban_boards WHERE id = $1'
+                : 'SELECT * FROM fictionlab.kanban_boards WHERE board_key = $1',
+            [board_id || board_key]
+        );
+
+        if (boardResult.rows.length === 0) {
+            throw new Error(`Board not found: ${board_id || board_key}`);
+        }
+
+        const board = boardResult.rows[0];
+
+        const columnsResult = await this.db.query(
+            `SELECT
+                col.status_key,
+                col.name,
+                col.position,
+                col.color,
+                col.wip_limit,
+                col.is_agent_pickup,
+                COUNT(card.id) AS card_count
+             FROM fictionlab.kanban_columns col
+             LEFT JOIN fictionlab.kanban_cards card
+               ON card.board_id = col.board_id AND card.status = col.status_key
+             WHERE col.board_id = $1
+             GROUP BY col.id, col.status_key, col.name, col.position, col.color, col.wip_limit, col.is_agent_pickup
+             ORDER BY col.position`,
+            [board.id]
+        );
+
+        return {
+            board,
+            columns: columnsResult.rows.map((row) => ({
+                ...row,
+                card_count: parseInt(row.card_count, 10)
+            }))
+        };
+    }
+
+    /**
+     * list_boards (supporting tool) — all boards + their total card counts.
+     */
+    async handleListBoards() {
+        const result = await this.db.query(
+            `SELECT b.*, COUNT(c.id) AS card_count
+             FROM fictionlab.kanban_boards b
+             LEFT JOIN fictionlab.kanban_cards c ON c.board_id = b.id
+             GROUP BY b.id
+             ORDER BY b.created_at`
+        );
+
+        return {
+            boards: result.rows.map((row) => ({
+                ...row,
+                card_count: parseInt(row.card_count, 10)
+            }))
+        };
+    }
+}

--- a/src/mcps/kanban-server/handlers/card-handlers.js
+++ b/src/mcps/kanban-server/handlers/card-handlers.js
@@ -1,0 +1,470 @@
+// src/mcps/kanban-server/handlers/card-handlers.js
+// Card CRUD + lifecycle tools: list_cards, create_card, update_card,
+// move_card, plus the supporting get_card / add_card_link / archive_card.
+// claim_card lives in claim-handlers.js — the atomic compare-and-swap is
+// kept in exactly one place.
+
+import { resolveBoardId, logActivity, notifyKanbanChanged, inferReviewPolicy } from './kanban-helpers.js';
+
+const CARD_STATUSES = ['backlog', 'ready', 'claimed', 'in_progress', 'review', 'blocked', 'done', 'archived'];
+
+export class CardHandlers {
+    constructor(db) {
+        this.db = db;
+    }
+
+    /**
+     * list_cards — the workhorse filter. board_key/board_id, assignee, agent,
+     * status, label, priority, agent_claimable_only, include_archived,
+     * include_workflow_phase, limit.
+     */
+    async handleListCards(args) {
+        const {
+            board_key,
+            board_id,
+            assignee,
+            agent,
+            status,
+            label,
+            priority,
+            agent_claimable_only = false,
+            include_archived = false,
+            include_workflow_phase = false,
+            limit = 200
+        } = args || {};
+
+        const conditions = [];
+        const params = [];
+        let i = 1;
+
+        if (board_id) {
+            conditions.push(`c.board_id = $${i++}`);
+            params.push(board_id);
+        } else if (board_key) {
+            conditions.push(`c.board_id = (SELECT id FROM fictionlab.kanban_boards WHERE board_key = $${i++})`);
+            params.push(board_key);
+        }
+
+        if (assignee === '__unassigned__') {
+            conditions.push('c.assignee IS NULL');
+        } else if (assignee) {
+            conditions.push(`c.assignee = $${i++}`);
+            params.push(assignee);
+        }
+
+        if (status) {
+            conditions.push(`c.status = $${i++}`);
+            params.push(status);
+        }
+
+        if (label) {
+            conditions.push(`$${i++} = ANY(c.labels)`);
+            params.push(label);
+        }
+
+        if (priority) {
+            conditions.push(`c.priority = $${i++}`);
+            params.push(priority);
+        }
+
+        // agent_claimable_only MUST exclude every assignee='rebecca' card by
+        // construction (not just by relying on the agent_claimable trigger).
+        if (agent_claimable_only) {
+            conditions.push(`c.agent_claimable = TRUE AND c.assignee IS DISTINCT FROM 'rebecca'`);
+            if (agent) {
+                conditions.push(`(c.assignee IS NULL OR c.assignee = $${i++})`);
+                params.push(agent);
+            }
+        } else if (agent) {
+            // agent given without agent_claimable_only: cards claimable-by-or-
+            // assigned-to this agent (unassigned pool, or already routed to it).
+            conditions.push(`(c.assignee = $${i} OR (c.assignee IS NULL AND c.agent_claimable = TRUE))`);
+            params.push(agent);
+            i++;
+        }
+
+        // Default excludes archived cards, unless the caller explicitly asked
+        // for archived cards via status:'archived'.
+        if (!include_archived && status !== 'archived') {
+            conditions.push(`c.status <> 'archived'`);
+        }
+
+        const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+        const workflowJoin = include_workflow_phase
+            ? 'LEFT JOIN fictionlab.active_workflows aw ON aw.id = c.workflow_registry_id'
+            : '';
+        const workflowSelect = include_workflow_phase
+            ? `, aw.current_node_name AS workflow_phase, aw.progress_percent AS workflow_progress_percent, aw.status AS workflow_status`
+            : '';
+
+        params.push(limit);
+
+        const result = await this.db.query(
+            `SELECT
+                c.*,
+                (SELECT COUNT(*) FROM fictionlab.kanban_comments cm WHERE cm.card_id = c.id) AS comment_count,
+                (SELECT COUNT(*) FROM fictionlab.kanban_card_links l WHERE l.card_id = c.id) AS link_count
+                ${workflowSelect}
+             FROM fictionlab.kanban_cards c
+             ${workflowJoin}
+             ${whereClause}
+             ORDER BY
+                CASE c.priority
+                    WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 WHEN 'low' THEN 3 ELSE 4
+                END,
+                c.position,
+                c.created_at
+             LIMIT $${i}`,
+            params
+        );
+
+        return {
+            cards: result.rows.map((row) => ({
+                ...row,
+                comment_count: parseInt(row.comment_count, 10),
+                link_count: parseInt(row.link_count, 10)
+            }))
+        };
+    }
+
+    /**
+     * create_card — full or quick-add (title-only is valid; board resolves to
+     * dev-backlog if neither board_key nor board_id given).
+     */
+    async handleCreateCard(args) {
+        const {
+            board_key,
+            board_id,
+            title,
+            body,
+            status = 'ready',
+            assignee,
+            priority = 'normal',
+            labels = [],
+            spec_ref,
+            issue_ref,
+            created_by = 'rebecca',
+            review_policy
+        } = args || {};
+
+        if (!title) {
+            throw new Error('title is required');
+        }
+
+        if (status && !CARD_STATUSES.includes(status)) {
+            throw new Error(`Invalid status: ${status}`);
+        }
+
+        const resolvedBoardId = await resolveBoardId(this.db, {
+            board_id,
+            board_key,
+            defaultBoardKey: 'dev-backlog'
+        });
+
+        // Agents may escalate a card to review-required but never downgrade it
+        // themselves -- an explicit override is only ever honored as-is here;
+        // "never downgrade" is enforced by update_card not exposing
+        // review_policy as a patchable field (see update_card below).
+        const resolvedReviewPolicy = review_policy || inferReviewPolicy({ labels, spec_ref, issue_ref, title, body });
+
+        const result = await this.db.query(
+            `INSERT INTO fictionlab.kanban_cards
+                (board_id, title, body, status, assignee, priority, labels, spec_ref, issue_ref, review_policy, created_by)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+             RETURNING *`,
+            [
+                resolvedBoardId,
+                title,
+                body || null,
+                status,
+                assignee || null,
+                priority,
+                labels,
+                spec_ref || null,
+                issue_ref || null,
+                resolvedReviewPolicy,
+                created_by
+            ]
+        );
+
+        const card = result.rows[0];
+
+        await logActivity(this.db, {
+            boardId: resolvedBoardId,
+            cardId: card.id,
+            actor: created_by,
+            action: 'created',
+            toStatus: card.status,
+            detail: { title, review_policy: resolvedReviewPolicy }
+        });
+        await notifyKanbanChanged(this.db, card.id);
+
+        return { card };
+    }
+
+    /**
+     * update_card — partial patch; only provided keys change.
+     * assignee:'rebecca' auto-clears agent_claimable via the DB trigger.
+     * assignee:'__clear__' unassigns.
+     * review_policy: escalate-only (S11 §11.5 decision 5 — "agents may
+     * escalate a card to review-required, never downgrade it themselves").
+     * 'auto-done' -> 'review-required' is always allowed; the reverse throws.
+     */
+    async handleUpdateCard(args) {
+        const {
+            card_id,
+            actor = 'rebecca',
+            title,
+            body,
+            assignee,
+            priority,
+            labels,
+            spec_ref,
+            issue_ref,
+            workflow_registry_id,
+            metadata,
+            review_policy
+        } = args || {};
+
+        if (!card_id) {
+            throw new Error('card_id is required');
+        }
+
+        const existing = await this.db.query('SELECT * FROM fictionlab.kanban_cards WHERE id = $1', [card_id]);
+        if (existing.rows.length === 0) {
+            throw new Error(`Card not found: ${card_id}`);
+        }
+
+        if (review_policy !== undefined && review_policy !== existing.rows[0].review_policy) {
+            if (existing.rows[0].review_policy === 'review-required' && review_policy === 'auto-done') {
+                throw new Error(
+                    'review_policy cannot be downgraded from review-required to auto-done — agents may only escalate a card, never downgrade it themselves. Ask Rebecca to change it if that is genuinely intended.'
+                );
+            }
+        }
+
+        const sets = [];
+        const params = [card_id];
+        let i = 2;
+        const changedFields = [];
+
+        if (title !== undefined) {
+            sets.push(`title = $${i++}`);
+            params.push(title);
+            changedFields.push('title');
+        }
+        if (body !== undefined) {
+            sets.push(`body = $${i++}`);
+            params.push(body);
+            changedFields.push('body');
+        }
+        if (assignee !== undefined) {
+            if (assignee === '__clear__') {
+                sets.push('assignee = NULL');
+            } else {
+                sets.push(`assignee = $${i++}`);
+                params.push(assignee);
+            }
+            changedFields.push('assignee');
+        }
+        if (priority !== undefined) {
+            sets.push(`priority = $${i++}`);
+            params.push(priority);
+            changedFields.push('priority');
+        }
+        if (labels !== undefined) {
+            sets.push(`labels = $${i++}`);
+            params.push(labels);
+            changedFields.push('labels');
+        }
+        if (spec_ref !== undefined) {
+            sets.push(`spec_ref = $${i++}`);
+            params.push(spec_ref);
+            changedFields.push('spec_ref');
+        }
+        if (issue_ref !== undefined) {
+            sets.push(`issue_ref = $${i++}`);
+            params.push(issue_ref);
+            changedFields.push('issue_ref');
+        }
+        if (workflow_registry_id !== undefined) {
+            sets.push(`workflow_registry_id = $${i++}`);
+            params.push(workflow_registry_id);
+            changedFields.push('workflow_registry_id');
+        }
+        if (metadata !== undefined) {
+            sets.push(`metadata = metadata || $${i++}`);
+            params.push(metadata);
+            changedFields.push('metadata');
+        }
+        if (review_policy !== undefined) {
+            sets.push(`review_policy = $${i++}`);
+            params.push(review_policy);
+            changedFields.push('review_policy');
+        }
+
+        if (sets.length === 0) {
+            throw new Error('No fields to update');
+        }
+
+        const result = await this.db.query(
+            `UPDATE fictionlab.kanban_cards SET ${sets.join(', ')} WHERE id = $1 RETURNING *`,
+            params
+        );
+
+        const card = result.rows[0];
+
+        await logActivity(this.db, {
+            boardId: card.board_id,
+            cardId: card.id,
+            actor,
+            action: 'updated',
+            detail: { fields: changedFields }
+        });
+        await notifyKanbanChanged(this.db, card.id);
+
+        return { card };
+    }
+
+    /**
+     * move_card — change status/lane. Writes activity {action:'moved',
+     * from_status, to_status}. Per S11 §11.5 decision 5: a review-required
+     * card moving into 'review' is automatically reassigned to 'rebecca'
+     * (an auto-done card may move straight to 'done' without this).
+     */
+    async handleMoveCard(args) {
+        const { card_id, to_status, actor = 'rebecca', position } = args || {};
+
+        if (!card_id || !to_status) {
+            throw new Error('card_id and to_status are required');
+        }
+        if (!CARD_STATUSES.includes(to_status)) {
+            throw new Error(`Invalid to_status: ${to_status}`);
+        }
+
+        const existing = await this.db.query('SELECT * FROM fictionlab.kanban_cards WHERE id = $1', [card_id]);
+        if (existing.rows.length === 0) {
+            throw new Error(`Card not found: ${card_id}`);
+        }
+        const existingCard = existing.rows[0];
+        const fromStatus = existingCard.status;
+
+        const sets = ['status = $2'];
+        const params = [card_id, to_status];
+        let i = 3;
+
+        if (position !== undefined) {
+            sets.push(`position = $${i++}`);
+            params.push(position);
+        }
+
+        if (to_status === 'review' && existingCard.review_policy === 'review-required') {
+            sets.push(`assignee = $${i++}`);
+            params.push('rebecca');
+        }
+
+        const result = await this.db.query(
+            `UPDATE fictionlab.kanban_cards SET ${sets.join(', ')} WHERE id = $1 RETURNING *`,
+            params
+        );
+        const card = result.rows[0];
+
+        await logActivity(this.db, {
+            boardId: card.board_id,
+            cardId: card.id,
+            actor,
+            action: 'moved',
+            fromStatus,
+            toStatus: to_status,
+            detail: {}
+        });
+        await notifyKanbanChanged(this.db, card.id);
+
+        return { card };
+    }
+
+    /**
+     * get_card (supporting tool) — card + comments + links + activity + live
+     * workflow_phase. The detail-drawer call.
+     */
+    async handleGetCard(args) {
+        const { card_id } = args || {};
+        if (!card_id) {
+            throw new Error('card_id is required');
+        }
+
+        const cardResult = await this.db.query(
+            `SELECT c.*,
+                    aw.current_node_name AS workflow_current_node_name,
+                    aw.progress_percent AS workflow_progress_percent,
+                    aw.status AS workflow_status
+             FROM fictionlab.kanban_cards c
+             LEFT JOIN fictionlab.active_workflows aw ON aw.id = c.workflow_registry_id
+             WHERE c.id = $1`,
+            [card_id]
+        );
+
+        if (cardResult.rows.length === 0) {
+            throw new Error(`Card not found: ${card_id}`);
+        }
+
+        const [comments, links, activity] = await Promise.all([
+            this.db.query('SELECT * FROM fictionlab.kanban_comments WHERE card_id = $1 ORDER BY created_at', [card_id]),
+            this.db.query('SELECT * FROM fictionlab.kanban_card_links WHERE card_id = $1 ORDER BY created_at', [card_id]),
+            this.db.query('SELECT * FROM fictionlab.kanban_activity WHERE card_id = $1 ORDER BY created_at DESC', [card_id])
+        ]);
+
+        return {
+            card: cardResult.rows[0],
+            comments: comments.rows,
+            links: links.rows,
+            activity: activity.rows
+        };
+    }
+
+    /**
+     * add_card_link (supporting tool) — attach a typed link to a card.
+     */
+    async handleAddCardLink(args) {
+        const { card_id, link_type, ref, label } = args || {};
+        if (!card_id || !link_type || !ref) {
+            throw new Error('card_id, link_type, and ref are required');
+        }
+
+        const cardResult = await this.db.query('SELECT board_id FROM fictionlab.kanban_cards WHERE id = $1', [card_id]);
+        if (cardResult.rows.length === 0) {
+            throw new Error(`Card not found: ${card_id}`);
+        }
+
+        const result = await this.db.query(
+            `INSERT INTO fictionlab.kanban_card_links (card_id, link_type, ref, label)
+             VALUES ($1, $2, $3, $4)
+             RETURNING *`,
+            [card_id, link_type, ref, label || null]
+        );
+        const link = result.rows[0];
+
+        await logActivity(this.db, {
+            boardId: cardResult.rows[0].board_id,
+            cardId: card_id,
+            actor: 'rebecca',
+            action: 'linked',
+            detail: { link_type, ref }
+        });
+        await notifyKanbanChanged(this.db, card_id);
+
+        return { link };
+    }
+
+    /**
+     * archive_card (supporting tool) = move_card to 'archived'.
+     */
+    async handleArchiveCard(args) {
+        const { card_id, actor = 'rebecca' } = args || {};
+        if (!card_id) {
+            throw new Error('card_id is required');
+        }
+        return this.handleMoveCard({ card_id, to_status: 'archived', actor });
+    }
+}

--- a/src/mcps/kanban-server/handlers/claim-handlers.js
+++ b/src/mcps/kanban-server/handlers/claim-handlers.js
@@ -1,0 +1,111 @@
+// src/mcps/kanban-server/handlers/claim-handlers.js
+// claim_card — the atomic compare-and-swap. This is the entire correctness
+// mechanism for "two agents can never both win a card": a single conditional
+// UPDATE ... RETURNING relies on Postgres row locking to guarantee exactly
+// one concurrent caller matches. No transaction/advisory-lock gymnastics
+// needed (S11 issue #58 §2c / spec §4c).
+
+import { logActivity, notifyKanbanChanged } from './kanban-helpers.js';
+
+export class ClaimHandlers {
+    constructor(db) {
+        this.db = db;
+    }
+
+    async handleClaimCard(args) {
+        const { card_id, agent, expected_status = 'ready', move_to = 'claimed' } = args || {};
+
+        if (!card_id) {
+            throw new Error('card_id is required');
+        }
+        if (!agent) {
+            throw new Error('agent is required');
+        }
+        if (agent === 'rebecca') {
+            throw new Error("agent must not be 'rebecca' — claim_card is for agent identities only (session-scoped claude-code:<sessionLabel> or a .kcpps config id)");
+        }
+        if (!['claimed', 'in_progress'].includes(move_to)) {
+            throw new Error(`Invalid move_to: ${move_to}`);
+        }
+
+        // The atomic compare-and-swap. Every predicate in the WHERE clause is
+        // independent defense-in-depth against the same failure mode (an
+        // agent ending up with a card that belongs to Rebecca):
+        //   - status = expected_status         -> still in the pool the caller thinks it's in
+        //   - agent_claimable = TRUE           -> not reserved (kept true by the DB trigger)
+        //   - assignee IS DISTINCT FROM 'rebecca' -> human cards NEVER agent-claimable
+        //   - assignee IS NULL OR assignee = agent -> unassigned pool, or already this agent's
+        const result = await this.db.query(
+            `UPDATE fictionlab.kanban_cards
+                SET status     = $2,
+                    assignee   = $3,
+                    claimed_by = $3,
+                    claimed_at = NOW()
+              WHERE id = $1
+                AND status = $4
+                AND agent_claimable = TRUE
+                AND assignee IS DISTINCT FROM 'rebecca'
+                AND (assignee IS NULL OR assignee = $3)
+              RETURNING *`,
+            [card_id, move_to, agent, expected_status]
+        );
+
+        if (result.rows.length > 0) {
+            const card = result.rows[0];
+
+            await logActivity(this.db, {
+                boardId: card.board_id,
+                cardId: card.id,
+                actor: agent,
+                action: 'claimed',
+                fromStatus: expected_status,
+                toStatus: move_to,
+                detail: { agent }
+            });
+            await notifyKanbanChanged(this.db, card.id);
+
+            return { claimed: true, card };
+        }
+
+        // 0 rows returned -> the claim lost (or the card/agent combo was never
+        // eligible). Inspect the current row to return the precise reason.
+        const current = await this.db.query('SELECT * FROM fictionlab.kanban_cards WHERE id = $1', [card_id]);
+
+        if (current.rows.length === 0) {
+            return { claimed: false, reason: 'not_found' };
+        }
+
+        const card = current.rows[0];
+        const reason = this.inferDenyReason(card, { agent, expectedStatus: expected_status });
+
+        await logActivity(this.db, {
+            boardId: card.board_id,
+            cardId: card.id,
+            actor: agent,
+            action: 'claim_denied',
+            detail: { reason, agent, expected_status }
+        });
+
+        return { claimed: false, reason };
+    }
+
+    inferDenyReason(card, { agent, expectedStatus }) {
+        if (card.assignee === 'rebecca' || !card.agent_claimable) {
+            return 'reserved_for_human';
+        }
+
+        if (card.status !== expectedStatus) {
+            // Status moved away from what the caller expected. If it looks like
+            // it was actually claimed (claimed_by/assignee set), that's a lost
+            // race; otherwise the card was simply never in the right lane to
+            // begin with.
+            return card.claimed_by || card.assignee ? 'already_claimed' : 'wrong_status';
+        }
+
+        if (card.assignee && card.assignee !== agent) {
+            return 'already_claimed';
+        }
+
+        return 'wrong_status';
+    }
+}

--- a/src/mcps/kanban-server/handlers/comment-handlers.js
+++ b/src/mcps/kanban-server/handlers/comment-handlers.js
@@ -1,0 +1,43 @@
+// src/mcps/kanban-server/handlers/comment-handlers.js
+// comment_card — append to a card's comment thread. Agents report progress
+// here (results, links, questions for a blocked card).
+
+import { logActivity, notifyKanbanChanged } from './kanban-helpers.js';
+
+export class CommentHandlers {
+    constructor(db) {
+        this.db = db;
+    }
+
+    async handleCommentCard(args) {
+        const { card_id, author, body } = args || {};
+
+        if (!card_id || !author || !body) {
+            throw new Error('card_id, author, and body are required');
+        }
+
+        const cardResult = await this.db.query('SELECT board_id FROM fictionlab.kanban_cards WHERE id = $1', [card_id]);
+        if (cardResult.rows.length === 0) {
+            throw new Error(`Card not found: ${card_id}`);
+        }
+
+        const result = await this.db.query(
+            `INSERT INTO fictionlab.kanban_comments (card_id, author, body)
+             VALUES ($1, $2, $3)
+             RETURNING *`,
+            [card_id, author, body]
+        );
+        const comment = result.rows[0];
+
+        await logActivity(this.db, {
+            boardId: cardResult.rows[0].board_id,
+            cardId: card_id,
+            actor: author,
+            action: 'commented',
+            detail: {}
+        });
+        await notifyKanbanChanged(this.db, card_id);
+
+        return { comment };
+    }
+}

--- a/src/mcps/kanban-server/handlers/kanban-helpers.js
+++ b/src/mcps/kanban-server/handlers/kanban-helpers.js
@@ -1,0 +1,118 @@
+// src/mcps/kanban-server/handlers/kanban-helpers.js
+// Small shared utilities used by all four kanban handler classes
+// (board/card/claim/comment-handlers). Kept together so the activity-log +
+// NOTIFY side effects can never drift out of sync between mutation tools.
+
+/**
+ * Resolve a board_id from either an explicit board_id, a board_key, or (for
+ * the create_card quick-add fast path) a default board_key. Throws if the
+ * board can't be found.
+ */
+export async function resolveBoardId(db, { board_id, board_key, defaultBoardKey } = {}) {
+    if (board_id) {
+        return board_id;
+    }
+
+    const key = board_key || defaultBoardKey;
+    if (!key) {
+        throw new Error('board_key or board_id is required');
+    }
+
+    const result = await db.query(
+        'SELECT id FROM fictionlab.kanban_boards WHERE board_key = $1',
+        [key]
+    );
+
+    if (result.rows.length === 0) {
+        throw new Error(`Board not found: ${key}`);
+    }
+
+    return result.rows[0].id;
+}
+
+/**
+ * Append a row to the append-only kanban_activity log. Every mutation tool
+ * calls this exactly once (claim_card writes an extra claim_denied row on a
+ * lost race, on top of its own claimed row when it wins).
+ */
+export async function logActivity(db, { boardId, cardId, actor, action, fromStatus, toStatus, detail }) {
+    await db.query(
+        `INSERT INTO fictionlab.kanban_activity
+            (board_id, card_id, actor, action, from_status, to_status, detail)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+            boardId || null,
+            cardId || null,
+            actor || 'unknown',
+            action,
+            fromStatus || null,
+            toStatus || null,
+            detail ? JSON.stringify(detail) : '{}'
+        ]
+    );
+}
+
+/**
+ * Emit NOTIFY kanban_changed, '<card_id>' on the shared pool connection so a
+ * LISTENer (the Electron plugin, per S11 decision 3) can push instant board
+ * updates instead of polling. Uses pg_notify() rather than a literal NOTIFY
+ * statement because pg_notify() accepts bound parameters — a plain
+ * `NOTIFY channel, 'payload'` cannot be parameterized.
+ */
+export async function notifyKanbanChanged(db, cardId) {
+    await db.query('SELECT pg_notify($1, $2)', ['kanban_changed', String(cardId)]);
+}
+
+/**
+ * S11 §11.5 (decision 5): default review_policy by risk class at create_card
+ * time. This can't be a DB column default because it needs to inspect the
+ * card's content (labels / spec_ref / issue_ref / title / body) — anything
+ * that looks like it touches live workflow definitions, DB migrations, the
+ * executor / run-workflow skill, or shared skills/configs defaults to
+ * 'review-required'; docs/specs/reports/analysis-only cards default to
+ * 'auto-done'. When ambiguous, default to the SAFE side ('review-required') —
+ * agents may escalate a card to review-required but must never downgrade it
+ * themselves, so an over-cautious default is the correct failure mode.
+ */
+export function inferReviewPolicy({ labels = [], spec_ref, issue_ref, title, body } = {}) {
+    const haystack = [
+        ...(Array.isArray(labels) ? labels : []),
+        spec_ref || '',
+        issue_ref || '',
+        title || '',
+        body || ''
+    ].join(' ').toLowerCase();
+
+    const highRiskPatterns = [
+        /migrations?[\\/]/,
+        /\bmigration\b/,
+        /workflow[-_ ]?definitions?/,
+        /workflow-manager/,
+        /run-?workflow/,
+        /\bexecutor\b/,
+        /\bskills?[\\/]/,
+        /shared[\\/]?configs?/,
+        /\.kcpps/,
+        /\bkanban-server\b/
+    ];
+
+    if (highRiskPatterns.some((re) => re.test(haystack))) {
+        return 'review-required';
+    }
+
+    const lowRiskPatterns = [
+        /\bdocs?[\\/]/,
+        /\bspecs?[\\/]/,
+        /\breports?[\\/]/,
+        /analysis[-_ ]?only/,
+        /docs?[-_ ]?only/,
+        /\breadme\b/
+    ];
+
+    if (lowRiskPatterns.some((re) => re.test(haystack))) {
+        return 'auto-done';
+    }
+
+    // Ambiguous / no signal at all -> safe default.
+    return 'review-required';
+}

--- a/src/mcps/kanban-server/index.js
+++ b/src/mcps/kanban-server/index.js
@@ -1,0 +1,140 @@
+// src/mcps/kanban-server/index.js
+// Kanban MCP Server (S11 kanban board plugin, GH issue #58)
+// A NEW, standalone server (not bolted onto workflow-manager-server) so the
+// atomic claim stays in exactly one place and card tools stay off every
+// writing node's token budget (only clients that declare the `kanban`
+// server load them). Port 3015 (next free after S9's 3014 reservation).
+
+// Protect stdout from debug logging in MCP stdio mode
+if (process.env.MCP_STDIO_MODE === 'true') {
+    console.error = function () {
+        process.stderr.write(Array.from(arguments).join(' ') + '\n');
+    };
+}
+
+import { BaseMCPServer } from '../../shared/base-server.js';
+import { BoardHandlers } from './handlers/board-handlers.js';
+import { CardHandlers } from './handlers/card-handlers.js';
+import { ClaimHandlers } from './handlers/claim-handlers.js';
+import { CommentHandlers } from './handlers/comment-handlers.js';
+import { kanbanToolsSchema } from './schemas/kanban-tools-schema.js';
+
+class KanbanMCPServer extends BaseMCPServer {
+    constructor() {
+        console.error('[KANBAN] Constructor starting...');
+        try {
+            super('kanban', '1.0.0');
+            console.error('[KANBAN] Constructor completed successfully');
+        } catch (error) {
+            console.error('[KANBAN] Constructor failed:', error.message);
+            console.error('[KANBAN] Stack:', error.stack);
+            throw error;
+        }
+
+        // All handlers share the ONE database pool (BaseMCPServer's shared
+        // 20-conn pool via getSharedDatabasePool()) — no per-request pools.
+        this.boardHandlers = new BoardHandlers(this.db);
+        this.cardHandlers = new CardHandlers(this.db);
+        this.claimHandlers = new ClaimHandlers(this.db);
+        this.commentHandlers = new CommentHandlers(this.db);
+
+        this.tools = this.getTools();
+
+        if (process.env.MCP_STDIO_MODE !== 'true') {
+            console.error(`[KANBAN] Initialized with ${this.tools.length} tools`);
+        }
+
+        this.testDatabaseConnection();
+    }
+
+    async testDatabaseConnection() {
+        try {
+            if (this.db) {
+                const healthPromise = this.db.healthCheck();
+                const timeoutPromise = new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('Database health check timed out')), 5000)
+                );
+
+                const health = await Promise.race([healthPromise, timeoutPromise]);
+                if (health.healthy) {
+                    console.error('[KANBAN] Database connection verified');
+                } else {
+                    console.error('[KANBAN] Database health check failed:', health.error);
+                }
+            }
+        } catch (error) {
+            console.error('[KANBAN] Database connection test failed:', error.message);
+        }
+    }
+
+    getTools() {
+        return [...kanbanToolsSchema];
+    }
+
+    getToolHandler(toolName) {
+        const handlers = {
+            // Board handlers (2 tools)
+            'get_board': this.boardHandlers.handleGetBoard.bind(this.boardHandlers),
+            'list_boards': this.boardHandlers.handleListBoards.bind(this.boardHandlers),
+            // Card handlers (7 tools)
+            'list_cards': this.cardHandlers.handleListCards.bind(this.cardHandlers),
+            'create_card': this.cardHandlers.handleCreateCard.bind(this.cardHandlers),
+            'update_card': this.cardHandlers.handleUpdateCard.bind(this.cardHandlers),
+            'move_card': this.cardHandlers.handleMoveCard.bind(this.cardHandlers),
+            'get_card': this.cardHandlers.handleGetCard.bind(this.cardHandlers),
+            'add_card_link': this.cardHandlers.handleAddCardLink.bind(this.cardHandlers),
+            'archive_card': this.cardHandlers.handleArchiveCard.bind(this.cardHandlers),
+            // Claim handler (1 tool — the atomic compare-and-swap)
+            'claim_card': this.claimHandlers.handleClaimCard.bind(this.claimHandlers),
+            // Comment handler (1 tool)
+            'comment_card': this.commentHandlers.handleCommentCard.bind(this.commentHandlers)
+        };
+        return handlers[toolName];
+    }
+}
+
+export { KanbanMCPServer };
+
+// CLI runner when called directly
+const normalizePath = (path) => {
+    if (!path) return '';
+    let normalizedPath = path.replace(/\\/g, '/');
+    if (!normalizedPath.startsWith('file:')) {
+        if (process.platform === 'win32') {
+            normalizedPath = `file:///${normalizedPath}`;
+        } else {
+            normalizedPath = `file://${normalizedPath}`;
+        }
+    }
+    normalizedPath = normalizedPath.replace(/^file:\/+/, 'file:///');
+    return normalizedPath;
+};
+
+const normalizedScriptPath = normalizePath(process.argv[1]);
+const normalizedCurrentModuleUrl = import.meta.url.replace(/\/{3,}/g, '///')
+    .replace(/^file:\/([^\/])/, 'file:///$1');
+
+const isDirectExecution = normalizedCurrentModuleUrl === normalizedScriptPath ||
+    decodeURIComponent(normalizedCurrentModuleUrl) === normalizedScriptPath;
+
+if (process.env.MCP_STDIO_MODE) {
+    console.error('[KANBAN] Running in MCP stdio mode - starting server...');
+    try {
+        const server = new KanbanMCPServer();
+        await server.run();
+    } catch (error) {
+        console.error('[KANBAN] Failed to start MCP server:', error.message);
+        console.error('[KANBAN] Stack:', error.stack);
+        process.exit(1);
+    }
+} else if (isDirectExecution) {
+    console.error('[KANBAN] Starting CLI runner...');
+    try {
+        const { CLIRunner } = await import('../../shared/cli-runner.js');
+        const runner = new CLIRunner(KanbanMCPServer);
+        await runner.run();
+    } catch (error) {
+        console.error('[KANBAN] CLI runner failed:', error.message);
+        throw error;
+    }
+}

--- a/src/mcps/kanban-server/schemas/kanban-tools-schema.js
+++ b/src/mcps/kanban-server/schemas/kanban-tools-schema.js
@@ -1,0 +1,214 @@
+// src/mcps/kanban-server/schemas/kanban-tools-schema.js
+// Tool schemas for the kanban-server MCP (S11 kanban board plugin, GH issue #58).
+// Shape matches schemas/active-workflow-tools-schema.js:
+// { name, description, inputSchema: { type:'object', properties, required } }.
+// All tools return { ok:true, ... } or { ok:false, error } via BaseMCPServer's
+// formatSuccess/formatError wrapping; every mutation also writes a
+// kanban_activity row (see handlers/kanban-helpers.js logActivity).
+
+const CARD_STATUS_ENUM = ['backlog', 'ready', 'claimed', 'in_progress', 'review', 'blocked', 'done', 'archived'];
+const PRIORITY_ENUM = ['low', 'normal', 'high', 'urgent'];
+
+export const kanbanToolsSchema = [
+    // ---- 7 required tools ----
+    {
+        name: 'get_board',
+        description: 'Gets a board plus its columns (ordered lanes) with per-column card counts — the board-render call.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                board_key: { type: 'string', description: 'Board slug, e.g. dev-backlog' },
+                board_id: { type: 'string', description: 'Board UUID (alternative to board_key)' }
+            }
+        }
+    },
+    {
+        name: 'list_cards',
+        description: 'Lists cards with filters: board, assignee, agent, status, label, priority, agent_claimable_only, include_archived, include_workflow_phase. The workhorse read tool.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                board_key: { type: 'string' },
+                board_id: { type: 'string' },
+                assignee: {
+                    type: 'string',
+                    description: "Exact match. Special: 'rebecca' (her queue); '__unassigned__' (assignee IS NULL)"
+                },
+                agent: {
+                    type: 'string',
+                    description: 'When set, returns cards claimable-by-or-assigned-to this agent id'
+                },
+                status: { type: 'string', enum: CARD_STATUS_ENUM },
+                label: { type: 'string', description: 'Single label the card must carry' },
+                priority: { type: 'string', enum: PRIORITY_ENUM },
+                agent_claimable_only: {
+                    type: 'boolean',
+                    default: false,
+                    description: "Only cards agents may claim (agent_claimable=TRUE AND assignee<>'rebecca')"
+                },
+                include_archived: { type: 'boolean', default: false },
+                include_workflow_phase: {
+                    type: 'boolean',
+                    default: false,
+                    description: 'Join live phase for cards with workflow_registry_id'
+                },
+                limit: { type: 'integer', default: 200 }
+            }
+        }
+    },
+    {
+        name: 'create_card',
+        description: "Creates a card — full or quick-add (title-only is valid, the fast path). Board resolves to 'dev-backlog' if neither board_key nor board_id given. review_policy is defaulted by risk class unless explicitly provided.",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                board_key: { type: 'string' },
+                board_id: { type: 'string' },
+                title: { type: 'string' },
+                body: { type: 'string' },
+                status: { type: 'string', enum: CARD_STATUS_ENUM, default: 'ready' },
+                assignee: { type: 'string' },
+                priority: { type: 'string', enum: PRIORITY_ENUM, default: 'normal' },
+                labels: { type: 'array', items: { type: 'string' } },
+                spec_ref: { type: 'string' },
+                issue_ref: { type: 'string' },
+                created_by: { type: 'string', default: 'rebecca' },
+                review_policy: {
+                    type: 'string',
+                    enum: ['auto-done', 'review-required'],
+                    description: 'Optional override for callers that already know the risk class; otherwise defaulted from title/body/labels/refs.'
+                }
+            },
+            required: ['title']
+        }
+    },
+    {
+        name: 'claim_card',
+        description: "ATOMIC compare-and-swap claim. Two agents can NEVER both win the same card. NEVER pass agent:'rebecca' — her cards are permanently reserved.",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                card_id: { type: 'string' },
+                agent: {
+                    type: 'string',
+                    description: "Claiming agent identity, e.g. 'claude-code:<sessionLabel>' or a .kcpps config id like 'local-qwen3-14b'. NEVER 'rebecca'."
+                },
+                expected_status: {
+                    type: 'string',
+                    default: 'ready',
+                    description: 'Only claim if the card is still in this status (default: the ready pool)'
+                },
+                move_to: {
+                    type: 'string',
+                    default: 'claimed',
+                    enum: ['claimed', 'in_progress'],
+                    description: 'Status to set on a winning claim'
+                }
+            },
+            required: ['card_id', 'agent']
+        }
+    },
+    {
+        name: 'update_card',
+        description: "Partial patch of a card — only provided keys change. assignee:'rebecca' auto-clears agent_claimable (DB trigger); assignee:'__clear__' unassigns.",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                card_id: { type: 'string' },
+                actor: { type: 'string', description: 'Who is editing (for the activity log)' },
+                title: { type: 'string' },
+                body: { type: 'string' },
+                assignee: { type: 'string' },
+                priority: { type: 'string', enum: PRIORITY_ENUM },
+                labels: { type: 'array', items: { type: 'string' } },
+                spec_ref: { type: 'string' },
+                issue_ref: { type: 'string' },
+                workflow_registry_id: {
+                    type: 'string',
+                    description: 'Link this card to a live workflow run (active_workflows.id)'
+                },
+                metadata: { type: 'object' },
+                review_policy: {
+                    type: 'string',
+                    enum: ['auto-done', 'review-required'],
+                    description: "Escalate-only: 'auto-done' -> 'review-required' is always allowed; the reverse throws (agents may escalate a card, never downgrade it themselves)."
+                }
+            },
+            required: ['card_id']
+        }
+    },
+    {
+        name: 'move_card',
+        description: "Changes a card's status/lane. Writes activity {action:'moved', from_status, to_status}. A review-required card moving to 'review' is auto-reassigned to 'rebecca'.",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                card_id: { type: 'string' },
+                to_status: { type: 'string', enum: CARD_STATUS_ENUM },
+                actor: { type: 'string' },
+                position: { type: 'integer', description: 'Optional new order within the target lane' }
+            },
+            required: ['card_id', 'to_status']
+        }
+    },
+    {
+        name: 'comment_card',
+        description: 'Appends to a card comment thread. Agents report progress/results here before moving a card to review.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                card_id: { type: 'string' },
+                author: { type: 'string' },
+                body: { type: 'string' }
+            },
+            required: ['card_id', 'author', 'body']
+        }
+    },
+
+    // ---- 4 supporting tools ----
+    {
+        name: 'list_boards',
+        description: 'Lists all boards with their total card counts.',
+        inputSchema: {
+            type: 'object',
+            properties: {}
+        }
+    },
+    {
+        name: 'get_card',
+        description: 'Gets a single card plus its comments, links, activity log, and live workflow_phase if linked — the detail-drawer call.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                card_id: { type: 'string' }
+            },
+            required: ['card_id']
+        }
+    },
+    {
+        name: 'add_card_link',
+        description: 'Attaches a typed link (spec/github_issue/workflow_run/file/url/card) to a card, beyond the inline spec_ref/issue_ref fields.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                card_id: { type: 'string' },
+                link_type: { type: 'string', enum: ['spec', 'github_issue', 'workflow_run', 'file', 'url', 'card'] },
+                ref: { type: 'string' },
+                label: { type: 'string' }
+            },
+            required: ['card_id', 'link_type', 'ref']
+        }
+    },
+    {
+        name: 'archive_card',
+        description: "Archives a card (= move_card to 'archived').",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                card_id: { type: 'string' },
+                actor: { type: 'string' }
+            },
+            required: ['card_id']
+        }
+    }
+];

--- a/src/mcps/kanban-server/stdio-adapter.js
+++ b/src/mcps/kanban-server/stdio-adapter.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// stdio-adapter.js
+// Adapter to run the Kanban MCP Server in stdio mode for Claude Code
+// integration. Copied from workflow-manager-server/stdio-adapter.js
+// (class name swapped) — required, not optional: S11 decision 6 means
+// Claude Code sessions are the ones driving local-model card work, and the
+// proven low-latency path for that is stdio (mirrors
+// MCP-Electron-App/src/main/plugin-context.ts's special-cased stdio branch
+// for workflow-manager).
+
+// Set stdio mode environment variable BEFORE importing server
+process.env.MCP_STDIO_MODE = 'true';
+
+// Redirect console.log to stderr to protect stdout
+const originalConsoleLog = console.log;
+console.log = function (...args) {
+    process.stderr.write('[STDIO-ADAPTER] ' + args.join(' ') + '\n');
+};
+
+// Import the server
+import { KanbanMCPServer } from './index.js';
+
+async function main() {
+    try {
+        console.error('[STDIO-ADAPTER] Starting Kanban MCP in stdio mode...');
+
+        // Create server instance
+        const server = new KanbanMCPServer();
+
+        // Connect to stdio transport
+        const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+        const transport = new StdioServerTransport();
+
+        console.error('[STDIO-ADAPTER] Connecting to stdio transport...');
+        await server.server.connect(transport);
+
+        console.error('[STDIO-ADAPTER] Kanban MCP ready on stdio');
+        console.error('[STDIO-ADAPTER] Available tools:', server.tools.length);
+
+        // Handle graceful shutdown
+        process.on('SIGINT', async () => {
+            console.error('[STDIO-ADAPTER] Received SIGINT, shutting down...');
+            await server.server.close();
+            process.exit(0);
+        });
+
+        process.on('SIGTERM', async () => {
+            console.error('[STDIO-ADAPTER] Received SIGTERM, shutting down...');
+            await server.server.close();
+            process.exit(0);
+        });
+
+    } catch (error) {
+        console.error('[STDIO-ADAPTER] Fatal error:', error.message);
+        console.error('[STDIO-ADAPTER] Stack:', error.stack);
+        process.exit(1);
+    }
+}
+
+main();

--- a/src/shared/run-migration.js
+++ b/src/shared/run-migration.js
@@ -60,9 +60,17 @@ export async function runMigration(migrationPath) {
                 `);
             }
             
-            // Record this migration
+            // Record this migration. Idempotent (ON CONFLICT DO NOTHING) because
+            // every migration file since 025 already self-records via its own
+            // guarded `INSERT INTO migrations (filename) ... ON CONFLICT DO NOTHING`
+            // inside the DO block above (see migrations/README.md convention) —
+            // without ON CONFLICT here, this unconditional insert throws
+            // "duplicate key value violates unique constraint migrations_filename_key"
+            // on every single migration that follows that convention (i.e. all of
+            // them), rolling back the whole transaction. Fixed 2026-07-06 while
+            // applying 042_kanban_tables.sql (GH issue #58).
             await client.query(
-                'INSERT INTO migrations (filename) VALUES ($1)',
+                'INSERT INTO migrations (filename) VALUES ($1) ON CONFLICT (filename) DO NOTHING',
                 [path.basename(migrationPath)]
             );
         });

--- a/src/single-server-runner.js
+++ b/src/single-server-runner.js
@@ -35,7 +35,8 @@ const serverConfigs = {
     'outline': { path: './config-mcps/outline-server/index.js', className: 'OutlinePhaseMCPServer' },
     'author': { path: './mcps/author-server/index.js', className: 'AuthorMCPServer' },
     'database-admin': { path: './mcps/database-admin-server/index.js', className: 'DatabaseAdminMCPServer' },
-    'workflow-manager': { path: './mcps/workflow-manager-server/index.js', className: 'WorkflowManagerMCPServer' }
+    'workflow-manager': { path: './mcps/workflow-manager-server/index.js', className: 'WorkflowManagerMCPServer' },
+    'kanban': { path: './mcps/kanban-server/index.js', className: 'KanbanMCPServer' }
 };
 
 // Active SSE transports Map

--- a/test/kanban-server/concurrent-claim-test.js
+++ b/test/kanban-server/concurrent-claim-test.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// test/kanban-server/concurrent-claim-test.js
+// The load-bearing test (S11 / GH issue #58 acceptance criterion 5): fires
+// two claim_card calls in parallel at the SAME ready/unassigned card and
+// asserts exactly one wins. Exercises the real ClaimHandlers class (the
+// production code, not a re-implementation) directly against the shared
+// DatabaseManager pool, so two truly concurrent connections race the atomic
+// `UPDATE ... WHERE status='ready' AND ... RETURNING` against Postgres's own
+// row-level locking -- no test-side locking of any kind. Repeats 20x per the
+// issue's acceptance criterion to shake out races.
+//
+// Uses its own ephemeral board (never dev-backlog); deletes it at the end
+// (ON DELETE CASCADE takes every card/activity row with it).
+//
+// Run: node test/kanban-server/concurrent-claim-test.js
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+import { DatabaseManager } from '../../src/shared/database.js';
+import { ClaimHandlers } from '../../src/mcps/kanban-server/handlers/claim-handlers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '../../.env') });
+
+const ITERATIONS = 20;
+
+async function main() {
+    const db = new DatabaseManager();
+    const claimHandlers = new ClaimHandlers(db);
+
+    const boardResult = await db.query(
+        `INSERT INTO fictionlab.kanban_boards (board_key, name, description)
+         VALUES ($1, 'Concurrent Claim Test', 'Ephemeral board created by test/kanban-server/concurrent-claim-test.js')
+         RETURNING id`,
+        [`kanban-claim-race-test-${Date.now()}`]
+    );
+    const testBoardId = boardResult.rows[0].id;
+
+    let wins = 0;
+    let denials = 0;
+    let failures = [];
+
+    for (let iteration = 1; iteration <= ITERATIONS; iteration++) {
+        const cardResult = await db.query(
+            `INSERT INTO fictionlab.kanban_cards (board_id, title, status, assignee, agent_claimable, created_by)
+             VALUES ($1, $2, 'ready', NULL, TRUE, 'rebecca')
+             RETURNING id`,
+            [testBoardId, `Race card #${iteration}`]
+        );
+        const cardId = cardResult.rows[0].id;
+
+        const agentA = `claude-code:race-a-${iteration}`;
+        const agentB = `local-qwen3-14b:race-b-${iteration}`;
+
+        // Fire both claims truly in parallel -- Promise.all schedules both
+        // before either resolves, and DatabaseManager.query() checks out a
+        // separate pool connection per call, so both UPDATEs can genuinely
+        // race at the Postgres engine level.
+        const [resultA, resultB] = await Promise.all([
+            claimHandlers.handleClaimCard({ card_id: cardId, agent: agentA }),
+            claimHandlers.handleClaimCard({ card_id: cardId, agent: agentB })
+        ]);
+
+        const claimedResults = [resultA, resultB].filter((r) => r.claimed);
+        const deniedResults = [resultA, resultB].filter((r) => !r.claimed);
+
+        const iterationOk =
+            claimedResults.length === 1 &&
+            deniedResults.length === 1 &&
+            deniedResults[0].reason === 'already_claimed';
+
+        if (claimedResults.length === 1) wins++;
+        if (deniedResults.length === 1 && deniedResults[0].reason === 'already_claimed') denials++;
+
+        if (!iterationOk) {
+            failures.push({ iteration, resultA, resultB });
+        } else {
+            const winnerAgent = claimedResults[0].card.assignee;
+            const finalCard = await db.query('SELECT claimed_by, assignee, status FROM fictionlab.kanban_cards WHERE id = $1', [cardId]);
+            const activityRows = await db.query(
+                `SELECT action, COUNT(*) AS count FROM fictionlab.kanban_activity WHERE card_id = $1 GROUP BY action`,
+                [cardId]
+            );
+            const claimedCount = activityRows.rows.find((r) => r.action === 'claimed')?.count || 0;
+            const deniedCount = activityRows.rows.find((r) => r.action === 'claim_denied')?.count || 0;
+
+            if (finalCard.rows[0].claimed_by !== winnerAgent) {
+                failures.push({ iteration, reason: 'claimed_by mismatch', finalCard: finalCard.rows[0], winnerAgent });
+            } else if (parseInt(claimedCount, 10) !== 1 || parseInt(deniedCount, 10) !== 1) {
+                failures.push({ iteration, reason: 'activity row count mismatch', claimedCount, deniedCount });
+            } else {
+                console.log(`  iteration ${iteration}: OK (winner=${winnerAgent})`);
+            }
+        }
+    }
+
+    // Cascade-delete the ephemeral test board (cards + activity go with it).
+    await db.query('DELETE FROM fictionlab.kanban_boards WHERE id = $1', [testBoardId]);
+    await db.close();
+
+    console.log(`\n${ITERATIONS} iterations: ${wins} exactly-one-winner, ${denials} exactly-one-already_claimed-denial.`);
+
+    if (failures.length > 0) {
+        console.log(`\n${failures.length} FAILURE(S):`);
+        for (const f of failures) {
+            console.log(JSON.stringify(f, null, 2));
+        }
+        process.exit(1);
+    }
+
+    console.log('All 20 iterations: exactly one winner, one denial, one claimed_by match, one claimed + one claim_denied activity row.');
+    process.exit(0);
+}
+
+main().catch((error) => {
+    console.error('Concurrent claim test crashed:', error);
+    process.exit(1);
+});

--- a/test/kanban-server/smoke-test.js
+++ b/test/kanban-server/smoke-test.js
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+// test/kanban-server/smoke-test.js
+// Exercises every kanban-server tool once against the LIVE database, over the
+// real stdio transport (the same path Claude Code / agents use per S11
+// decision 6). Creates its own throwaway test board (never touches the real
+// dev-backlog board), then deletes that board at the end — ON DELETE CASCADE
+// takes its columns/cards/comments/links/activity rows with it, so this test
+// leaves nothing behind.
+//
+// Run: node test/kanban-server/smoke-test.js
+// Requires: DATABASE_URL in .env (see src/shared/database.js), the
+// 042_kanban_tables.sql migration already applied.
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import pg from 'pg';
+import dotenv from 'dotenv';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+dotenv.config({ path: path.join(repoRoot, '.env') });
+
+const { Pool } = pg;
+
+let passCount = 0;
+let failCount = 0;
+
+function check(label, condition, detail) {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        passCount++;
+    } else {
+        console.log(`  FAIL  ${label}${detail ? ' -- ' + detail : ''}`);
+        failCount++;
+    }
+}
+
+async function callTool(client, name, args) {
+    const result = await client.callTool({ name, arguments: args || {} });
+    if (result.isError) {
+        throw new Error(`Tool ${name} returned an error: ${result.content?.[0]?.text}`);
+    }
+    const text = result.content?.[0]?.text;
+    return text ? JSON.parse(text) : undefined;
+}
+
+async function main() {
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+    // Safety-net pre-clean: the quick-add sub-test below lands a card on the
+    // REAL dev-backlog board (that's the point of the test — no board given
+    // -> resolves to dev-backlog). If a prior run of this script was
+    // interrupted before its own cleanup ran, sweep any stragglers by title
+    // pattern before we start, so dev-backlog never accumulates test junk.
+    await pool.query(`DELETE FROM fictionlab.kanban_cards WHERE title LIKE 'Quick-add smoke test %'`);
+
+    // --- Test scaffolding: an ephemeral board, never the real dev-backlog ---
+    const testBoardKey = `kanban-smoke-test-${Date.now()}`;
+    const boardResult = await pool.query(
+        `INSERT INTO fictionlab.kanban_boards (board_key, name, description)
+         VALUES ($1, 'Kanban Smoke Test', 'Ephemeral board created by test/kanban-server/smoke-test.js')
+         RETURNING id`,
+        [testBoardKey]
+    );
+    const testBoardId = boardResult.rows[0].id;
+
+    await pool.query(
+        `INSERT INTO fictionlab.kanban_columns (board_id, status_key, name, position, is_agent_pickup)
+         VALUES
+            ($1, 'backlog', 'Backlog', 0, FALSE),
+            ($1, 'ready', 'Ready to work', 1, TRUE),
+            ($1, 'in_progress', 'In progress', 2, FALSE),
+            ($1, 'review', 'In review', 3, FALSE),
+            ($1, 'blocked', 'Blocked', 4, FALSE),
+            ($1, 'done', 'Done', 5, FALSE),
+            ($1, 'archived', 'Archived', 6, FALSE),
+            ($1, 'claimed', 'Claimed', 7, FALSE)`,
+        [testBoardId]
+    );
+
+    console.log(`Created ephemeral test board ${testBoardKey} (${testBoardId})`);
+
+    const devBacklogResult = await pool.query(
+        `SELECT id FROM fictionlab.kanban_boards WHERE board_key = 'dev-backlog'`
+    );
+    const devBacklogId = devBacklogResult.rows[0]?.id;
+
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: [path.join(repoRoot, 'src/mcps/kanban-server/stdio-adapter.js')],
+        cwd: repoRoot,
+        env: { ...process.env, MCP_STDIO_MODE: 'true' }
+    });
+
+    const client = new Client({ name: 'kanban-smoke-test', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+    console.log('Connected to kanban-server over stdio.\n');
+
+    try {
+        // 1. list_boards
+        const boardsRes = await callTool(client, 'list_boards', {});
+        check('list_boards returns our test board', boardsRes.boards.some((b) => b.id === testBoardId));
+
+        // 2. get_board
+        const getBoardRes = await callTool(client, 'get_board', { board_id: testBoardId });
+        check('get_board returns 8 columns', getBoardRes.columns.length === 8, `got ${getBoardRes.columns.length}`);
+        check(
+            'get_board ready column is_agent_pickup=true',
+            getBoardRes.columns.find((c) => c.status_key === 'ready')?.is_agent_pickup === true
+        );
+
+        // 3. create_card (full form)
+        const createRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'Smoke test card',
+            body: 'Body text for the smoke test card.',
+            labels: ['test'],
+            priority: 'high'
+        });
+        const cardId = createRes.card.id;
+        check('create_card returns a card id', !!cardId);
+        check("create_card default status is 'ready'", createRes.card.status === 'ready');
+        check("create_card created_by defaults to 'rebecca'", createRes.card.created_by === 'rebecca');
+        check(
+            "create_card review_policy defaults to 'review-required' (no doc/spec signal)",
+            createRes.card.review_policy === 'review-required'
+        );
+
+        // 3b. create_card quick-add (title only, no board given -> dev-backlog)
+        const quickAddRes = await callTool(client, 'create_card', { title: `Quick-add smoke test ${Date.now()}` });
+        check('create_card quick-add succeeds with title only', !!quickAddRes.card.id);
+        check(
+            'create_card quick-add resolves to dev-backlog',
+            quickAddRes.card.board_id === devBacklogId
+        );
+        // Clean up the quick-add card immediately (it landed on the REAL dev-backlog board).
+        // Belt-and-suspenders: delete by id AND by the same title pattern the
+        // pre-clean sweep uses, in case anything else produced a stray row.
+        await pool.query('DELETE FROM fictionlab.kanban_cards WHERE id = $1', [quickAddRes.card.id]);
+        await pool.query(`DELETE FROM fictionlab.kanban_cards WHERE title LIKE 'Quick-add smoke test %'`);
+
+        // 4. list_cards filters
+        const unassignedRes = await callTool(client, 'list_cards', { board_id: testBoardId, assignee: '__unassigned__' });
+        check('list_cards __unassigned__ finds the new card', unassignedRes.cards.some((c) => c.id === cardId));
+
+        const claimableRes = await callTool(client, 'list_cards', { board_id: testBoardId, agent_claimable_only: true });
+        check('list_cards agent_claimable_only finds the new card', claimableRes.cards.some((c) => c.id === cardId));
+
+        const labelRes = await callTool(client, 'list_cards', { board_id: testBoardId, label: 'test' });
+        check('list_cards label filter finds the new card', labelRes.cards.some((c) => c.id === cardId));
+
+        // 5. update_card (partial patch)
+        const updateRes = await callTool(client, 'update_card', {
+            card_id: cardId,
+            priority: 'urgent',
+            labels: ['test', 'updated']
+        });
+        check("update_card applied priority='urgent'", updateRes.card.priority === 'urgent');
+        check('update_card applied labels patch', JSON.stringify(updateRes.card.labels.sort()) === JSON.stringify(['test', 'updated']));
+        check('update_card left title untouched (partial patch)', updateRes.card.title === 'Smoke test card');
+
+        // 5b. update_card review_policy — escalate-only guard (S11 §11.5 decision 5)
+        const docsCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'Docs-only smoke test card',
+            body: 'This is a docs-only change, no code touched.'
+        });
+        const docsCardId = docsCardRes.card.id;
+        check("create_card infers review_policy='auto-done' for a docs-only card", docsCardRes.card.review_policy === 'auto-done');
+
+        const escalateRes = await callTool(client, 'update_card', { card_id: docsCardId, review_policy: 'review-required' });
+        check("update_card allows escalating auto-done -> review-required", escalateRes.card.review_policy === 'review-required');
+
+        let downgradeRejected = false;
+        try {
+            await callTool(client, 'update_card', { card_id: docsCardId, review_policy: 'auto-done' });
+        } catch (e) {
+            downgradeRejected = /downgrad/i.test(e.message);
+        }
+        check('update_card rejects downgrading review-required -> auto-done', downgradeRejected);
+
+        // 6. claim_card (win)
+        const claimRes = await callTool(client, 'claim_card', { card_id: cardId, agent: 'claude-code:smoke-test' });
+        check('claim_card wins the claim', claimRes.claimed === true);
+        check("claim_card sets status='claimed'", claimRes.card?.status === 'claimed');
+        check('claim_card sets assignee to the claiming agent', claimRes.card?.assignee === 'claude-code:smoke-test');
+
+        // 6b. claim_card (second attempt on an already-claimed card)
+        const reClaimRes = await callTool(client, 'claim_card', { card_id: cardId, agent: 'claude-code:other-session' });
+        check('claim_card second attempt is denied', reClaimRes.claimed === false);
+        check("claim_card second attempt reason='already_claimed'", reClaimRes.reason === 'already_claimed', reClaimRes.reason);
+
+        // 7. move_card -> review (review-required card should auto-reassign to rebecca)
+        const moveRes = await callTool(client, 'move_card', { card_id: cardId, to_status: 'review', actor: 'claude-code:smoke-test' });
+        check("move_card sets status='review'", moveRes.card.status === 'review');
+        check(
+            "move_card auto-reassigns review-required card to 'rebecca'",
+            moveRes.card.assignee === 'rebecca'
+        );
+
+        // 8. comment_card
+        const commentRes = await callTool(client, 'comment_card', {
+            card_id: cardId,
+            author: 'claude-code:smoke-test',
+            body: 'Finished the smoke test scenario.'
+        });
+        check('comment_card returns a comment id', !!commentRes.comment.id);
+
+        // 9. add_card_link
+        const linkRes = await callTool(client, 'add_card_link', {
+            card_id: cardId,
+            link_type: 'github_issue',
+            ref: 'RLRyals/MCP-Writing-Servers#58',
+            label: 'Implementation issue'
+        });
+        check('add_card_link returns a link id', !!linkRes.link.id);
+
+        // 10. get_card (detail-drawer call)
+        const detailRes = await callTool(client, 'get_card', { card_id: cardId });
+        check('get_card returns the card', detailRes.card.id === cardId);
+        check('get_card returns >=1 comment', detailRes.comments.length >= 1);
+        check('get_card returns >=1 link', detailRes.links.length >= 1);
+        check('get_card returns activity rows', detailRes.activity.length > 0);
+        const actions = detailRes.activity.map((a) => a.action).sort();
+        check(
+            'get_card activity includes created/claimed/moved/commented/linked',
+            ['claim_denied', 'claimed', 'commented', 'created', 'linked', 'moved', 'updated'].every((a) => actions.includes(a)),
+            JSON.stringify(actions)
+        );
+
+        // 11. archive_card
+        const archiveRes = await callTool(client, 'archive_card', { card_id: cardId, actor: 'rebecca' });
+        check("archive_card sets status='archived'", archiveRes.card.status === 'archived');
+
+        const excludesArchivedRes = await callTool(client, 'list_cards', { board_id: testBoardId });
+        check('list_cards default excludes archived card', !excludesArchivedRes.cards.some((c) => c.id === cardId));
+
+        const includesArchivedRes = await callTool(client, 'list_cards', { board_id: testBoardId, include_archived: true });
+        check('list_cards include_archived:true finds the archived card', includesArchivedRes.cards.some((c) => c.id === cardId));
+
+        // --- Human-reserve guard ---
+        const humanCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: "Rebecca's card",
+            assignee: 'rebecca'
+        });
+        const humanCardId = humanCardRes.card.id;
+        check(
+            'create_card with assignee=rebecca sets agent_claimable=false (trigger)',
+            humanCardRes.card.agent_claimable === false
+        );
+
+        const humanClaimRes = await callTool(client, 'claim_card', {
+            card_id: humanCardId,
+            agent: 'claude-code:smoke-test',
+            expected_status: humanCardRes.card.status
+        });
+        check('claim_card on a rebecca-assigned card is denied', humanClaimRes.claimed === false);
+        check(
+            "claim_card on a rebecca-assigned card reason='reserved_for_human'",
+            humanClaimRes.reason === 'reserved_for_human',
+            humanClaimRes.reason
+        );
+
+        const humanCardAfter = await pool.query('SELECT assignee, status FROM fictionlab.kanban_cards WHERE id = $1', [humanCardId]);
+        check(
+            'claim_card denial caused no state change on the rebecca card',
+            humanCardAfter.rows[0].assignee === 'rebecca'
+        );
+
+        // claim_card must reject agent:'rebecca' outright
+        let rejectedRebeccaAgent = false;
+        try {
+            await callTool(client, 'claim_card', { card_id: humanCardId, agent: 'rebecca' });
+        } catch (e) {
+            rejectedRebeccaAgent = /rebecca/i.test(e.message);
+        }
+        check("claim_card rejects agent:'rebecca' outright", rejectedRebeccaAgent);
+    } finally {
+        await client.close();
+        // Cascade-delete the ephemeral test board (columns/cards/comments/links/activity all go with it).
+        await pool.query('DELETE FROM fictionlab.kanban_boards WHERE id = $1', [testBoardId]);
+        console.log(`\nCleaned up ephemeral test board ${testBoardKey}`);
+        await pool.end();
+    }
+
+    console.log(`\n${passCount} passed, ${failCount} failed.`);
+    process.exit(failCount > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+    console.error('Smoke test crashed:', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements the DB + MCP-server half of **S11 — FictionLab Kanban Board Plugin**. The board UI is a separate deliverable: **RLRyals/MCP-Electron-App#179**.

- **`migrations/042_kanban_tables.sql`** — idempotent DO-block guarded on the `migrations` table. Creates `fictionlab.kanban_{boards,columns,cards,card_links,comments,activity}`, both triggers (`kanban_update_timestamp`, `kanban_enforce_human_reserve`), and seeds the single `dev-backlog` board + its 8 columns. Includes `kanban_cards.review_policy VARCHAR(20) NOT NULL DEFAULT 'review-required' CHECK (review_policy IN ('auto-done','review-required'))` per the issue's §11.5 resolution.
- **`src/mcps/kanban-server/`** — new `KanbanMCPServer` (class + config key `kanban`), modeled on `workflow-manager-server`: `index.js`, `handlers/{board,card,claim,comment}-handlers.js` + a shared `kanban-helpers.js`, `schemas/kanban-tools-schema.js`, `stdio-adapter.js`. **11 tools**: the 7 required (`get_board`, `list_cards`, `create_card`, `claim_card`, `update_card`, `move_card`, `comment_card`) + 4 supporting (`list_boards`, `get_card`, `add_card_link`, `archive_card`).
- Registered at **all three points**: `src/single-server-runner.js` `serverConfigs`, `src/http-sse-server.js` dynamic-import block (loaded-count bumped to `/13`), and `mcp-config/mcp-config.json`.
- `src/shared/run-migration.js`: fixed a pre-existing bug (its own unconditional `INSERT INTO migrations` had no `ON CONFLICT`, so it threw on every migration that self-records per the standard guarded-DO-block convention — i.e. every migration since 025). Needed to apply 042 at all.

## Resolved decisions this PR implements (per issue #58 §11 — not re-litigated)

1. Session-scoped agent identity (`claude-code:<sessionLabel>`, or a `.kcpps` config id for local lanes) — enforced by rejecting `agent:'rebecca'` outright in `claim_card`.
2. One board + filterable labels (no per-category boards).
3. `NOTIFY kanban_changed, '<card_id>'` via `pg_notify()` on every mutation (`create_card`, `claim_card`, `update_card`, `move_card`, `comment_card`, plus `add_card_link`/`archive_card` for consistency) on the shared pool connection.
4. `review_policy`, risk-based, defaulted at `create_card` time by a content heuristic (labels/spec_ref/issue_ref/title/body — migration/workflow-def/executor/skills/config signals → `review-required`; docs/specs/reports/analysis signals → `auto-done`; ambiguous → `review-required`, the safe default). `move_card` to `review` auto-reassigns a `review-required` card to `assignee='rebecca'`.
5. Stdio-first: `stdio-adapter.js` is the primary path for Claude Code sessions driving local-model lanes (no standing watcher in v1).

## Spec deviations / judgment calls made this session

1. **`review_policy` escalate-only guard, added.** The pre-existing partial work let `create_card` set/override `review_policy` but didn't expose it on `update_card` at all, so there was no way for an agent to actually escalate a card per the issue's "agents may escalate to review-required, never downgrade" rule. Added `review_policy` to `update_card`'s patchable fields with an explicit guard: `auto-done -> review-required` is always allowed; the reverse throws an error naming the rule. Covered by 3 new smoke-test assertions.
2. **`mcp-config/mcp-config.json` — added the `kanban` entry**, overriding the prior session's choice to omit it. The issue flagged this as ambiguous ("this HTTP entry may be unnecessary — add it anyway for parity/HTTP-fallback unless the implementer confirms stdio-only is sufficient"), and the pre-existing work chose to omit it, reasoning that `workflow-manager`/`database-admin`/`npe` are already absent from this file (a consistent op-server-family pattern). I verified via a repo-wide grep that no code in this repo reads `mcp-config.json` at runtime — it's a static reference file only consumed by an external Electron host. Since adding the entry is a no-op cost-wise and acceptance criterion #9 explicitly reads "kanban is present in all three registration points," I added it for literal compliance. The stdio path remains the primary supported transport regardless.
3. **Left the `{ok:true/...}` / `{ok:false, error}` return-contract language from the issue unimplemented as literally worded.** Confirmed via grep that no sibling server in this repo (`workflow-manager-server`, `database-admin-server`, etc.) wraps tool results in an `ok` field — they all rely on `BaseMCPServer.formatSuccess`/`formatError`, returning raw data on success and an `isError:true` text response on failure. Kanban follows this actual codebase convention rather than the issue's aspirational (unused-elsewhere) wording, per the "match existing conventions" instruction.
4. Migration numbering confirmed still correct at build time: `041` remains unclaimed on disk, so `042_kanban_tables.sql` is the right number (no renumbering needed).
5. Minor, non-blocking: the new integration tests live under a new top-level `test/kanban-server/` rather than the repo's existing `tests/` (plural) directory. Left as-is because the existing `tests/` convention is hand-rolled `describe`/`it` unit tests with no DB dependency (`tests/database-admin-server/*.test.js`), whereas these are live-DB + spawned-process integration tests — a different enough category that a separate top-level folder seemed reasonable. Flagging in case Rebecca prefers them moved under `tests/`.

## Verification

- **Migration**, on a throwaway database (`kanban_issue58_test`) cloned via `pg_dump --schema-only` from `fictionlab-postgres`'s live `mcp_writing_db` then stripped of the kanban_* objects to simulate a clean pre-042 state — never applied to the live DB in this session:
  - Applied via `node src/shared/run-migration.js 042_kanban_tables.sql` — succeeded (this is what surfaced the `run-migration.js` bug above).
  - Ran a second time: idempotent — `migrations` row count for `042_kanban_tables.sql` stayed at 1, board/column seed rows did not duplicate.
  - Confirmed via `\d fictionlab.kanban_cards`: all CHECK constraints present (`status`, `priority`, `review_policy`), both triggers present, FK to `fictionlab.active_workflows(id)` with `ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED`.
  - Directly verified the `review_policy` CHECK constraint rejects an invalid value, and the `kanban_enforce_human_reserve` trigger forces `agent_claimable=FALSE` even when a caller explicitly passes `TRUE` alongside `assignee='rebecca'`.
  - Verified `NOTIFY kanban_changed` fires and carries the mutated card's id as payload, using a separate raw `pg` `LISTEN` connection racing against the production `CardHandlers.handleCreateCard` call (simulating the Electron plugin's listener).
  - Dropped the throwaway database at the end of the session.
- **Server boot**: `node src/single-server-runner.js kanban 3015` against the throwaway DB — `/health` confirms a healthy shared DB pool; `/info` lists all 11 tools.
- **Test suite**, run against the throwaway DB:
  - `test/kanban-server/smoke-test.js` — connects over the real stdio transport (spawns `stdio-adapter.js`), exercises all 11 tools, the human-reserve guard, quick-add-resolves-to-dev-backlog, and the new review_policy escalate/downgrade guard. **40/40 assertions pass.** Cleans up its own ephemeral board + any quick-add residue.
  - `test/kanban-server/concurrent-claim-test.js` — the load-bearing acceptance test: 20 iterations of two `claim_card` calls fired truly in parallel (`Promise.all`, two independent pool connections) at the real `ClaimHandlers` production code. **20/20**: exactly one `{claimed:true}` + one `{claimed:false, reason:'already_claimed'}` per iteration, `claimed_by` matches the winner, exactly one `claimed` + one `claim_denied` activity row each time; both "agents" won at different points across the run (genuine race).

## Cross-links

- Board UI (host-bundled React view, gated on the plugin): **RLRyals/MCP-Electron-App#179**
- Active-Workflows-panel refresh bug (informs #179's poll-vs-LISTEN choice, independent of this repo's NOTIFY work): **RLRyals/MCP-Electron-App#178**

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)
