### PR TITLE
feat(kanban): due_at + due/overdue filter (S14 fold-in minimum)

### DIFF
--- a/migrations/043_kanban_cards_add_due_at.sql
+++ b/migrations/043_kanban_cards_add_due_at.sql
@@ -1,0 +1,42 @@
+-- Migration: 043_kanban_cards_add_due_at
+-- Description: S14 fold-in minimum (S14-broadquill-dashboard-plugin.md
+-- Status header) — kanban cards need a due date so the S11 board can filter
+-- "due / overdue" without waiting on the full S14 business panel
+-- (bq_deadlines / bq_pipeline_items) follow-up. `assignee` already exists on
+-- kanban_cards (migration 042) and already supports "assigned to Rebecca"
+-- filtering via list_cards(assignee:'rebecca') — no schema change needed for
+-- that half of the S14 minimum.
+--
+-- Numbered 043 (not 041): 041 remains reserved for S9 model-testing per
+-- 042_kanban_tables.sql's own header note, even though it is still unclaimed
+-- on disk at the time this migration was written — re-scan migrations/ for
+-- the true next free number if that has changed by the time this is applied.
+--
+-- due_at is TIMESTAMPTZ (not DATE) to match every other timestamp column on
+-- kanban_cards and to allow a specific time-of-day deadline, not just a
+-- calendar date. NULL = no deadline (the common case).
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM migrations WHERE filename = '043_kanban_cards_add_due_at.sql') THEN
+        RAISE NOTICE 'Migration 043_kanban_cards_add_due_at.sql already applied, skipping.';
+        RETURN;
+    END IF;
+
+    ALTER TABLE fictionlab.kanban_cards
+        ADD COLUMN IF NOT EXISTS due_at TIMESTAMPTZ;
+
+    COMMENT ON COLUMN fictionlab.kanban_cards.due_at IS
+        'Optional card due date/time (S14 fold-in minimum). NULL = no deadline. Drives list_cards(due_filter) and the board''s due/overdue filter.';
+
+    -- Partial index: only rows that actually carry a deadline and are not
+    -- already done/archived are ever relevant to an overdue/upcoming scan.
+    CREATE INDEX IF NOT EXISTS idx_kanban_cards_due_at
+        ON fictionlab.kanban_cards(due_at)
+        WHERE due_at IS NOT NULL AND status NOT IN ('done', 'archived');
+
+    INSERT INTO migrations (filename) VALUES ('043_kanban_cards_add_due_at.sql')
+    ON CONFLICT (filename) DO NOTHING;
+
+    RAISE NOTICE 'Migration 043_kanban_cards_add_due_at.sql completed successfully.';
+END $$;

--- a/src/mcps/kanban-server/handlers/card-handlers.js
+++ b/src/mcps/kanban-server/handlers/card-handlers.js
@@ -16,7 +16,7 @@ export class CardHandlers {
     /**
      * list_cards — the workhorse filter. board_key/board_id, assignee, agent,
      * status, label, priority, agent_claimable_only, include_archived,
-     * include_workflow_phase, limit.
+     * include_workflow_phase, due_filter, limit.
      */
     async handleListCards(args) {
         const {
@@ -30,6 +30,7 @@ export class CardHandlers {
             agent_claimable_only = false,
             include_archived = false,
             include_workflow_phase = false,
+            due_filter,
             limit = 200
         } = args || {};
 
@@ -89,6 +90,15 @@ export class CardHandlers {
             conditions.push(`c.status <> 'archived'`);
         }
 
+        // S14 fold-in minimum: due/overdue filtering. Both branches exclude
+        // done/archived cards -- a completed or archived card is never
+        // "overdue" or "upcoming" in any UI-meaningful sense.
+        if (due_filter === 'overdue') {
+            conditions.push(`c.due_at IS NOT NULL AND c.due_at < NOW() AND c.status NOT IN ('done', 'archived')`);
+        } else if (due_filter === 'upcoming') {
+            conditions.push(`c.due_at IS NOT NULL AND c.due_at >= NOW() AND c.status NOT IN ('done', 'archived')`);
+        }
+
         const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
 
         const workflowJoin = include_workflow_phase
@@ -100,6 +110,18 @@ export class CardHandlers {
 
         params.push(limit);
 
+        // When filtering by due date, the soonest-due card matters more than
+        // priority/position ordering -- lead with due_at ascending. Otherwise
+        // keep the existing priority-then-position-then-created_at order.
+        const orderClause = due_filter
+            ? 'ORDER BY c.due_at ASC NULLS LAST, c.priority, c.position'
+            : `ORDER BY
+                CASE c.priority
+                    WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 WHEN 'low' THEN 3 ELSE 4
+                END,
+                c.position,
+                c.created_at`;
+
         const result = await this.db.query(
             `SELECT
                 c.*,
@@ -109,12 +131,7 @@ export class CardHandlers {
              FROM fictionlab.kanban_cards c
              ${workflowJoin}
              ${whereClause}
-             ORDER BY
-                CASE c.priority
-                    WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 WHEN 'low' THEN 3 ELSE 4
-                END,
-                c.position,
-                c.created_at
+             ${orderClause}
              LIMIT $${i}`,
             params
         );
@@ -145,6 +162,7 @@ export class CardHandlers {
             spec_ref,
             issue_ref,
             created_by = 'rebecca',
+            due_at,
             review_policy
         } = args || {};
 
@@ -170,8 +188,8 @@ export class CardHandlers {
 
         const result = await this.db.query(
             `INSERT INTO fictionlab.kanban_cards
-                (board_id, title, body, status, assignee, priority, labels, spec_ref, issue_ref, review_policy, created_by)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                (board_id, title, body, status, assignee, priority, labels, spec_ref, issue_ref, review_policy, created_by, due_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
              RETURNING *`,
             [
                 resolvedBoardId,
@@ -184,7 +202,8 @@ export class CardHandlers {
                 spec_ref || null,
                 issue_ref || null,
                 resolvedReviewPolicy,
-                created_by
+                created_by,
+                due_at || null
             ]
         );
 
@@ -223,6 +242,7 @@ export class CardHandlers {
             spec_ref,
             issue_ref,
             workflow_registry_id,
+            due_at,
             metadata,
             review_policy
         } = args || {};
@@ -292,6 +312,15 @@ export class CardHandlers {
             sets.push(`workflow_registry_id = $${i++}`);
             params.push(workflow_registry_id);
             changedFields.push('workflow_registry_id');
+        }
+        if (due_at !== undefined) {
+            if (due_at === '__clear__') {
+                sets.push('due_at = NULL');
+            } else {
+                sets.push(`due_at = $${i++}`);
+                params.push(due_at);
+            }
+            changedFields.push('due_at');
         }
         if (metadata !== undefined) {
             sets.push(`metadata = metadata || $${i++}`);

--- a/src/mcps/kanban-server/schemas/kanban-tools-schema.js
+++ b/src/mcps/kanban-server/schemas/kanban-tools-schema.js
@@ -24,7 +24,7 @@ export const kanbanToolsSchema = [
     },
     {
         name: 'list_cards',
-        description: 'Lists cards with filters: board, assignee, agent, status, label, priority, agent_claimable_only, include_archived, include_workflow_phase. The workhorse read tool.',
+        description: 'Lists cards with filters: board, assignee, agent, status, label, priority, agent_claimable_only, include_archived, include_workflow_phase, due_filter. The workhorse read tool.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -52,6 +52,11 @@ export const kanbanToolsSchema = [
                     default: false,
                     description: 'Join live phase for cards with workflow_registry_id'
                 },
+                due_filter: {
+                    type: 'string',
+                    enum: ['overdue', 'upcoming'],
+                    description: "S14 fold-in minimum. 'overdue': due_at is set, in the past, and status is not done/archived. 'upcoming': due_at is set and in the future (status not done/archived). Results are additionally ordered by due_at ascending when this is set."
+                },
                 limit: { type: 'integer', default: 200 }
             }
         }
@@ -73,6 +78,10 @@ export const kanbanToolsSchema = [
                 spec_ref: { type: 'string' },
                 issue_ref: { type: 'string' },
                 created_by: { type: 'string', default: 'rebecca' },
+                due_at: {
+                    type: 'string',
+                    description: 'ISO 8601 timestamp. Optional card deadline (S14 fold-in minimum). Omit for no deadline.'
+                },
                 review_policy: {
                     type: 'string',
                     enum: ['auto-done', 'review-required'],
@@ -126,6 +135,10 @@ export const kanbanToolsSchema = [
                 workflow_registry_id: {
                     type: 'string',
                     description: 'Link this card to a live workflow run (active_workflows.id)'
+                },
+                due_at: {
+                    type: 'string',
+                    description: "ISO 8601 timestamp. '__clear__' removes the deadline (same sentinel convention as assignee)."
                 },
                 metadata: { type: 'object' },
                 review_policy: {

--- a/test/kanban-server/smoke-test.js
+++ b/test/kanban-server/smoke-test.js
@@ -278,6 +278,69 @@ async function main() {
             rejectedRebeccaAgent = /rebecca/i.test(e.message);
         }
         check("claim_card rejects agent:'rebecca' outright", rejectedRebeccaAgent);
+
+        // --- S14 fold-in minimum: due_at + due_filter + assignee='rebecca' ---
+        // (assignee='rebecca' filtering already exercised implicitly above via
+        // humanCardRes/humanCardAfter; this block adds explicit due-date coverage.)
+        const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        const nextWeek = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+        const overdueCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: "Rebecca's overdue card",
+            assignee: 'rebecca',
+            due_at: yesterday
+        });
+        const overdueCardId = overdueCardRes.card.id;
+        check('create_card accepts due_at', overdueCardRes.card.due_at !== null && overdueCardRes.card.due_at !== undefined);
+
+        const upcomingCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'Upcoming-deadline card',
+            due_at: nextWeek
+        });
+        const upcomingCardId = upcomingCardRes.card.id;
+
+        const noDeadlineCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'No-deadline card'
+        });
+        const noDeadlineCardId = noDeadlineCardRes.card.id;
+        check('create_card without due_at leaves due_at null', noDeadlineCardRes.card.due_at === null);
+
+        const overdueListRes = await callTool(client, 'list_cards', { board_id: testBoardId, due_filter: 'overdue' });
+        check('list_cards due_filter=overdue finds the overdue card', overdueListRes.cards.some((c) => c.id === overdueCardId));
+        check('list_cards due_filter=overdue excludes the upcoming card', !overdueListRes.cards.some((c) => c.id === upcomingCardId));
+        check('list_cards due_filter=overdue excludes the no-deadline card', !overdueListRes.cards.some((c) => c.id === noDeadlineCardId));
+
+        const upcomingListRes = await callTool(client, 'list_cards', { board_id: testBoardId, due_filter: 'upcoming' });
+        check('list_cards due_filter=upcoming finds the upcoming card', upcomingListRes.cards.some((c) => c.id === upcomingCardId));
+        check('list_cards due_filter=upcoming excludes the overdue card', !upcomingListRes.cards.some((c) => c.id === overdueCardId));
+
+        const rebeccaQueueRes = await callTool(client, 'list_cards', { board_id: testBoardId, assignee: 'rebecca' });
+        check(
+            "list_cards assignee='rebecca' finds her overdue card ('assigned to Rebecca' filter minimum)",
+            rebeccaQueueRes.cards.some((c) => c.id === overdueCardId)
+        );
+        check(
+            "list_cards assignee='rebecca' excludes the unassigned upcoming card",
+            !rebeccaQueueRes.cards.some((c) => c.id === upcomingCardId)
+        );
+
+        // update_card due_at patch + '__clear__' sentinel
+        const setDueRes = await callTool(client, 'update_card', { card_id: noDeadlineCardId, due_at: nextWeek });
+        check('update_card sets due_at', !!setDueRes.card.due_at);
+
+        const clearDueRes = await callTool(client, 'update_card', { card_id: noDeadlineCardId, due_at: '__clear__' });
+        check("update_card due_at:'__clear__' removes the deadline", clearDueRes.card.due_at === null);
+
+        // A done card with a past due_at must never surface as overdue.
+        await callTool(client, 'move_card', { card_id: overdueCardId, to_status: 'done', actor: 'rebecca' });
+        const overdueAfterDoneRes = await callTool(client, 'list_cards', { board_id: testBoardId, due_filter: 'overdue' });
+        check(
+            'list_cards due_filter=overdue excludes a done card even with a past due_at',
+            !overdueAfterDoneRes.cards.some((c) => c.id === overdueCardId)
+        );
     } finally {
         await client.close();
         // Cascade-delete the ephemeral test board (columns/cards/comments/links/activity all go with it).


### PR DESCRIPTION
## Summary
- S14-broadquill-dashboard-plugin.md's Status header retargets its business panel to fold into the S11 kanban plugin (MCP-Electron-App#179). The minimum server-side scope for that build is a card due date plus an overdue/upcoming filter; `assignee` already existed on `kanban_cards` (migration 042, PR #60) and already supported "assigned to Rebecca" filtering, so no change was needed for that half.
- `migrations/043_kanban_cards_add_due_at.sql` — adds `kanban_cards.due_at TIMESTAMPTZ` + a partial index (`due_at IS NOT NULL AND status NOT IN ('done','archived')`). Numbered 043, not 041 — 041 remains reserved for S9 model-testing per migration 042's own header note (re-checked `migrations/` at build time; still unclaimed on disk).
- `kanban-tools-schema.js` / `card-handlers.js` — `due_at` added to `create_card` and `update_card` (with the `'__clear__'` sentinel, matching `assignee`'s existing convention); `list_cards` gains `due_filter: 'overdue' | 'upcoming'`, which also reorders results by `due_at` ascending and always excludes done/archived cards.
- `test/kanban-server/smoke-test.js` extended with due_at + due_filter + `assignee='rebecca'` coverage.

## Test plan
- [x] Migration applied to the live `fictionlab-postgres` / `mcp_writing_db` DB via `node src/shared/run-migration.js 043_kanban_cards_add_due_at.sql`; ran a second time to confirm idempotency (skip-NOTICE, no error).
- [x] `node test/kanban-server/smoke-test.js` — 52/52 assertions pass against the live DB, including the new due_at/due_filter/assignee coverage.

Companion PRs (same branch name, cross-linked):
- RLRyals/fictionlab-workflow — new `fictionlab-kanban` plugin package
- RLRyals/MCP-Electron-App#179 — host-side board view (this PR is a dependency of it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)