### PR TITLE
feat(kanban): identities model replaces hardcoded 'rebecca' human-gate

### DIFF
--- a/migrations/044_kanban_identities.sql
+++ b/migrations/044_kanban_identities.sql
@@ -1,0 +1,119 @@
+-- Migration: 044_kanban_identities
+-- Description: Replace the kanban human-gate's hardcoded 'rebecca' literal
+-- with an identities model (GH issue #62). Cards will be assigned to more
+-- than one human/identity: Rebecca's mother (running her own books through
+-- the same system), pen names acting as themselves ("post to socials as
+-- Blake Merrick"), and future hires (PA, editor). Before this migration only
+-- assignee='rebecca' ever set agent_claimable=FALSE -- a card assigned to
+-- 'mom' or 'assistant' stayed agent-claimable, so an agent could legally
+-- claim work meant for a human. The gate must be identity-kind-driven, not
+-- name-driven.
+--
+-- Numbered 044 (next free after 043_kanban_cards_add_due_at.sql; 041 remains
+-- reserved for S9 model-testing per 042's own header note). Re-scan
+-- migrations/ for the true next free number if that has changed by the time
+-- this is applied.
+--
+-- fictionlab.kanban_identities: id VARCHAR(100) PK (matches assignee values
+-- 1:1 -- no FK enforced on kanban_cards.assignee, by design: a card may be
+-- pre-assigned to an identity string before it's formally registered, and an
+-- unrecognized string may still reach the table via raw SQL bypassing the
+-- app layer -- the trigger below fails safe in that case rather than a hard
+-- FK violation). kind IN ('human','persona','agent'):
+--   - human   -> NEVER agent-claimable. The hard gate.
+--   - persona -> agent-claimable. A pen-name/persona card ("post to socials
+--     as Blake Merrick") may be executed by an agent acting AS that persona
+--     -- including claim_card claiming using the persona's own id as
+--     `agent` (kanban-server claim-handlers.js).
+--   - agent   -> agent-claimable. A registered agent/worker identity.
+--     claim_card self-registers any first-seen claiming agent id as
+--     kind='agent' (ON CONFLICT DO NOTHING) so the fail-safe below never
+--     misfires on a claim's own UPDATE and flips agent_claimable back off
+--     for a card an agent legitimately just won.
+-- Seed: ('rebecca','Rebecca','human') -- existing behavior unchanged.
+--
+-- kanban_enforce_human_reserve (rewritten): agent_claimable is forced FALSE
+-- when NEW.assignee resolves to an active 'human' identity, OR when
+-- NEW.assignee is set at all but matches NO active identity row --
+-- fail-safe: an unrecognized assignee is treated as human (not claimable)
+-- rather than silently staying agent-claimable. A NULL assignee (unassigned
+-- pool) is never touched. A known active 'persona' or 'agent' identity is
+-- left alone -- whatever agent_claimable the caller/default passed stands.
+-- This remains belt-and-suspenders, same spirit as the original 042 trigger:
+-- kanban-server's create_card/update_card independently REJECT an
+-- unrecognized assignee before it ever reaches this trigger (see
+-- kanban-helpers.js validateAssignee) -- the trigger's fail-safe branch is
+-- defense-in-depth for a write that bypasses that validation, not the
+-- primary gate.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM migrations WHERE filename = '044_kanban_identities.sql') THEN
+        RAISE NOTICE 'Migration 044_kanban_identities.sql already applied, skipping.';
+        RETURN;
+    END IF;
+
+    -- =========================================================
+    -- 1. kanban_identities
+    -- =========================================================
+    CREATE TABLE IF NOT EXISTS fictionlab.kanban_identities (
+        id           VARCHAR(100) PRIMARY KEY,
+        display_name TEXT,
+        kind         TEXT NOT NULL CHECK (kind IN ('human', 'persona', 'agent')),
+        active       BOOLEAN NOT NULL DEFAULT TRUE,
+        created_at   TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    COMMENT ON TABLE fictionlab.kanban_identities IS 'Identities that a kanban_cards.assignee value may resolve to. Drives the human-claimable gate (see kanban_enforce_human_reserve) -- replaces the old hardcoded assignee=''rebecca'' literal (GH issue #62).';
+    COMMENT ON COLUMN fictionlab.kanban_identities.kind IS 'human = never agent-claimable (hard gate; also the fail-safe default for any unrecognized assignee). persona = pen-name/actor identity, agent-claimable (an agent may act AS this persona, including claiming with the persona''s own id). agent = a registered agent/worker identity, agent-claimable.';
+
+    RAISE NOTICE 'Created fictionlab.kanban_identities';
+
+    INSERT INTO fictionlab.kanban_identities (id, display_name, kind)
+    VALUES ('rebecca', 'Rebecca', 'human')
+    ON CONFLICT (id) DO NOTHING;
+
+    RAISE NOTICE 'Seeded kanban_identities: rebecca (human)';
+
+    -- =========================================================
+    -- 2. Rewrite kanban_enforce_human_reserve to be identity-kind-driven
+    --    (function body only -- the existing BEFORE INSERT OR UPDATE trigger
+    --    on kanban_cards from migration 042 already points at this function
+    --    name, so no DROP/CREATE TRIGGER is needed here).
+    -- =========================================================
+    CREATE OR REPLACE FUNCTION fictionlab.kanban_enforce_human_reserve()
+    RETURNS TRIGGER AS $func$
+    DECLARE
+        identity_kind TEXT;
+    BEGIN
+        IF NEW.assignee IS NOT NULL THEN
+            SELECT kind INTO identity_kind
+            FROM fictionlab.kanban_identities
+            WHERE id = NEW.assignee AND active;
+
+            -- NULL identity_kind = no active identity row matches this
+            -- assignee at all -- fail-safe: treat as human, never claimable.
+            IF identity_kind IS NULL OR identity_kind = 'human' THEN
+                NEW.agent_claimable := FALSE;
+            END IF;
+        END IF;
+        RETURN NEW;
+    END;
+    $func$ LANGUAGE plpgsql;
+
+    RAISE NOTICE 'Rewrote kanban_enforce_human_reserve trigger function (identity-kind-driven)';
+
+    -- Column comment update (was: "Set FALSE by trigger when assignee='rebecca'").
+    COMMENT ON COLUMN fictionlab.kanban_cards.agent_claimable IS 'Set FALSE by trigger (kanban_enforce_human_reserve) when assignee resolves to an active human identity, or to no known identity at all (fail-safe). The hard gate for agent claims.';
+
+    INSERT INTO migrations (filename) VALUES ('044_kanban_identities.sql')
+    ON CONFLICT (filename) DO NOTHING;
+
+    RAISE NOTICE '=================================================================';
+    RAISE NOTICE 'Migration 044_kanban_identities.sql completed successfully';
+    RAISE NOTICE '=================================================================';
+    RAISE NOTICE 'Created table fictionlab.kanban_identities (human|persona|agent)';
+    RAISE NOTICE 'Seeded identity: rebecca (human)';
+    RAISE NOTICE 'Rewrote kanban_enforce_human_reserve: identity-kind-driven, fail-safe on unknown assignee';
+    RAISE NOTICE '=================================================================';
+END $$;

--- a/src/mcps/kanban-server/handlers/card-handlers.js
+++ b/src/mcps/kanban-server/handlers/card-handlers.js
@@ -4,7 +4,7 @@
 // claim_card lives in claim-handlers.js — the atomic compare-and-swap is
 // kept in exactly one place.
 
-import { resolveBoardId, logActivity, notifyKanbanChanged, inferReviewPolicy } from './kanban-helpers.js';
+import { resolveBoardId, logActivity, notifyKanbanChanged, inferReviewPolicy, validateAssignee } from './kanban-helpers.js';
 
 const CARD_STATUSES = ['backlog', 'ready', 'claimed', 'in_progress', 'review', 'blocked', 'done', 'archived'];
 
@@ -68,10 +68,16 @@ export class CardHandlers {
             params.push(priority);
         }
 
-        // agent_claimable_only MUST exclude every assignee='rebecca' card by
-        // construction (not just by relying on the agent_claimable trigger).
+        // agent_claimable_only MUST exclude every card assigned to an active
+        // human identity by construction (not just by relying on the
+        // agent_claimable trigger) — GH issue #62: identity-kind-driven, not
+        // name-driven, so this covers 'rebecca' and every other human
+        // identity (e.g. 'mom') alike.
         if (agent_claimable_only) {
-            conditions.push(`c.agent_claimable = TRUE AND c.assignee IS DISTINCT FROM 'rebecca'`);
+            conditions.push(`c.agent_claimable = TRUE AND NOT EXISTS (
+                SELECT 1 FROM fictionlab.kanban_identities ki
+                WHERE ki.id = c.assignee AND ki.kind = 'human' AND ki.active
+            )`);
             if (agent) {
                 conditions.push(`(c.assignee IS NULL OR c.assignee = $${i++})`);
                 params.push(agent);
@@ -174,6 +180,8 @@ export class CardHandlers {
             throw new Error(`Invalid status: ${status}`);
         }
 
+        await validateAssignee(this.db, assignee);
+
         const resolvedBoardId = await resolveBoardId(this.db, {
             board_id,
             board_key,
@@ -224,7 +232,9 @@ export class CardHandlers {
 
     /**
      * update_card — partial patch; only provided keys change.
-     * assignee:'rebecca' auto-clears agent_claimable via the DB trigger.
+     * assignee is validated against fictionlab.kanban_identities (unknown
+     * ids are rejected — GH issue #62); an assignee resolving to an active
+     * human identity auto-clears agent_claimable via the DB trigger.
      * assignee:'__clear__' unassigns.
      * review_policy: escalate-only (S11 §11.5 decision 5 — "agents may
      * escalate a card to review-required, never downgrade it themselves").
@@ -280,6 +290,7 @@ export class CardHandlers {
             changedFields.push('body');
         }
         if (assignee !== undefined) {
+            await validateAssignee(this.db, assignee);
             if (assignee === '__clear__') {
                 sets.push('assignee = NULL');
             } else {

--- a/src/mcps/kanban-server/handlers/claim-handlers.js
+++ b/src/mcps/kanban-server/handlers/claim-handlers.js
@@ -21,19 +21,50 @@ export class ClaimHandlers {
         if (!agent) {
             throw new Error('agent is required');
         }
-        if (agent === 'rebecca') {
-            throw new Error("agent must not be 'rebecca' — claim_card is for agent identities only (session-scoped claude-code:<sessionLabel> or a .kcpps config id)");
+
+        // Generalizes the old hardcoded `agent === 'rebecca'` check to any
+        // registered active human identity (GH issue #62 — the gate must be
+        // identity-kind-driven, not name-driven: 'mom' or a future hire must
+        // be blocked here exactly like 'rebecca' always was). The literal
+        // 'rebecca' comparison is kept alongside as a fail-safe in case the
+        // seed row is ever missing/inactive.
+        const identityResult = await this.db.query(
+            'SELECT kind FROM fictionlab.kanban_identities WHERE id = $1 AND active',
+            [agent]
+        );
+        const agentIdentityKind = identityResult.rows[0]?.kind;
+        if (agent === 'rebecca' || agentIdentityKind === 'human') {
+            throw new Error(
+                `agent must not be a human identity ('${agent}') — claim_card is for agent/persona identities only (session-scoped claude-code:<sessionLabel>, a .kcpps config id, or a persona claiming on its own behalf)`
+            );
         }
         if (!['claimed', 'in_progress'].includes(move_to)) {
             throw new Error(`Invalid move_to: ${move_to}`);
         }
 
+        // Self-register this agent id as kind='agent' (idempotent, ON
+        // CONFLICT DO NOTHING) the first time it's ever seen claiming. This
+        // keeps the kanban_enforce_human_reserve trigger's fail-safe
+        // ("unrecognized assignee -> treat as human") from misfiring on the
+        // claim's own UPDATE below and flipping agent_claimable back off for
+        // a card an agent legitimately just won. An id already registered
+        // (e.g. a persona claiming as itself) is left untouched — its
+        // existing kind stands.
+        if (!agentIdentityKind) {
+            await this.db.query(
+                `INSERT INTO fictionlab.kanban_identities (id, display_name, kind)
+                 VALUES ($1, $2, 'agent')
+                 ON CONFLICT (id) DO NOTHING`,
+                [agent, agent]
+            );
+        }
+
         // The atomic compare-and-swap. Every predicate in the WHERE clause is
         // independent defense-in-depth against the same failure mode (an
-        // agent ending up with a card that belongs to Rebecca):
-        //   - status = expected_status         -> still in the pool the caller thinks it's in
-        //   - agent_claimable = TRUE           -> not reserved (kept true by the DB trigger)
-        //   - assignee IS DISTINCT FROM 'rebecca' -> human cards NEVER agent-claimable
+        // agent ending up with a card reserved for a human):
+        //   - status = expected_status  -> still in the pool the caller thinks it's in
+        //   - agent_claimable = TRUE    -> not reserved (kept true by the DB trigger)
+        //   - NOT EXISTS (... kind='human' ...) -> human-assigned cards NEVER agent-claimable
         //   - assignee IS NULL OR assignee = agent -> unassigned pool, or already this agent's
         const result = await this.db.query(
             `UPDATE fictionlab.kanban_cards
@@ -44,7 +75,10 @@ export class ClaimHandlers {
               WHERE id = $1
                 AND status = $4
                 AND agent_claimable = TRUE
-                AND assignee IS DISTINCT FROM 'rebecca'
+                AND NOT EXISTS (
+                    SELECT 1 FROM fictionlab.kanban_identities ki
+                    WHERE ki.id = assignee AND ki.kind = 'human' AND ki.active
+                )
                 AND (assignee IS NULL OR assignee = $3)
               RETURNING *`,
             [card_id, move_to, agent, expected_status]
@@ -90,7 +124,10 @@ export class ClaimHandlers {
     }
 
     inferDenyReason(card, { agent, expectedStatus }) {
-        if (card.assignee === 'rebecca' || !card.agent_claimable) {
+        // agent_claimable is kept accurate by the kanban_enforce_human_reserve
+        // trigger for every identity (not just 'rebecca') — a single check
+        // here is now sufficient (GH issue #62).
+        if (!card.agent_claimable) {
             return 'reserved_for_human';
         }
 

--- a/src/mcps/kanban-server/handlers/identity-handlers.js
+++ b/src/mcps/kanban-server/handlers/identity-handlers.js
@@ -1,0 +1,80 @@
+// src/mcps/kanban-server/handlers/identity-handlers.js
+// list_identities + upsert_identity — the identities model backing the
+// human-claimable gate (GH issue #62). fictionlab.kanban_identities maps a
+// kanban_cards.assignee value to a kind: 'human' (never agent-claimable),
+// 'persona' (agent-claimable — an agent may act as a pen name/persona), or
+// 'agent' (agent-claimable — a registered agent/worker identity).
+// create_card/update_card validate assignee against this table and reject
+// unknown ids (see kanban-helpers.js validateAssignee) — upsert_identity is
+// the only way to register a new one; there is no silent auto-create.
+
+const IDENTITY_KINDS = ['human', 'persona', 'agent'];
+
+export class IdentityHandlers {
+    constructor(db) {
+        this.db = db;
+    }
+
+    /**
+     * list_identities — all registered identities, optionally filtered by
+     * kind, optionally including inactive ones (default: active only).
+     */
+    async handleListIdentities(args) {
+        const { kind, include_inactive = false } = args || {};
+
+        const conditions = [];
+        const params = [];
+        let i = 1;
+
+        if (kind) {
+            if (!IDENTITY_KINDS.includes(kind)) {
+                throw new Error(`Invalid kind: ${kind}`);
+            }
+            conditions.push(`kind = $${i++}`);
+            params.push(kind);
+        }
+
+        if (!include_inactive) {
+            conditions.push('active = TRUE');
+        }
+
+        const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+        const result = await this.db.query(
+            `SELECT * FROM fictionlab.kanban_identities ${whereClause} ORDER BY id`,
+            params
+        );
+
+        return { identities: result.rows };
+    }
+
+    /**
+     * upsert_identity — register a new identity or update an existing one's
+     * display_name/kind/active. This is the ONLY sanctioned way to add an
+     * assignee value that create_card/update_card will accept — there is no
+     * silent auto-create on write.
+     */
+    async handleUpsertIdentity(args) {
+        const { id, display_name, kind, active = true } = args || {};
+
+        if (!id) {
+            throw new Error('id is required');
+        }
+        if (!kind || !IDENTITY_KINDS.includes(kind)) {
+            throw new Error(`kind is required and must be one of: ${IDENTITY_KINDS.join(', ')}`);
+        }
+
+        const result = await this.db.query(
+            `INSERT INTO fictionlab.kanban_identities (id, display_name, kind, active)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (id) DO UPDATE
+                SET display_name = EXCLUDED.display_name,
+                    kind         = EXCLUDED.kind,
+                    active       = EXCLUDED.active
+             RETURNING *`,
+            [id, display_name || id, kind, active]
+        );
+
+        return { identity: result.rows[0] };
+    }
+}

--- a/src/mcps/kanban-server/handlers/kanban-helpers.js
+++ b/src/mcps/kanban-server/handlers/kanban-helpers.js
@@ -74,6 +74,43 @@ export async function notifyKanbanChanged(db, cardId) {
  * agents may escalate a card to review-required but must never downgrade it
  * themselves, so an over-cautious default is the correct failure mode.
  */
+/**
+ * Validate an assignee id against fictionlab.kanban_identities before it's
+ * written via create_card/update_card (GH issue #62 — the human-gate must be
+ * identity-kind-driven, not name-driven). Unknown ids are REJECTED here, no
+ * silent auto-create — the error lists every known active identity so the
+ * caller can pick a real one or register a new one via upsert_identity.
+ *
+ * This is the primary gate. The DB trigger (kanban_enforce_human_reserve,
+ * migration 044) is separate, fail-safe defense-in-depth for a write that
+ * bypasses this validation entirely (e.g. raw SQL) — it treats an
+ * unrecognized assignee as human rather than silently leaving it
+ * agent-claimable.
+ *
+ * Pass-through, no-op cases: assignee is falsy (unset) or the '__clear__'
+ * unassign sentinel — both are always allowed.
+ */
+export async function validateAssignee(db, assignee) {
+    if (!assignee || assignee === '__clear__') {
+        return;
+    }
+
+    const result = await db.query(
+        'SELECT 1 FROM fictionlab.kanban_identities WHERE id = $1 AND active',
+        [assignee]
+    );
+
+    if (result.rows.length === 0) {
+        const known = await db.query(
+            'SELECT id FROM fictionlab.kanban_identities WHERE active ORDER BY id'
+        );
+        const knownIds = known.rows.map((r) => r.id).join(', ') || '(none registered)';
+        throw new Error(
+            `Unknown assignee '${assignee}'. Known identities: ${knownIds}. Register it first via upsert_identity.`
+        );
+    }
+}
+
 export function inferReviewPolicy({ labels = [], spec_ref, issue_ref, title, body } = {}) {
     const haystack = [
         ...(Array.isArray(labels) ? labels : []),

--- a/src/mcps/kanban-server/index.js
+++ b/src/mcps/kanban-server/index.js
@@ -17,6 +17,7 @@ import { BoardHandlers } from './handlers/board-handlers.js';
 import { CardHandlers } from './handlers/card-handlers.js';
 import { ClaimHandlers } from './handlers/claim-handlers.js';
 import { CommentHandlers } from './handlers/comment-handlers.js';
+import { IdentityHandlers } from './handlers/identity-handlers.js';
 import { kanbanToolsSchema } from './schemas/kanban-tools-schema.js';
 
 class KanbanMCPServer extends BaseMCPServer {
@@ -37,6 +38,7 @@ class KanbanMCPServer extends BaseMCPServer {
         this.cardHandlers = new CardHandlers(this.db);
         this.claimHandlers = new ClaimHandlers(this.db);
         this.commentHandlers = new CommentHandlers(this.db);
+        this.identityHandlers = new IdentityHandlers(this.db);
 
         this.tools = this.getTools();
 
@@ -87,7 +89,10 @@ class KanbanMCPServer extends BaseMCPServer {
             // Claim handler (1 tool — the atomic compare-and-swap)
             'claim_card': this.claimHandlers.handleClaimCard.bind(this.claimHandlers),
             // Comment handler (1 tool)
-            'comment_card': this.commentHandlers.handleCommentCard.bind(this.commentHandlers)
+            'comment_card': this.commentHandlers.handleCommentCard.bind(this.commentHandlers),
+            // Identity handlers (2 tools) — GH issue #62 identities model
+            'list_identities': this.identityHandlers.handleListIdentities.bind(this.identityHandlers),
+            'upsert_identity': this.identityHandlers.handleUpsertIdentity.bind(this.identityHandlers)
         };
         return handlers[toolName];
     }

--- a/src/mcps/kanban-server/schemas/kanban-tools-schema.js
+++ b/src/mcps/kanban-server/schemas/kanban-tools-schema.js
@@ -8,6 +8,7 @@
 
 const CARD_STATUS_ENUM = ['backlog', 'ready', 'claimed', 'in_progress', 'review', 'blocked', 'done', 'archived'];
 const PRIORITY_ENUM = ['low', 'normal', 'high', 'urgent'];
+const IDENTITY_KIND_ENUM = ['human', 'persona', 'agent'];
 
 export const kanbanToolsSchema = [
     // ---- 7 required tools ----
@@ -32,7 +33,7 @@ export const kanbanToolsSchema = [
                 board_id: { type: 'string' },
                 assignee: {
                     type: 'string',
-                    description: "Exact match. Special: 'rebecca' (her queue); '__unassigned__' (assignee IS NULL)"
+                    description: "Exact match against an identity id (see list_identities), e.g. 'rebecca' (her queue). Special: '__unassigned__' (assignee IS NULL)"
                 },
                 agent: {
                     type: 'string',
@@ -44,7 +45,7 @@ export const kanbanToolsSchema = [
                 agent_claimable_only: {
                     type: 'boolean',
                     default: false,
-                    description: "Only cards agents may claim (agent_claimable=TRUE AND assignee<>'rebecca')"
+                    description: 'Only cards agents may claim (agent_claimable=TRUE AND assignee is not an active human identity — see list_identities)'
                 },
                 include_archived: { type: 'boolean', default: false },
                 include_workflow_phase: {
@@ -72,7 +73,10 @@ export const kanbanToolsSchema = [
                 title: { type: 'string' },
                 body: { type: 'string' },
                 status: { type: 'string', enum: CARD_STATUS_ENUM, default: 'ready' },
-                assignee: { type: 'string' },
+                assignee: {
+                    type: 'string',
+                    description: 'Must be a registered active identity id (see list_identities / upsert_identity) — unknown ids are rejected, no silent auto-create.'
+                },
                 priority: { type: 'string', enum: PRIORITY_ENUM, default: 'normal' },
                 labels: { type: 'array', items: { type: 'string' } },
                 spec_ref: { type: 'string' },
@@ -93,14 +97,14 @@ export const kanbanToolsSchema = [
     },
     {
         name: 'claim_card',
-        description: "ATOMIC compare-and-swap claim. Two agents can NEVER both win the same card. NEVER pass agent:'rebecca' — her cards are permanently reserved.",
+        description: 'ATOMIC compare-and-swap claim. Two agents can NEVER both win the same card. NEVER pass an agent id that resolves to an active human identity (see list_identities) — human cards are permanently reserved.',
         inputSchema: {
             type: 'object',
             properties: {
                 card_id: { type: 'string' },
                 agent: {
                     type: 'string',
-                    description: "Claiming agent identity, e.g. 'claude-code:<sessionLabel>' or a .kcpps config id like 'local-qwen3-14b'. NEVER 'rebecca'."
+                    description: "Claiming agent identity, e.g. 'claude-code:<sessionLabel>', a .kcpps config id like 'local-qwen3-14b', or a persona id claiming on its own behalf. NEVER an id registered as kind='human'. First-seen ids are auto-registered as kind='agent'."
                 },
                 expected_status: {
                     type: 'string',
@@ -119,7 +123,7 @@ export const kanbanToolsSchema = [
     },
     {
         name: 'update_card',
-        description: "Partial patch of a card — only provided keys change. assignee:'rebecca' auto-clears agent_claimable (DB trigger); assignee:'__clear__' unassigns.",
+        description: "Partial patch of a card — only provided keys change. assignee must be a registered active identity (unknown ids rejected); one resolving to an active human identity auto-clears agent_claimable (DB trigger). assignee:'__clear__' unassigns.",
         inputSchema: {
             type: 'object',
             properties: {
@@ -127,7 +131,10 @@ export const kanbanToolsSchema = [
                 actor: { type: 'string', description: 'Who is editing (for the activity log)' },
                 title: { type: 'string' },
                 body: { type: 'string' },
-                assignee: { type: 'string' },
+                assignee: {
+                    type: 'string',
+                    description: "Must be a registered active identity id (see list_identities / upsert_identity), or '__clear__' to unassign."
+                },
                 priority: { type: 'string', enum: PRIORITY_ENUM },
                 labels: { type: 'array', items: { type: 'string' } },
                 spec_ref: { type: 'string' },
@@ -222,6 +229,37 @@ export const kanbanToolsSchema = [
                 actor: { type: 'string' }
             },
             required: ['card_id']
+        }
+    },
+
+    // ---- 2 identity tools (GH issue #62 — identities model) ----
+    {
+        name: 'list_identities',
+        description: "Lists registered kanban identities (human/persona/agent) — the set of ids create_card/update_card will accept as assignee. Defaults to active only.",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                kind: { type: 'string', enum: IDENTITY_KIND_ENUM, description: 'Filter to a single kind' },
+                include_inactive: { type: 'boolean', default: false }
+            }
+        }
+    },
+    {
+        name: 'upsert_identity',
+        description: "Registers a new identity or updates an existing one's display_name/kind/active. The ONLY sanctioned way to add an assignee value create_card/update_card will accept — there is no silent auto-create on write.",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { type: 'string', description: 'Matches the assignee values this identity represents, e.g. rebecca, mom, blake-merrick' },
+                display_name: { type: 'string' },
+                kind: {
+                    type: 'string',
+                    enum: IDENTITY_KIND_ENUM,
+                    description: "human = never agent-claimable. persona = agent-claimable (an agent may act as this persona, including claiming as it). agent = agent-claimable registered worker identity."
+                },
+                active: { type: 'boolean', default: true }
+            },
+            required: ['id', 'kind']
         }
     }
 ];

--- a/test/kanban-server/smoke-test.js
+++ b/test/kanban-server/smoke-test.js
@@ -55,6 +55,15 @@ async function main() {
     // interrupted before its own cleanup ran, sweep any stragglers by title
     // pattern before we start, so dev-backlog never accumulates test junk.
     await pool.query(`DELETE FROM fictionlab.kanban_cards WHERE title LIKE 'Quick-add smoke test %'`);
+    // Same for the test-only identities registered by the GH issue #62
+    // identities-model block below (plus the two claiming-agent ids this
+    // script uses, which claim_card auto-registers as kind='agent' the
+    // first time they're ever seen -- see claim-handlers.js), in case a
+    // prior run was interrupted before its own cleanup ran.
+    await pool.query(
+        `DELETE FROM fictionlab.kanban_identities
+         WHERE id IN ('smoke-test-mom', 'smoke-test-persona', 'claude-code:smoke-test', 'claude-code:other-session')`
+    );
 
     // --- Test scaffolding: an ephemeral board, never the real dev-backlog ---
     const testBoardKey = `kanban-smoke-test-${Date.now()}`;
@@ -327,6 +336,154 @@ async function main() {
             !rebeccaQueueRes.cards.some((c) => c.id === upcomingCardId)
         );
 
+        // --- GH issue #62: identities model (replaces the hardcoded 'rebecca' human-gate) ---
+
+        // list_identities: seed 'rebecca' (human) is present before we add anything.
+        const seedIdentitiesRes = await callTool(client, 'list_identities', {});
+        check(
+            "list_identities returns the seeded 'rebecca' identity (kind=human)",
+            seedIdentitiesRes.identities.some((idn) => idn.id === 'rebecca' && idn.kind === 'human')
+        );
+
+        // Register a second human (her mother) and a persona (pen name).
+        const humanIdentityId = 'smoke-test-mom';
+        const personaIdentityId = 'smoke-test-persona';
+        const upsertHumanRes = await callTool(client, 'upsert_identity', {
+            id: humanIdentityId,
+            display_name: 'Smoke Test Mom',
+            kind: 'human'
+        });
+        check("upsert_identity registers a second human identity", upsertHumanRes.identity.kind === 'human');
+
+        const upsertPersonaRes = await callTool(client, 'upsert_identity', {
+            id: personaIdentityId,
+            display_name: 'Smoke Test Persona',
+            kind: 'persona'
+        });
+        check("upsert_identity registers a persona identity", upsertPersonaRes.identity.kind === 'persona');
+
+        const afterAddIdentitiesRes = await callTool(client, 'list_identities', {});
+        check(
+            'list_identities returns seeds plus additions',
+            [humanIdentityId, personaIdentityId, 'rebecca'].every(
+                (id) => afterAddIdentitiesRes.identities.some((idn) => idn.id === id)
+            )
+        );
+
+        // upsert_identity is idempotent (update-in-place, not a duplicate row).
+        const upsertAgainRes = await callTool(client, 'upsert_identity', {
+            id: humanIdentityId,
+            display_name: 'Smoke Test Mom (renamed)',
+            kind: 'human'
+        });
+        check(
+            'upsert_identity updates in place on a repeat call',
+            upsertAgainRes.identity.display_name === 'Smoke Test Mom (renamed)'
+        );
+
+        // create_card assigned to the second human: agent_claimable must be
+        // FALSE exactly like 'rebecca' -- the gate is identity-kind-driven,
+        // not name-driven.
+        const momCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: "Mom's card",
+            assignee: humanIdentityId
+        });
+        const momCardId = momCardRes.card.id;
+        check(
+            'create_card assigned to a second human identity sets agent_claimable=false (not just rebecca)',
+            momCardRes.card.agent_claimable === false
+        );
+
+        const momClaimRes = await callTool(client, 'claim_card', {
+            card_id: momCardId,
+            agent: 'claude-code:smoke-test',
+            expected_status: momCardRes.card.status
+        });
+        check("claim_card on a second-human-assigned card is denied", momClaimRes.claimed === false);
+        check(
+            "claim_card on a second-human-assigned card reason='reserved_for_human'",
+            momClaimRes.reason === 'reserved_for_human',
+            momClaimRes.reason
+        );
+
+        // claim_card must also reject agent:<second human id> outright, same
+        // as it rejects agent:'rebecca'.
+        let rejectedMomAgent = false;
+        try {
+            await callTool(client, 'claim_card', { card_id: momCardId, agent: humanIdentityId });
+        } catch (e) {
+            rejectedMomAgent = /human identity/i.test(e.message);
+        }
+        check("claim_card rejects agent:<second human identity> outright", rejectedMomAgent);
+
+        // create_card assigned to a persona: agent_claimable stays TRUE (a
+        // persona/pen-name card may be executed by an agent acting as that
+        // persona), and an agent may claim it using the persona's own id.
+        const personaCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'Post to socials as the persona',
+            assignee: personaIdentityId
+        });
+        const personaCardId = personaCardRes.card.id;
+        check(
+            'create_card assigned to a persona leaves agent_claimable=true',
+            personaCardRes.card.agent_claimable === true
+        );
+
+        const personaClaimRes = await callTool(client, 'claim_card', {
+            card_id: personaCardId,
+            agent: personaIdentityId,
+            expected_status: personaCardRes.card.status
+        });
+        check(
+            'claim_card succeeds claiming a persona-assigned card as that persona',
+            personaClaimRes.claimed === true
+        );
+        check(
+            "claim_card on a persona card leaves it agent-claimable in principle (kind unaffected)",
+            personaClaimRes.card?.assignee === personaIdentityId
+        );
+
+        // Unknown assignee cannot be written via tools -- create_card and
+        // update_card must reject it (no silent auto-create).
+        let createRejectedUnknown = false;
+        try {
+            await callTool(client, 'create_card', {
+                board_id: testBoardId,
+                title: 'Card for an unregistered assignee',
+                assignee: 'smoke-test-unknown-nobody'
+            });
+        } catch (e) {
+            createRejectedUnknown = /unknown assignee/i.test(e.message);
+        }
+        check('create_card rejects an unknown assignee id', createRejectedUnknown);
+
+        let updateRejectedUnknown = false;
+        try {
+            await callTool(client, 'update_card', {
+                card_id: personaCardId,
+                assignee: 'smoke-test-unknown-nobody'
+            });
+        } catch (e) {
+            updateRejectedUnknown = /unknown assignee/i.test(e.message);
+        }
+        check('update_card rejects an unknown assignee id', updateRejectedUnknown);
+
+        // Fail-safe: if an unrecognized assignee reaches the table anyway
+        // (bypassing tool validation via raw SQL), the trigger must still
+        // treat it as human -- agent_claimable forced FALSE.
+        const bypassCardResult = await pool.query(
+            `INSERT INTO fictionlab.kanban_cards (board_id, title, assignee)
+             VALUES ($1, 'Bypassed unknown-assignee card', 'smoke-test-unknown-nobody')
+             RETURNING agent_claimable`,
+            [testBoardId]
+        );
+        check(
+            'DB trigger fail-safe treats an unrecognized assignee (reaching the table directly) as human',
+            bypassCardResult.rows[0].agent_claimable === false
+        );
+
         // update_card due_at patch + '__clear__' sentinel
         const setDueRes = await callTool(client, 'update_card', { card_id: noDeadlineCardId, due_at: nextWeek });
         check('update_card sets due_at', !!setDueRes.card.due_at);
@@ -345,6 +502,13 @@ async function main() {
         await client.close();
         // Cascade-delete the ephemeral test board (columns/cards/comments/links/activity all go with it).
         await pool.query('DELETE FROM fictionlab.kanban_boards WHERE id = $1', [testBoardId]);
+        // Clean up the test-only identities registered above (GH issue #62),
+        // plus the two claiming-agent ids auto-registered as kind='agent' by
+        // claim_card -- this smoke test leaves nothing behind, same as the board.
+        await pool.query(
+            `DELETE FROM fictionlab.kanban_identities
+             WHERE id IN ('smoke-test-mom', 'smoke-test-persona', 'claude-code:smoke-test', 'claude-code:other-session')`
+        );
         console.log(`\nCleaned up ephemeral test board ${testBoardKey}`);
         await pool.end();
     }


### PR DESCRIPTION
## Summary

Closes #62. Replaces the kanban human-gate's hardcoded `assignee = 'rebecca'` literal with a proper identities model, so the gate works for any human (Rebecca's mother, future hires) and any persona (pen names acting on their own behalf), not just one literal string.

- **migrations/044_kanban_identities.sql** (next free number after 043): adds `fictionlab.kanban_identities` (`id`, `display_name`, `kind` — `human`/`persona`/`agent`, `active`), seeds `('rebecca', 'Rebecca', 'human')`, and rewrites the `kanban_enforce_human_reserve` trigger to be identity-kind-driven: `agent_claimable` is forced `FALSE` when the assignee resolves to an active `human` identity **or to no known identity at all** (fail-safe — unrecognized assignee is treated as human). Applied to the live `fictionlab-postgres` DB and verified idempotent (second run skip-NOTICEs, no error).
- **kanban-helpers.js**: new `validateAssignee()` — `create_card`/`update_card` reject an unrecognized assignee id outright (no silent auto-create), listing known identities in the error.
- **card-handlers.js**: calls `validateAssignee` in both `create_card`/`update_card`; `list_cards`' `agent_claimable_only` filter now excludes any active human identity's cards (was: `'rebecca'` literal only).
- **claim-handlers.js**: rejects `agent` ids resolving to an active human identity (was: literal `'rebecca'` only); self-registers a first-seen claiming agent id as `kind='agent'` (idempotent `ON CONFLICT DO NOTHING`) so the trigger's fail-safe doesn't misfire on the claim's own `UPDATE` and flip `agent_claimable` back off — a persona can also claim on its own behalf using its own registered id. `inferDenyReason` simplified to trust `agent_claimable` alone, since the trigger now keeps it accurate for every identity kind.
- **identity-handlers.js** (new) + **kanban-tools-schema.js** + **index.js**: `list_identities` and `upsert_identity` tools — the only sanctioned way to register an assignee id the card tools will accept.
- **smoke-test.js**: extended per the issue — second human (`smoke-test-mom`) never agent-claimable, persona (`smoke-test-persona`) claimable including by claiming as itself, unknown assignee rejected by `create_card`/`update_card`, and the DB trigger's fail-safe demonstrated via a raw-SQL write that bypasses tool validation. Existing `'rebecca'` assertions untouched and still green.

## Deviation from the issue plan (and why)

The plan didn't call out `claim_card`'s own hardcoded `agent === 'rebecca'` check or its WHERE-clause literal — but leaving those as pure string literals would have reintroduced the exact "name-driven, not identity-kind-driven" bug the issue is about (e.g. `agent: 'mom'` would still have slipped through `claim_card`'s own guard even though `create_card`/`update_card` now block assigning cards to her). Generalized both to check `kanban_identities` instead, and added the agent self-registration step described above so this generalization doesn't regress the existing claim/re-claim smoke-test assertions (an unregistered claiming agent id would otherwise trip the new fail-safe and falsely report `reserved_for_human` on a second claim attempt).

## Test plan

- [x] `docker exec -i fictionlab-postgres psql -U writer -d mcp_writing_db < migrations/044_kanban_identities.sql` — applied live, run twice, second run cleanly skips (idempotent).
- [x] `node test/kanban-server/smoke-test.js` against the live DB — **67/67 passing**, run twice back-to-back, no residual test data (board, cards, and test-only identities all cleaned up).
- [x] Card assigned to `smoke-test-mom` (kind human) never agent-claimable; card assigned to `smoke-test-persona` (kind persona) claimable, including claiming as the persona itself.
- [x] Unknown assignee rejected by `create_card`/`update_card`; a raw-SQL bypass still gets the trigger's human fail-safe.
- [x] `list_identities` returns seeds plus additions; existing `'rebecca'` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)