### PR TITLE
kanban-server: GitHub sync poller -- auto-move cards to Done on PR merge/issue close

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,32 @@ jobs:
           echo "✅ Tests completed successfully"
           echo "📊 Coverage goal: 90%+"
 
+  kanban-github-sync-tests:
+    name: Kanban GitHub Sync Poller Tests
+    runs-on: ubuntu-latest
+    # GH issue #64: unit tests for the URL/owner-repo#N parsing, matching,
+    # and status-transition logic. DB and gh CLI are both fully mocked (see
+    # tests/kanban-server/), so no postgres service or gh auth is needed here.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run github-sync-lib unit tests
+        run: node tests/kanban-server/github-sync-lib.test.js
+
+      - name: Run github-sync orchestration tests (mocked DB + gh client)
+        run: node tests/kanban-server/github-sync.test.js
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ diagnostic-report.json
 server.log
 error.log
 .claude/settings.local.json
+
+# kanban-server GitHub sync poller (GH issue #64) -- runtime-generated
+# watermark state + log, never checked in (the config json IS checked in).
+src/mcps/kanban-server/tools/github-sync.state.json
+src/mcps/kanban-server/tools/github-sync.log

--- a/src/mcps/kanban-server/README.md
+++ b/src/mcps/kanban-server/README.md
@@ -1,0 +1,113 @@
+# Kanban Server
+
+MCP server for the FictionLab kanban board (S11 kanban plugin, GH issue #58).
+Tools live in `handlers/` (board/card/claim/comment/identity), schema in
+`schemas/kanban-tools-schema.js`, and shared helpers (activity log, NOTIFY,
+review-policy inference, identity validation) in `handlers/kanban-helpers.js`.
+Storage is `fictionlab.kanban_boards` / `kanban_columns` / `kanban_cards` /
+`kanban_card_links` / `kanban_comments` / `kanban_activity` in `mcp_writing_db`
+(migration `042_kanban_tables.sql`, extended by `043_...` and `044_...`).
+
+Live-DB integration scripts (ephemeral throwaway board, real gh/DB): `test/kanban-server/`.
+Mocked-DB unit tests (CI-safe): `tests/kanban-server/`.
+
+## GitHub Sync (GH issue #64)
+
+`tools/github-sync.js` is a standalone poller (not part of the MCP server
+process) that closes the loop between GitHub and the board: when a merged PR
+or a closed issue matches a card's link, the card auto-moves
+`in_progress`/`review` -> `done`.
+
+**Why a local poller and not a webhook/GitHub Action:** the `fictionlab`
+schema only exists in the local Docker Postgres (`fictionlab-postgres`) --
+GitHub-hosted runners can't reach it, and a webhook would require exposing a
+public endpoint. A local script using the same `gh` CLI auth Rebecca already
+has on this machine needs neither. This follows the existing pattern:
+daemons/pollers are standalone Scheduled-Task scripts that write to Postgres;
+interactive surfaces are the Electron app.
+
+### How matching works
+
+For every watched repo, each poll looks up merged PRs and closed issues since
+the last watermark (`gh api search/issues`), then for each event builds a set
+of "match targets": the PR/issue itself, plus -- for a merged PR -- every
+issue its body closes via a GitHub closing keyword (`Fixes #64`,
+`Closes RLRyals/other-repo#12`, `Resolves <url>`, etc; see
+`extractClosingReferences` in `tools/github-sync-lib.js`).
+
+A card matches an event if ANY of the following resolve to the same
+owner/repo/number as a match target:
+- the card's own `issue_ref` field (`owner/repo#N` shorthand), or
+- a `kanban_card_links` row of `link_type` `'url'` or `'github_issue'`.
+
+Only cards currently `in_progress` or `review` are ever touched --
+`backlog`/`ready`/`claimed`/`blocked`/`done`/`archived` are never modified and
+a card never moves backwards. A move is stamped into
+`metadata.github_sync = { event, url, at }`; a rerun that would produce the
+same stamp is skipped (idempotent), on top of the status gate itself. Every
+move also writes a `fictionlab.kanban_activity` row via the same
+`logActivity()`/`notifyKanbanChanged()` helpers every other kanban-server
+tool uses (action `'auto-moved'`), so it shows up in the board's activity
+feed identically to a manual `move_card` call.
+
+### Config
+
+`tools/github-sync.config.json` (checked into git -- edit and commit changes):
+
+```json
+{
+    "watched_repos": ["RLRyals/MCP-Electron-App", "RLRyals/MCP-Writing-Servers", "RLRyals/fictionlab-workflow"],
+    "dry_run_default": false,
+    "initial_lookback_hours": 24
+}
+```
+
+DB connection reuses the same `DATABASE_URL`/`.env` convention as the rest of
+kanban-server (`shared/database.js`'s `DatabaseManager`) -- nothing extra to
+configure there.
+
+### Running it
+
+```
+node src/mcps/kanban-server/tools/github-sync.js --dry-run
+node src/mcps/kanban-server/tools/github-sync.js
+```
+
+Flags: `--dry-run` (zero writes -- prints the plan, does not advance the
+watermark), `--config <path>`, `--state <path>`, `--log <path>`,
+`--since <ISO8601>` (override the stored watermark, e.g. for a manual
+re-scan), `--verbose` (print per-error detail).
+
+State (`tools/github-sync.state.json`, gitignored) tracks `last_run_at`; on
+first run (no state file) it looks back `initial_lookback_hours` (default
+24h). Errors (a failed `gh api` call, a DB hiccup) are caught per repo/card,
+logged to `tools/github-sync.log` (gitignored), and never crash the run.
+
+### Registering the Scheduled Task
+
+**Not registered automatically.** Rebecca enables it deliberately by running
+(PowerShell or cmd, one time):
+
+```
+schtasks /create /tn "Kanban GitHub Sync" /tr "node C:\github\MCP-Writing-Servers\src\mcps\kanban-server\tools\github-sync.js" /sc minute /mo 15 /f
+```
+
+This runs every 15 minutes as the current Windows user (so it inherits the
+same `gh auth login` session already on this machine) and only fires while
+that user is logged on. Verify / manage it with:
+
+```
+schtasks /query /tn "Kanban GitHub Sync" /v /fo LIST   # inspect
+schtasks /run /tn "Kanban GitHub Sync"                 # run once, right now
+schtasks /delete /tn "Kanban GitHub Sync" /f           # remove it
+```
+
+### Tests
+
+```
+node tests/kanban-server/github-sync-lib.test.js   # pure parsing/matching/transition logic
+node tests/kanban-server/github-sync.test.js       # orchestration, DB + gh both mocked
+```
+
+Both are wired into CI (`.github/workflows/test.yml`, job
+`kanban-github-sync-tests`) and require no live database or `gh` auth.

--- a/src/mcps/kanban-server/tools/github-sync-lib.js
+++ b/src/mcps/kanban-server/tools/github-sync-lib.js
@@ -1,0 +1,204 @@
+// src/mcps/kanban-server/tools/github-sync-lib.js
+// Pure, dependency-free logic for the GitHub sync poller (GH issue #64):
+// URL / "owner/repo#N" parsing, "Fixes #N"-style closing-keyword extraction,
+// card <-> event matching, and the conservative status-transition rule.
+//
+// Deliberately has NO gh CLI calls and NO database access -- everything here
+// is a pure function over plain objects so it can be unit tested without
+// mocking a subprocess or a Postgres connection (see
+// tests/kanban-server/github-sync-lib.test.js). The orchestration that wires
+// this up to `gh api` and the shared DatabaseManager lives in
+// ./github-sync.js.
+
+// Card statuses eligible to auto-complete. Conservative by design (S11 /
+// issue #64 spec): backlog/blocked/done/archived/claimed/ready are NEVER
+// touched by this poller, and a card never moves backwards.
+export const ELIGIBLE_STATUSES = ['in_progress', 'review'];
+
+// GitHub's own closing-keyword set (see "Linking a pull request to an issue"
+// docs): close, closes, closed, fix, fixes, fixed, resolve, resolves,
+// resolved. Matched case-insensitively.
+const CLOSE_KEYWORD_RE = /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?\s+([^\s,;]+)/gi;
+
+/**
+ * Parse a single GitHub reference string into { owner, repo, number, kind }.
+ * Accepts:
+ *   - Full URLs: https://github.com/owner/repo/issues/123 (with optional
+ *     trailing slash, query string, or #fragment; http or https; a bare
+ *     "github.com/..." with no scheme also matches).
+ *   - Shorthand: "owner/repo#123" (the convention used by kanban_cards.
+ *     issue_ref and kanban_card_links rows of link_type 'github_issue').
+ * `kind` is 'pr' | 'issue' for a URL match (the path segment tells us),
+ * or null for the shorthand form (ambiguous by design -- matching doesn't
+ * care whether the target is a PR or an issue, only that the number+repo
+ * agree, per issue #64 spec item 3).
+ * Returns null if the string isn't a recognizable GitHub ref at all (e.g. a
+ * 'spec' or 'file' link_type's ref, or plain prose).
+ */
+export function parseGithubRef(raw) {
+    if (!raw || typeof raw !== 'string') {
+        return null;
+    }
+    const str = raw.trim();
+
+    const urlMatch = str.match(
+        /github\.com\/([^\/\s]+)\/([^\/\s]+?)(?:\.git)?\/(issues|pull)\/(\d+)(?:[\/?#].*)?$/i
+    );
+    if (urlMatch) {
+        return {
+            owner: urlMatch[1],
+            repo: urlMatch[2],
+            number: parseInt(urlMatch[4], 10),
+            kind: urlMatch[3].toLowerCase() === 'pull' ? 'pr' : 'issue'
+        };
+    }
+
+    const shortMatch = str.match(/^([\w.-]+)\/([\w.-]+)#(\d+)$/);
+    if (shortMatch) {
+        return {
+            owner: shortMatch[1],
+            repo: shortMatch[2],
+            number: parseInt(shortMatch[3], 10),
+            kind: null
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Extract every "Fixes #N" / "Closes owner/repo#N" / "Resolves <url>"-style
+ * reference from a PR body, defaulting the owner/repo to the PR's own repo
+ * (context) when the token is a bare "#N". Dedupes by owner/repo#number.
+ * Only the token immediately following a closing keyword is captured --
+ * matches GitHub's own auto-close behavior (a comma-separated list like
+ * "Closes #12, #13" only auto-closes #12; #13 needs its own keyword), so
+ * this poller never over-claims a match GitHub itself wouldn't have made.
+ */
+export function extractClosingReferences(body, context = {}) {
+    if (!body || typeof body !== 'string') {
+        return [];
+    }
+
+    const results = [];
+    const seen = new Set();
+    CLOSE_KEYWORD_RE.lastIndex = 0;
+
+    let match;
+    while ((match = CLOSE_KEYWORD_RE.exec(body)) !== null) {
+        const token = match[2].replace(/[)\]>,.;!]+$/, '');
+        let ref = null;
+
+        if (/^#\d+$/.test(token)) {
+            if (context.owner && context.repo) {
+                ref = { owner: context.owner, repo: context.repo, number: parseInt(token.slice(1), 10) };
+            }
+        } else {
+            const parsed = parseGithubRef(token);
+            if (parsed) {
+                ref = { owner: parsed.owner, repo: parsed.repo, number: parsed.number };
+            }
+        }
+
+        if (ref) {
+            const key = `${ref.owner}/${ref.repo}#${ref.number}`.toLowerCase();
+            if (!seen.has(key)) {
+                seen.add(key);
+                results.push(ref);
+            }
+        }
+    }
+
+    return results;
+}
+
+/** owner/repo comparison is case-insensitive (GitHub repo slugs are). */
+export function refersToSameTarget(parsedRef, target) {
+    if (!parsedRef || !target) {
+        return false;
+    }
+    return (
+        parsedRef.owner.toLowerCase() === target.owner.toLowerCase() &&
+        parsedRef.repo.toLowerCase() === target.repo.toLowerCase() &&
+        parsedRef.number === target.number
+    );
+}
+
+/**
+ * Does this card reference ANY of the event's match targets? Checks, in
+ * order: the card's own issue_ref shorthand field, then its
+ * kanban_card_links rows of link_type 'url' or 'github_issue' (issue #64
+ * spec item 3a/3b). Returns the first match as
+ * { via: 'issue_ref'|'url'|'github_issue', ref, target } or null.
+ */
+export function cardMatchesTargets(card, targets) {
+    if (!Array.isArray(targets) || targets.length === 0) {
+        return null;
+    }
+
+    if (card.issue_ref) {
+        const parsed = parseGithubRef(card.issue_ref);
+        for (const target of targets) {
+            if (refersToSameTarget(parsed, target)) {
+                return { via: 'issue_ref', ref: card.issue_ref, target };
+            }
+        }
+    }
+
+    for (const link of card.links || []) {
+        if (link.link_type !== 'url' && link.link_type !== 'github_issue') {
+            continue;
+        }
+        const parsed = parseGithubRef(link.ref);
+        for (const target of targets) {
+            if (refersToSameTarget(parsed, target)) {
+                return { via: link.link_type, ref: link.ref, target };
+            }
+        }
+    }
+
+    return null;
+}
+
+/** Stable idempotency key for an event, stamped into metadata.github_sync. */
+export function buildEventKey(event) {
+    return `${event.kind}:${event.owner}/${event.repo}#${event.number}`;
+}
+
+/**
+ * Decide what (if anything) should happen to a card for a given event.
+ * card: { status, issue_ref, links: [{link_type, ref}], metadata }
+ * event: { kind: 'pr_merged'|'issue_closed', owner, repo, number, matchTargets }
+ *
+ * Returns one of:
+ *   { action: 'skip', reason: 'ineligible_status' }  -- backlog/blocked/done/
+ *       archived/claimed/ready are NEVER touched, regardless of match.
+ *   { action: 'skip', reason: 'no_match' }
+ *   { action: 'skip', reason: 'already_stamped', match }  -- idempotent rerun
+ *       guard: metadata.github_sync.event already equals this event's key.
+ *   { action: 'move', fromStatus, toStatus: 'done', match, eventKey }
+ */
+export function planCardTransition(card, event) {
+    if (!ELIGIBLE_STATUSES.includes(card.status)) {
+        return { action: 'skip', reason: 'ineligible_status' };
+    }
+
+    const match = cardMatchesTargets(card, event.matchTargets);
+    if (!match) {
+        return { action: 'skip', reason: 'no_match' };
+    }
+
+    const eventKey = buildEventKey(event);
+    const existingStamp = card.metadata && card.metadata.github_sync;
+    if (existingStamp && existingStamp.event === eventKey) {
+        return { action: 'skip', reason: 'already_stamped', match };
+    }
+
+    return {
+        action: 'move',
+        fromStatus: card.status,
+        toStatus: 'done',
+        match,
+        eventKey
+    };
+}

--- a/src/mcps/kanban-server/tools/github-sync.config.json
+++ b/src/mcps/kanban-server/tools/github-sync.config.json
@@ -1,0 +1,9 @@
+{
+    "watched_repos": [
+        "RLRyals/MCP-Electron-App",
+        "RLRyals/MCP-Writing-Servers",
+        "RLRyals/fictionlab-workflow"
+    ],
+    "dry_run_default": false,
+    "initial_lookback_hours": 24
+}

--- a/src/mcps/kanban-server/tools/github-sync.js
+++ b/src/mcps/kanban-server/tools/github-sync.js
@@ -1,0 +1,422 @@
+#!/usr/bin/env node
+// src/mcps/kanban-server/tools/github-sync.js
+// GitHub sync poller (GH issue #64): when a watched repo's PR merges or its
+// issue closes, auto-move the matching kanban card review/in_progress ->
+// done. A LOCAL scheduled-task script (not a server) -- see the issue body
+// for the architecture rationale (the fictionlab schema is local-only;
+// webhooks would need a public endpoint; this reuses the existing `gh` CLI
+// auth instead). Run on demand (`node github-sync.js --dry-run`) or every
+// 10-15 min via a Windows Scheduled Task -- see README.md "GitHub Sync"
+// section for the exact (NOT auto-registered) schtasks command.
+//
+// Reuses kanban-server's own conventions on purpose:
+//   - DB access: shared/database.js's DatabaseManager (same DATABASE_URL /
+//     .env convention as every other kanban-server entry point).
+//   - Activity log + NOTIFY: handlers/kanban-helpers.js's logActivity /
+//     notifyKanbanChanged -- the exact same functions every mutation tool
+//     uses, so this poller's moves show up in the activity feed identically
+//     to an agent's move_card call.
+//   - Matching/parsing/transition rules: pure logic in ./github-sync-lib.js
+//     (unit tested with a mocked DB in tests/kanban-server/).
+//
+// Safety: --dry-run performs ZERO writes (no UPDATE, no INSERT, no watermark
+// advance) and prints the plan. Any error (a bad `gh` call, a malformed PR
+// body, a DB hiccup) is caught per-repo/per-card, logged to
+// github-sync.log next to this script, and the run continues -- this must
+// never crash a scheduled task silently.
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+import { DatabaseManager } from '../../../shared/database.js';
+import { logActivity, notifyKanbanChanged } from '../handlers/kanban-helpers.js';
+import { extractClosingReferences, planCardTransition } from './github-sync-lib.js';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Defensive: load .env by absolute path so this still works when a
+// Scheduled Task invokes `node` from an arbitrary working directory (the
+// same reasoning as test/kanban-server/concurrent-claim-test.js).
+dotenv.config({ path: path.resolve(__dirname, '../../../../.env') });
+
+const DEFAULT_CONFIG_PATH = path.join(__dirname, 'github-sync.config.json');
+const DEFAULT_STATE_PATH = path.join(__dirname, 'github-sync.state.json');
+const DEFAULT_LOG_PATH = path.join(__dirname, 'github-sync.log');
+
+// ---------------------------------------------------------------------------
+// Config / state / logging (file I/O -- kept separate from the pure lib so
+// the lib stays trivially unit-testable).
+// ---------------------------------------------------------------------------
+
+export function loadConfig(configPath) {
+    if (!fs.existsSync(configPath)) {
+        throw new Error(`Config file not found: ${configPath}`);
+    }
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    if (!Array.isArray(parsed.watched_repos) || parsed.watched_repos.length === 0) {
+        throw new Error('Config watched_repos must be a non-empty array of "owner/repo" strings');
+    }
+    return {
+        watched_repos: parsed.watched_repos,
+        dry_run_default: parsed.dry_run_default === true,
+        initial_lookback_hours: Number.isFinite(parsed.initial_lookback_hours) ? parsed.initial_lookback_hours : 24
+    };
+}
+
+export function loadState(statePath) {
+    if (!fs.existsSync(statePath)) {
+        return {};
+    }
+    try {
+        return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    } catch {
+        return {};
+    }
+}
+
+export function saveState(statePath, state) {
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export function appendLog(logPath, line) {
+    const stamped = `[${new Date().toISOString()}] ${line}\n`;
+    try {
+        fs.appendFileSync(logPath, stamped, 'utf8');
+    } catch {
+        // Logging must never be the thing that crashes the poller.
+        process.stderr.write(stamped);
+    }
+}
+
+function computeInitialSince(hours) {
+    return new Date(Date.now() - hours * 3600 * 1000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// GitHub side: `gh api search/issues` (works for both PRs and issues -- the
+// search API treats a PR as an issue with a `pull_request` sub-object).
+// Wrapped behind a small client object so tests can inject a fake one with
+// zero subprocess/network dependency.
+// ---------------------------------------------------------------------------
+
+async function runGhSearch(query) {
+    const items = [];
+    const perPage = 100;
+    for (let page = 1; page <= 5; page++) {
+        // --method GET is required: gh api defaults to POST whenever -f/-F
+        // params are present, and search/issues is GET-only (a bare `gh api
+        // search/issues -f q=...` 404s -- discovered during the live
+        // --dry-run verification for this issue).
+        const { stdout } = await execFileAsync(
+            'gh',
+            [
+                'api',
+                'search/issues',
+                '--method',
+                'GET',
+                '-f',
+                `q=${query}`,
+                '-F',
+                `per_page=${perPage}`,
+                '-F',
+                `page=${page}`
+            ],
+            { maxBuffer: 10 * 1024 * 1024 }
+        );
+        const parsed = JSON.parse(stdout);
+        const pageItems = parsed.items || [];
+        items.push(...pageItems);
+        if (pageItems.length < perPage) {
+            break;
+        }
+    }
+    return items;
+}
+
+export function createGhClient() {
+    return {
+        async searchMergedPRs(repoFullName, since) {
+            return runGhSearch(`repo:${repoFullName} is:pr is:merged merged:>${since}`);
+        },
+        async searchClosedIssues(repoFullName, since) {
+            return runGhSearch(`repo:${repoFullName} is:issue is:closed closed:>${since}`);
+        }
+    };
+}
+
+function toEvents(items, repoFullName, kind) {
+    const [owner, repo] = repoFullName.split('/');
+    return items.map((item) => {
+        const matchTargets = [{ owner, repo, number: item.number }];
+        if (kind === 'pr_merged') {
+            for (const ref of extractClosingReferences(item.body || '', { owner, repo })) {
+                matchTargets.push(ref);
+            }
+        }
+        return {
+            kind,
+            owner,
+            repo,
+            number: item.number,
+            url: item.html_url,
+            title: item.title,
+            matchTargets
+        };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// DB side: fetch candidate cards (only in_progress/review are ever eligible
+// -- see github-sync-lib.js ELIGIBLE_STATUSES), and apply a planned move.
+// ---------------------------------------------------------------------------
+
+export async function fetchCandidateCards(db) {
+    const result = await db.query(
+        `SELECT c.id, c.board_id, c.status, c.issue_ref, c.metadata,
+                COALESCE(
+                    (SELECT json_agg(json_build_object('link_type', l.link_type, 'ref', l.ref))
+                     FROM fictionlab.kanban_card_links l
+                     WHERE l.card_id = c.id AND l.link_type IN ('url', 'github_issue')),
+                    '[]'
+                ) AS links
+         FROM fictionlab.kanban_cards c
+         WHERE c.status IN ('in_progress', 'review')`
+    );
+    return result.rows.map((row) => ({
+        ...row,
+        links: typeof row.links === 'string' ? JSON.parse(row.links) : row.links || [],
+        metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata || {}
+    }));
+}
+
+/**
+ * Apply one planned move: UPDATE guarded by WHERE status = fromStatus (loses
+ * gracefully to any concurrent change instead of clobbering it -- returns
+ * null rather than throwing), stamp metadata.github_sync for idempotency,
+ * write the kanban_activity row via the SAME logActivity() every other
+ * kanban-server tool uses, and NOTIFY like every other mutation.
+ */
+export async function applyTransition(db, card, transition, event, { actor = 'github-sync' } = {}) {
+    const stamp = { event: transition.eventKey, url: event.url, at: new Date().toISOString() };
+
+    const result = await db.query(
+        `UPDATE fictionlab.kanban_cards
+            SET status = $1,
+                metadata = metadata || $2::jsonb
+         WHERE id = $3 AND status = $4
+         RETURNING *`,
+        ['done', JSON.stringify({ github_sync: stamp }), card.id, transition.fromStatus]
+    );
+
+    if (result.rows.length === 0) {
+        // Card's status changed between fetch and write (e.g. an agent moved
+        // it in the meantime) -- do nothing, this is not our race to win.
+        return null;
+    }
+
+    const updated = result.rows[0];
+    const eventNoun = event.kind === 'pr_merged' ? 'PR' : 'issue';
+    const eventVerb = event.kind === 'pr_merged' ? 'merged' : 'closed';
+
+    await logActivity(db, {
+        boardId: updated.board_id,
+        cardId: updated.id,
+        actor,
+        action: 'auto-moved',
+        fromStatus: transition.fromStatus,
+        toStatus: 'done',
+        detail: {
+            reason: `${eventNoun} #${event.number} ${eventVerb}`,
+            event: transition.eventKey,
+            url: event.url,
+            title: event.title,
+            matched_via: transition.match.via,
+            matched_ref: transition.match.ref
+        }
+    });
+    await notifyKanbanChanged(db, updated.id);
+
+    return updated;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration -- injectable db/ghClient so this is unit-testable with a
+// fully mocked DB and a canned gh response (see
+// tests/kanban-server/github-sync.test.js). dryRun performs the exact same
+// matching/plan-building but skips the write loop entirely.
+// ---------------------------------------------------------------------------
+
+export async function runSync({ db, ghClient, config, since, dryRun, log = () => {} }) {
+    const cards = await fetchCandidateCards(db);
+    const planned = [];
+    const errors = [];
+
+    for (const repoFullName of config.watched_repos) {
+        try {
+            const mergedItems = await ghClient.searchMergedPRs(repoFullName, since);
+            for (const event of toEvents(mergedItems, repoFullName, 'pr_merged')) {
+                for (const card of cards) {
+                    const transition = planCardTransition(card, event);
+                    if (transition.action === 'move') {
+                        planned.push({ card, event, transition });
+                    }
+                }
+            }
+        } catch (error) {
+            errors.push({ repo: repoFullName, phase: 'merged_prs', error: error.message });
+            log(`ERROR searching merged PRs for ${repoFullName}: ${error.message}`);
+        }
+
+        try {
+            const closedItems = await ghClient.searchClosedIssues(repoFullName, since);
+            for (const event of toEvents(closedItems, repoFullName, 'issue_closed')) {
+                for (const card of cards) {
+                    const transition = planCardTransition(card, event);
+                    if (transition.action === 'move') {
+                        planned.push({ card, event, transition });
+                    }
+                }
+            }
+        } catch (error) {
+            errors.push({ repo: repoFullName, phase: 'closed_issues', error: error.message });
+            log(`ERROR searching closed issues for ${repoFullName}: ${error.message}`);
+        }
+    }
+
+    // A card can match more than one event in the same run (its own PR
+    // merges AND a different merged PR's "Fixes #N" hits the same linked
+    // issue) -- only move it once per run; first match wins.
+    const seenCardIds = new Set();
+    const plan = [];
+    for (const item of planned) {
+        if (seenCardIds.has(item.card.id)) {
+            continue;
+        }
+        seenCardIds.add(item.card.id);
+        plan.push(item);
+    }
+
+    const moved = [];
+    if (!dryRun) {
+        for (const item of plan) {
+            try {
+                const updated = await applyTransition(db, item.card, item.transition, item.event);
+                if (updated) {
+                    moved.push({ ...item, updated });
+                }
+            } catch (error) {
+                errors.push({ card_id: item.card.id, phase: 'apply_transition', error: error.message });
+                log(`ERROR applying transition for card ${item.card.id}: ${error.message}`);
+            }
+        }
+    }
+
+    return { plan, moved, errors };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+    const args = { dryRun: false, verbose: false };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--dry-run') args.dryRun = true;
+        else if (a === '--verbose') args.verbose = true;
+        else if (a === '--config') args.config = argv[++i];
+        else if (a === '--state') args.state = argv[++i];
+        else if (a === '--log') args.log = argv[++i];
+        else if (a === '--since') args.since = argv[++i];
+    }
+    return args;
+}
+
+function describePlanItem(item, dryRun, moved) {
+    const wasMoved = moved.some((m) => m.card.id === item.card.id);
+    const verb = dryRun ? 'WOULD MOVE' : wasMoved ? 'MOVED' : 'SKIPPED (race)';
+    const eventNoun = item.event.kind === 'pr_merged' ? 'PR' : 'issue';
+    const eventVerb = item.event.kind === 'pr_merged' ? 'merged' : 'closed';
+    return (
+        `  [${verb}] card ${item.card.id} (${item.transition.fromStatus} -> done) ` +
+        `via ${item.transition.match.via}=${item.transition.match.ref} -- ` +
+        `${eventNoun} #${item.event.number} ${eventVerb} in ${item.event.owner}/${item.event.repo} (${item.event.url})`
+    );
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const configPath = args.config || DEFAULT_CONFIG_PATH;
+    const statePath = args.state || DEFAULT_STATE_PATH;
+    const logPath = args.log || DEFAULT_LOG_PATH;
+    const log = (line) => appendLog(logPath, line);
+
+    let db;
+    try {
+        const config = loadConfig(configPath);
+        const dryRun = args.dryRun || config.dry_run_default;
+        const state = loadState(statePath);
+        const since = args.since || state.last_run_at || computeInitialSince(config.initial_lookback_hours);
+        const runStartedAt = new Date().toISOString();
+
+        db = new DatabaseManager();
+        const ghClient = createGhClient();
+
+        const { plan, moved, errors } = await runSync({ db, ghClient, config, since, dryRun, log });
+
+        console.log(
+            `github-sync: since=${since} dryRun=${dryRun} watched_repos=[${config.watched_repos.join(', ')}]`
+        );
+        console.log(`github-sync: ${plan.length} card(s) matched an eligible transition.`);
+        for (const item of plan) {
+            console.log(describePlanItem(item, dryRun, moved));
+        }
+        if (errors.length > 0) {
+            console.log(`github-sync: ${errors.length} error(s) occurred -- see ${logPath}`);
+            if (args.verbose) {
+                for (const e of errors) console.log(`  ERROR: ${JSON.stringify(e)}`);
+            }
+        }
+
+        if (dryRun) {
+            console.log('github-sync: --dry-run, watermark NOT advanced, zero writes performed.');
+        } else {
+            saveState(statePath, { last_run_at: runStartedAt, last_run_completed_at: new Date().toISOString() });
+            console.log(`github-sync: watermark advanced to ${runStartedAt}`);
+        }
+    } catch (error) {
+        log(`FATAL: ${error.stack || error.message}`);
+        console.error(`github-sync: fatal error (logged to ${logPath}): ${error.message}`);
+        process.exitCode = 1;
+    } finally {
+        if (db) {
+            await db.close().catch(() => {});
+        }
+    }
+}
+
+// Cross-platform (Windows file:// URL) direct-execution guard -- same
+// pattern as src/mcps/kanban-server/index.js, so this also behaves when
+// imported (by tests) vs run directly (by a Scheduled Task or the CLI).
+const normalizePath = (p) => {
+    if (!p) return '';
+    let normalized = p.replace(/\\/g, '/');
+    if (!normalized.startsWith('file:')) {
+        normalized = process.platform === 'win32' ? `file:///${normalized}` : `file://${normalized}`;
+    }
+    return normalized.replace(/^file:\/+/, 'file:///');
+};
+
+const normalizedScriptPath = normalizePath(process.argv[1]);
+const normalizedModuleUrl = import.meta.url.replace(/\/{3,}/g, '///').replace(/^file:\/([^\/])/, 'file:///$1');
+const isDirectExecution =
+    normalizedModuleUrl === normalizedScriptPath || decodeURIComponent(normalizedModuleUrl) === normalizedScriptPath;
+
+if (isDirectExecution) {
+    main();
+}

--- a/tests/kanban-server/github-sync-lib.test.js
+++ b/tests/kanban-server/github-sync-lib.test.js
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+// tests/kanban-server/github-sync-lib.test.js
+// Unit tests for the GH issue #64 GitHub sync poller's pure logic: URL /
+// "owner/repo#N" parsing, "Fixes #N"-style closing-keyword extraction, card
+// <-> event matching, and the conservative status-transition rule. No DB, no
+// gh CLI, no network -- see src/mcps/kanban-server/tools/github-sync-lib.js.
+//
+// Style note: this repo's tests/ dir uses a global describe/it runner
+// (tests/database-admin-server/run-tests.js) that does NOT await test
+// bodies, which would silently mis-report any async assertion. Everything
+// in github-sync-lib.js is synchronous/pure, so that's not an issue here,
+// but this file follows the simpler PASS/FAIL counter convention already
+// established by test/kanban-server/smoke-test.js (this repo's other
+// self-contained pass/fail script) for consistency with the sibling
+// orchestration-level test file (github-sync.test.js), which IS async.
+//
+// Run: node tests/kanban-server/github-sync-lib.test.js
+
+import {
+    parseGithubRef,
+    extractClosingReferences,
+    refersToSameTarget,
+    cardMatchesTargets,
+    buildEventKey,
+    planCardTransition,
+    ELIGIBLE_STATUSES
+} from '../../src/mcps/kanban-server/tools/github-sync-lib.js';
+
+let pass = 0;
+let fail = 0;
+
+function check(label, condition, detail) {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        pass++;
+    } else {
+        console.log(`  FAIL  ${label}${detail ? ' -- ' + detail : ''}`);
+        fail++;
+    }
+}
+
+console.log('github-sync-lib.test.js\n');
+
+// ---------------------------------------------------------------------------
+// parseGithubRef
+// ---------------------------------------------------------------------------
+console.log('parseGithubRef');
+
+{
+    const r = parseGithubRef('RLRyals/MCP-Writing-Servers#64');
+    check('shorthand owner/repo#N parses', !!r);
+    check('shorthand owner', r?.owner === 'RLRyals');
+    check('shorthand repo', r?.repo === 'MCP-Writing-Servers');
+    check('shorthand number is an integer', r?.number === 64);
+    check('shorthand kind is null (ambiguous by design)', r?.kind === null);
+}
+
+{
+    const r = parseGithubRef('https://github.com/RLRyals/MCP-Electron-App/pull/199');
+    check('PR URL parses', !!r);
+    check('PR URL owner/repo', r?.owner === 'RLRyals' && r?.repo === 'MCP-Electron-App');
+    check('PR URL number', r?.number === 199);
+    check("PR URL kind='pr'", r?.kind === 'pr');
+}
+
+{
+    const r = parseGithubRef('https://github.com/RLRyals/MCP-Electron-App/issues/42');
+    check('issue URL parses', !!r);
+    check("issue URL kind='issue'", r?.kind === 'issue');
+    check('issue URL number', r?.number === 42);
+}
+
+{
+    const r = parseGithubRef('https://github.com/RLRyals/MCP-Electron-App/pull/199#issuecomment-12345');
+    check('PR URL with trailing #fragment still parses', !!r && r.number === 199);
+}
+
+{
+    const r = parseGithubRef('https://github.com/RLRyals/MCP-Electron-App/pull/199/files');
+    check('PR URL with trailing /files still parses', !!r && r.number === 199);
+}
+
+{
+    const r = parseGithubRef('github.com/RLRyals/MCP-Electron-App/issues/7');
+    check('bare github.com/... (no scheme) still parses', !!r && r.number === 7);
+}
+
+check('null ref returns null', parseGithubRef(null) === null);
+check('empty string returns null', parseGithubRef('') === null);
+check('unrelated URL returns null', parseGithubRef('https://example.com/foo/bar') === null);
+check('plain prose returns null', parseGithubRef('see the spec doc') === null);
+check('bare #123 (no owner/repo) returns null -- ambiguous, not our convention', parseGithubRef('#123') === null);
+
+// ---------------------------------------------------------------------------
+// extractClosingReferences ("Fixes #N" etc in a PR body)
+// ---------------------------------------------------------------------------
+console.log('\nextractClosingReferences');
+
+{
+    const refs = extractClosingReferences('This PR does the thing.\n\nFixes #64.', {
+        owner: 'RLRyals',
+        repo: 'MCP-Writing-Servers'
+    });
+    check('"Fixes #64." extracts one ref (trailing period stripped)', refs.length === 1, JSON.stringify(refs));
+    check('extracted ref defaults to context owner/repo', refs[0]?.owner === 'RLRyals' && refs[0]?.repo === 'MCP-Writing-Servers');
+    check('extracted ref number', refs[0]?.number === 64);
+}
+
+{
+    const cases = ['Closes #5', 'closed #5', 'Fix #5', 'fixes #5', 'FIXED #5', 'Resolve #5', 'resolves #5', 'Resolved #5'];
+    for (const body of cases) {
+        const refs = extractClosingReferences(body, { owner: 'o', repo: 'r' });
+        check(`keyword variant "${body}" extracts #5`, refs.length === 1 && refs[0].number === 5, JSON.stringify(refs));
+    }
+}
+
+{
+    const refs = extractClosingReferences('Closes: #12', { owner: 'o', repo: 'r' });
+    check('keyword with colon ("Closes: #12") still extracts', refs.length === 1 && refs[0].number === 12);
+}
+
+{
+    const refs = extractClosingReferences('Fixes owner2/repo2#99 while here', { owner: 'o', repo: 'r' });
+    check('cross-repo shorthand "Fixes owner2/repo2#99" overrides context', refs.length === 1);
+    check('cross-repo owner/repo captured, not context', refs[0]?.owner === 'owner2' && refs[0]?.repo === 'repo2');
+}
+
+{
+    const refs = extractClosingReferences('Resolves https://github.com/o2/r2/issues/8 (see thread)', {
+        owner: 'o',
+        repo: 'r'
+    });
+    check('closing keyword followed by a full URL extracts that target', refs.length === 1 && refs[0].number === 8, JSON.stringify(refs));
+    check('URL-form closing ref owner/repo taken from the URL, not context', refs[0]?.owner === 'o2' && refs[0]?.repo === 'r2');
+}
+
+{
+    // Matches GitHub's own behavior: only the token immediately after the
+    // keyword is a real closing reference -- "Closes #12, #13" only closes
+    // #12 on GitHub itself.
+    const refs = extractClosingReferences('Closes #12, #13 and #14', { owner: 'o', repo: 'r' });
+    check('comma-separated list only captures the token right after the keyword', refs.length === 1 && refs[0].number === 12, JSON.stringify(refs));
+}
+
+{
+    const refs = extractClosingReferences('Fixes #9 and also fixes #9 again', { owner: 'o', repo: 'r' });
+    check('duplicate refs are deduped', refs.length === 1);
+}
+
+{
+    const refs = extractClosingReferences('Fixes #1. Also closes #2!', { owner: 'o', repo: 'r' });
+    check('multiple distinct keyword occurrences all extracted', refs.length === 2, JSON.stringify(refs));
+    check('both numbers present', refs.some((r) => r.number === 1) && refs.some((r) => r.number === 2));
+}
+
+check('empty body returns []', extractClosingReferences('', { owner: 'o', repo: 'r' }).length === 0);
+check('null body returns []', extractClosingReferences(null, { owner: 'o', repo: 'r' }).length === 0);
+check(
+    'body with no closing keywords returns []',
+    extractClosingReferences('Just a description, no linkage here.', { owner: 'o', repo: 'r' }).length === 0
+);
+check(
+    'a bare #N with no owner/repo context is dropped (never guesses a repo)',
+    extractClosingReferences('Fixes #64', {}).length === 0
+);
+
+// ---------------------------------------------------------------------------
+// refersToSameTarget
+// ---------------------------------------------------------------------------
+console.log('\nrefersToSameTarget');
+
+check(
+    'same owner/repo/number (different case) matches -- repo slugs are case-insensitive',
+    refersToSameTarget(
+        { owner: 'RLRyals', repo: 'MCP-Electron-App', number: 199 },
+        { owner: 'rlryals', repo: 'mcp-electron-app', number: 199 }
+    )
+);
+check(
+    'different number does not match',
+    !refersToSameTarget({ owner: 'o', repo: 'r', number: 1 }, { owner: 'o', repo: 'r', number: 2 })
+);
+check(
+    'different repo does not match',
+    !refersToSameTarget({ owner: 'o', repo: 'r1', number: 1 }, { owner: 'o', repo: 'r2', number: 1 })
+);
+check('null parsedRef never matches', !refersToSameTarget(null, { owner: 'o', repo: 'r', number: 1 }));
+
+// ---------------------------------------------------------------------------
+// cardMatchesTargets
+// ---------------------------------------------------------------------------
+console.log('\ncardMatchesTargets');
+
+{
+    const targets = [{ owner: 'RLRyals', repo: 'MCP-Electron-App', number: 199 }];
+
+    const viaIssueRef = cardMatchesTargets({ issue_ref: 'RLRyals/MCP-Electron-App#199', links: [] }, targets);
+    check("matches via card's own issue_ref shorthand", viaIssueRef?.via === 'issue_ref');
+
+    const viaGithubIssueLink = cardMatchesTargets(
+        { links: [{ link_type: 'github_issue', ref: 'RLRyals/MCP-Electron-App#199' }] },
+        targets
+    );
+    check("matches via a 'github_issue' link", viaGithubIssueLink?.via === 'github_issue');
+
+    const viaUrlLink = cardMatchesTargets(
+        { links: [{ link_type: 'url', ref: 'https://github.com/RLRyals/MCP-Electron-App/pull/199' }] },
+        targets
+    );
+    check("matches via a 'url' link", viaUrlLink?.via === 'url');
+
+    const viaSpecLink = cardMatchesTargets(
+        { links: [{ link_type: 'spec', ref: 'RLRyals/MCP-Electron-App#199' }] },
+        targets
+    );
+    check("a 'spec' link_type is NOT considered a GitHub sync source", viaSpecLink === null);
+
+    const noMatch = cardMatchesTargets({ issue_ref: 'RLRyals/MCP-Electron-App#1' }, targets);
+    check('no match returns null', noMatch === null);
+
+    const noTargets = cardMatchesTargets({ issue_ref: 'RLRyals/MCP-Electron-App#199' }, []);
+    check('empty targets array returns null', noTargets === null);
+}
+
+{
+    // Issue #64 acceptance criterion: "A PR whose body says 'Fixes #N' also
+    // completes cards that reference issue N."
+    const targets = [
+        { owner: 'RLRyals', repo: 'MCP-Writing-Servers', number: 71 }, // the PR itself
+        { owner: 'RLRyals', repo: 'MCP-Writing-Servers', number: 64 } // "Fixes #64" in its body
+    ];
+    const cardOnTheIssue = cardMatchesTargets({ issue_ref: 'RLRyals/MCP-Writing-Servers#64' }, targets);
+    check('a card linked to the closed ISSUE matches a PR event via its "Fixes #N" target', cardOnTheIssue?.via === 'issue_ref');
+}
+
+// ---------------------------------------------------------------------------
+// buildEventKey / planCardTransition
+// ---------------------------------------------------------------------------
+console.log('\nplanCardTransition');
+
+check(
+    'buildEventKey is stable and includes kind/owner/repo/number',
+    buildEventKey({ kind: 'pr_merged', owner: 'RLRyals', repo: 'MCP-Electron-App', number: 199 }) ===
+        'pr_merged:RLRyals/MCP-Electron-App#199'
+);
+
+const matchingEvent = {
+    kind: 'pr_merged',
+    owner: 'RLRyals',
+    repo: 'MCP-Electron-App',
+    number: 199,
+    matchTargets: [{ owner: 'RLRyals', repo: 'MCP-Electron-App', number: 199 }]
+};
+
+for (const status of ELIGIBLE_STATUSES) {
+    const card = { status, issue_ref: 'RLRyals/MCP-Electron-App#199', metadata: {} };
+    const plan = planCardTransition(card, matchingEvent);
+    check(`status='${status}' + a match -> action='move'`, plan.action === 'move', JSON.stringify(plan));
+    check(`status='${status}' move sets toStatus='done'`, plan.toStatus === 'done');
+    check(`status='${status}' move preserves fromStatus`, plan.fromStatus === status);
+}
+
+for (const status of ['backlog', 'ready', 'claimed', 'blocked', 'done', 'archived']) {
+    const card = { status, issue_ref: 'RLRyals/MCP-Electron-App#199', metadata: {} };
+    const plan = planCardTransition(card, matchingEvent);
+    check(
+        `status='${status}' is NEVER touched even with a match (conservative rule)`,
+        plan.action === 'skip' && plan.reason === 'ineligible_status',
+        JSON.stringify(plan)
+    );
+}
+
+{
+    const card = { status: 'in_progress', issue_ref: 'RLRyals/MCP-Electron-App#1', metadata: {} };
+    const plan = planCardTransition(card, matchingEvent);
+    check('eligible status but no matching ref -> skip/no_match', plan.action === 'skip' && plan.reason === 'no_match');
+}
+
+{
+    // Idempotency: a card already stamped with this exact event must be
+    // skipped even though its status is still eligible (belt-and-suspenders
+    // on top of the status gate itself, per issue #64 spec item 4).
+    const eventKey = buildEventKey(matchingEvent);
+    const card = {
+        status: 'review',
+        issue_ref: 'RLRyals/MCP-Electron-App#199',
+        metadata: { github_sync: { event: eventKey, url: 'https://github.com/RLRyals/MCP-Electron-App/pull/199', at: '2026-07-08T00:00:00Z' } }
+    };
+    const plan = planCardTransition(card, matchingEvent);
+    check('already-stamped card with the SAME event is skipped (idempotent rerun)', plan.action === 'skip' && plan.reason === 'already_stamped', JSON.stringify(plan));
+}
+
+{
+    // A DIFFERENT event should still be evaluated on its own merits even if
+    // the card carries a stamp from a prior, different event -- but since a
+    // card only carries a "review"/"in_progress" status while unresolved,
+    // and moving to done for event A makes status ineligible for event B,
+    // this mostly matters for two events landing on the same card within a
+    // single run (see github-sync.test.js's de-dupe-in-one-run coverage).
+    // Here we assert the stamp comparison itself is event-specific.
+    const otherEvent = { ...matchingEvent, number: 200, matchTargets: [{ owner: 'RLRyals', repo: 'MCP-Electron-App', number: 200 }] };
+    const card = {
+        status: 'review',
+        links: [{ link_type: 'github_issue', ref: 'RLRyals/MCP-Electron-App#200' }],
+        metadata: { github_sync: { event: buildEventKey(matchingEvent), url: 'x', at: 'y' } }
+    };
+    const plan = planCardTransition(card, otherEvent);
+    check('a stamp from a DIFFERENT event does not block a new, distinct match', plan.action === 'move', JSON.stringify(plan));
+}
+
+// ---------------------------------------------------------------------------
+console.log(`\n${pass} passed, ${fail} failed. (github-sync-lib.test.js)`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/kanban-server/github-sync.test.js
+++ b/tests/kanban-server/github-sync.test.js
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+// tests/kanban-server/github-sync.test.js
+// Orchestration-level tests for the GH issue #64 GitHub sync poller. The DB
+// is a hand-rolled in-memory fake (no real Postgres connection anywhere in
+// this file -- see the HARD SAFETY RULE in the issue: automated tests must
+// mock the DB) and the gh CLI is a fake client returning canned search
+// results, so this exercises runSync()/applyTransition() end to end without
+// touching a subprocess or a network call.
+//
+// Run: node tests/kanban-server/github-sync.test.js
+
+import {
+    runSync,
+    fetchCandidateCards,
+    applyTransition
+} from '../../src/mcps/kanban-server/tools/github-sync.js';
+import { buildEventKey } from '../../src/mcps/kanban-server/tools/github-sync-lib.js';
+
+let pass = 0;
+let fail = 0;
+
+function check(label, condition, detail) {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        pass++;
+    } else {
+        console.log(`  FAIL  ${label}${detail ? ' -- ' + detail : ''}`);
+        fail++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fake DB: enough of the pg.Pool-shaped `.query(text, params)` surface that
+// kanban-helpers.js's logActivity/notifyKanbanChanged and this module's own
+// queries work unmodified against production code, backed by a plain JS
+// array of "rows" instead of a real connection.
+// ---------------------------------------------------------------------------
+
+function makeFakeDb(initialCards) {
+    // initialCards: [{ id, board_id, status, issue_ref, metadata, links: [{link_type, ref}] }]
+    const cards = initialCards.map((c) => ({ ...c, metadata: c.metadata || {} }));
+    const activity = [];
+    const notifications = [];
+    const calls = []; // every query text seen, for write-count assertions
+
+    return {
+        cards,
+        activity,
+        notifications,
+        calls,
+        async query(text, params = []) {
+            calls.push(text.trim());
+
+            // fetchCandidateCards: SELECT ... FROM fictionlab.kanban_cards c WHERE c.status IN ('in_progress', 'review')
+            if (text.includes('FROM fictionlab.kanban_cards c') && text.includes("WHERE c.status IN ('in_progress', 'review')")) {
+                const rows = cards
+                    .filter((c) => c.status === 'in_progress' || c.status === 'review')
+                    .map((c) => ({
+                        id: c.id,
+                        board_id: c.board_id,
+                        status: c.status,
+                        issue_ref: c.issue_ref || null,
+                        metadata: c.metadata,
+                        links: c.links || []
+                    }));
+                return { rows };
+            }
+
+            // applyTransition: UPDATE fictionlab.kanban_cards SET status = $1, metadata = metadata || $2::jsonb WHERE id = $3 AND status = $4 RETURNING *
+            if (text.startsWith('UPDATE fictionlab.kanban_cards')) {
+                const [newStatus, metadataPatchJson, cardId, expectedFromStatus] = params;
+                const card = cards.find((c) => c.id === cardId);
+                if (!card || card.status !== expectedFromStatus) {
+                    return { rows: [] }; // guarded UPDATE ... WHERE status=$4 found no row -- simulates a lost race
+                }
+                const patch = JSON.parse(metadataPatchJson);
+                card.status = newStatus;
+                card.metadata = { ...card.metadata, ...patch };
+                return { rows: [{ ...card }] };
+            }
+
+            // logActivity: INSERT INTO fictionlab.kanban_activity (...)
+            if (text.includes('INSERT INTO fictionlab.kanban_activity')) {
+                const [boardId, cardId, actor, action, fromStatus, toStatus, detail] = params;
+                activity.push({ boardId, cardId, actor, action, fromStatus, toStatus, detail: JSON.parse(detail) });
+                return { rows: [] };
+            }
+
+            // notifyKanbanChanged: SELECT pg_notify($1, $2)
+            if (text.includes('pg_notify')) {
+                notifications.push(params[1]);
+                return { rows: [] };
+            }
+
+            throw new Error(`makeFakeDb: unhandled query: ${text}`);
+        }
+    };
+}
+
+function makeFakeGhClient({ mergedByRepo = {}, closedByRepo = {} } = {}) {
+    return {
+        async searchMergedPRs(repoFullName) {
+            return mergedByRepo[repoFullName] || [];
+        },
+        async searchClosedIssues(repoFullName) {
+            return closedByRepo[repoFullName] || [];
+        }
+    };
+}
+
+function pr(number, { body = '', title = `PR #${number}` } = {}) {
+    return {
+        number,
+        title,
+        body,
+        html_url: `https://github.com/RLRyals/MCP-Electron-App/pull/${number}`
+    };
+}
+
+function issue(number, { title = `Issue #${number}` } = {}) {
+    return {
+        number,
+        title,
+        body: '',
+        html_url: `https://github.com/RLRyals/MCP-Electron-App/issues/${number}`
+    };
+}
+
+const config = { watched_repos: ['RLRyals/MCP-Electron-App'] };
+const NOOP_LOG = () => {};
+
+async function main() {
+    console.log('github-sync.test.js\n');
+
+    // -----------------------------------------------------------------
+    // 1. A card linked (via github_issue link) to a merged PR moves
+    //    review -> done, with an activity row and a NOTIFY.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            {
+                id: 'card-1',
+                board_id: 'board-1',
+                status: 'review',
+                links: [{ link_type: 'github_issue', ref: 'RLRyals/MCP-Electron-App#199' }]
+            }
+        ]);
+        const gh = makeFakeGhClient({ mergedByRepo: { 'RLRyals/MCP-Electron-App': [pr(199)] } });
+
+        const { plan, moved, errors } = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: false, log: NOOP_LOG });
+
+        check('linked card is planned for a move', plan.length === 1);
+        check('linked card was actually moved', moved.length === 1);
+        check('no errors', errors.length === 0, JSON.stringify(errors));
+        check("card status is now 'done'", db.cards[0].status === 'done');
+        check(
+            'metadata.github_sync stamp was written',
+            db.cards[0].metadata.github_sync?.event === 'pr_merged:RLRyals/MCP-Electron-App#199'
+        );
+        check('exactly one activity row was written', db.activity.length === 1);
+        check("activity action is 'auto-moved'", db.activity[0].action === 'auto-moved');
+        check("activity from_status='review', to_status='done'", db.activity[0].fromStatus === 'review' && db.activity[0].toStatus === 'done');
+        check('exactly one NOTIFY was emitted', db.notifications.length === 1 && db.notifications[0] === 'card-1');
+    }
+
+    // -----------------------------------------------------------------
+    // 2. "Fixes #N" in a merged PR body completes a card that references
+    //    the ISSUE, not the PR itself.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            {
+                id: 'card-2',
+                board_id: 'board-1',
+                status: 'in_progress',
+                issue_ref: 'RLRyals/MCP-Electron-App#64'
+            }
+        ]);
+        const gh = makeFakeGhClient({
+            mergedByRepo: { 'RLRyals/MCP-Electron-App': [pr(201, { body: 'Implements the feature.\n\nFixes #64.' })] }
+        });
+
+        const { moved, errors } = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: false, log: NOOP_LOG });
+
+        check('"Fixes #64" in PR #201 body completes the card referencing issue #64', moved.length === 1, JSON.stringify(errors));
+        check("card status is now 'done'", db.cards[0].status === 'done');
+        check(
+            'stamp records the PR-merged event (not a separate issue-closed event)',
+            db.cards[0].metadata.github_sync?.event === 'pr_merged:RLRyals/MCP-Electron-App#201'
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // 3. Conservative transition: backlog/blocked/done/archived cards are
+    //    NEVER touched even when they match.
+    // -----------------------------------------------------------------
+    {
+        const untouchable = ['backlog', 'ready', 'claimed', 'blocked', 'done', 'archived'];
+        const db = makeFakeDb(
+            untouchable.map((status, i) => ({
+                id: `card-untouch-${i}`,
+                board_id: 'board-1',
+                status,
+                issue_ref: 'RLRyals/MCP-Electron-App#199'
+            }))
+        );
+        const gh = makeFakeGhClient({ mergedByRepo: { 'RLRyals/MCP-Electron-App': [pr(199)] } });
+
+        const { plan, moved } = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: false, log: NOOP_LOG });
+
+        check('no backlog/ready/claimed/blocked/done/archived card is ever planned', plan.length === 0, JSON.stringify(plan));
+        check('no writes happened for untouchable cards', moved.length === 0);
+        check(
+            'every untouchable card retains its original status unchanged',
+            untouchable.every((status, i) => db.cards[i].status === status)
+        );
+        check('zero UPDATE queries were issued at all', db.calls.every((c) => !c.startsWith('UPDATE')));
+    }
+
+    // -----------------------------------------------------------------
+    // 4. --dry-run performs ZERO writes (no UPDATE, no INSERT activity, no
+    //    NOTIFY) but still reports the plan.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            {
+                id: 'card-3',
+                board_id: 'board-1',
+                status: 'review',
+                issue_ref: 'RLRyals/MCP-Electron-App#202'
+            }
+        ]);
+        const gh = makeFakeGhClient({ mergedByRepo: { 'RLRyals/MCP-Electron-App': [pr(202)] } });
+
+        const { plan, moved, errors } = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: true, log: NOOP_LOG });
+
+        check('dry-run still reports the card in the plan', plan.length === 1);
+        check('dry-run performs no actual moves', moved.length === 0);
+        check('dry-run has no errors', errors.length === 0);
+        check("dry-run leaves card status untouched ('review')", db.cards[0].status === 'review');
+        check('dry-run issues zero UPDATE queries', !db.calls.some((c) => c.startsWith('UPDATE')));
+        check('dry-run writes zero activity rows', db.activity.length === 0);
+        check('dry-run emits zero NOTIFYs', db.notifications.length === 0);
+    }
+
+    // -----------------------------------------------------------------
+    // 5. Idempotent rerun: running twice with the same event does not
+    //    double-move or double-log a card already stamped.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            {
+                id: 'card-4',
+                board_id: 'board-1',
+                status: 'in_progress',
+                issue_ref: 'RLRyals/MCP-Electron-App#203'
+            }
+        ]);
+        const gh = makeFakeGhClient({ mergedByRepo: { 'RLRyals/MCP-Electron-App': [pr(203)] } });
+
+        const first = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: false, log: NOOP_LOG });
+        check('first run moves the card', first.moved.length === 1);
+
+        // Second run against an OVERLAPPING window (e.g. a watermark that
+        // didn't advance because the previous run crashed before saving
+        // state) re-fetches the same merged PR. The card is now 'done', so
+        // the status gate alone would already protect it -- but assert the
+        // stamp-based guard reports the right skip reason as well by
+        // re-running planCardTransition against the post-move card state.
+        const second = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: false, log: NOOP_LOG });
+        check('second run (rerun, overlapping window) plans nothing new', second.plan.length === 0, JSON.stringify(second.plan));
+        check('second run performs no additional writes', second.moved.length === 0);
+        check('activity log still has exactly one row after two runs (idempotent)', db.activity.length === 1);
+    }
+
+    // -----------------------------------------------------------------
+    // 6. A closed issue (no linked PR at all) also completes a matching
+    //    card.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            {
+                id: 'card-5',
+                board_id: 'board-1',
+                status: 'review',
+                links: [{ link_type: 'url', ref: 'https://github.com/RLRyals/MCP-Electron-App/issues/77' }]
+            }
+        ]);
+        const gh = makeFakeGhClient({ closedByRepo: { 'RLRyals/MCP-Electron-App': [issue(77)] } });
+
+        const { moved } = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: false, log: NOOP_LOG });
+        check('closed issue with no PR still completes the linked card', moved.length === 1);
+        check("stamp records an 'issue_closed' event", db.cards[0].metadata.github_sync?.event === 'issue_closed:RLRyals/MCP-Electron-App#77');
+    }
+
+    // -----------------------------------------------------------------
+    // 7. A card matched by two different events in the SAME run is only
+    //    moved once (de-dupe), and a card in an unrelated repo/number is
+    //    left alone.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            {
+                id: 'card-6',
+                board_id: 'board-1',
+                status: 'review',
+                issue_ref: 'RLRyals/MCP-Electron-App#50'
+            },
+            {
+                id: 'card-unrelated',
+                board_id: 'board-1',
+                status: 'review',
+                issue_ref: 'RLRyals/MCP-Electron-App#9999'
+            }
+        ]);
+        const gh = makeFakeGhClient({
+            mergedByRepo: {
+                'RLRyals/MCP-Electron-App': [
+                    pr(210, { body: 'Fixes #50' }),
+                    pr(211, { body: 'Also fixes #50 (split PR)' })
+                ]
+            }
+        });
+
+        const { moved } = await runSync({ db, ghClient: gh, config, since: '2026-07-01T00:00:00Z', dryRun: false, log: NOOP_LOG });
+        check('card matched by two events in one run is moved exactly once', moved.filter((m) => m.card.id === 'card-6').length === 1);
+        check('unrelated card is untouched', db.cards.find((c) => c.id === 'card-unrelated').status === 'review');
+        check('exactly one activity row for the de-duped card', db.activity.filter((a) => a.cardId === 'card-6').length === 1);
+    }
+
+    // -----------------------------------------------------------------
+    // 8. A gh API failure for one repo is caught, logged, and does not
+    //    crash the run or block other repos/cards.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            { id: 'card-7', board_id: 'board-1', status: 'review', issue_ref: 'RLRyals/MCP-Writing-Servers#1' }
+        ]);
+        const multiRepoConfig = { watched_repos: ['RLRyals/MCP-Electron-App', 'RLRyals/MCP-Writing-Servers'] };
+        const gh = {
+            async searchMergedPRs(repoFullName) {
+                if (repoFullName === 'RLRyals/MCP-Electron-App') {
+                    throw new Error('simulated gh api failure (rate limit)');
+                }
+                return [pr(1, {})].map((p) => ({ ...p, html_url: `https://github.com/${repoFullName}/pull/1` }));
+            },
+            async searchClosedIssues() {
+                return [];
+            }
+        };
+
+        const loggedLines = [];
+        const { moved, errors } = await runSync({
+            db,
+            ghClient: gh,
+            config: multiRepoConfig,
+            since: '2026-07-01T00:00:00Z',
+            dryRun: false,
+            log: (line) => loggedLines.push(line)
+        });
+
+        check('a failing repo produces a logged error, not a thrown exception', errors.length === 1, JSON.stringify(errors));
+        check('the error mentions the failing repo', errors[0].repo === 'RLRyals/MCP-Electron-App');
+        check('log() was called with the error detail', loggedLines.some((l) => l.includes('simulated gh api failure')));
+        check('the OTHER repo (MCP-Writing-Servers) still gets processed and its card moved', moved.length === 1);
+    }
+
+    // -----------------------------------------------------------------
+    // 9. applyTransition loses gracefully to a concurrent status change
+    //    (WHERE status = fromStatus guard) instead of clobbering it.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([{ id: 'card-8', board_id: 'board-1', status: 'archived' }]);
+        // Simulate a stale in-memory card object claiming it was still
+        // 'review' when in fact the DB row has already moved to 'archived'
+        // (e.g. an agent archived it between fetchCandidateCards and here).
+        const staleCard = { id: 'card-8', board_id: 'board-1', status: 'review', metadata: {} };
+        const event = {
+            kind: 'pr_merged',
+            owner: 'RLRyals',
+            repo: 'MCP-Electron-App',
+            number: 300,
+            url: 'https://github.com/RLRyals/MCP-Electron-App/pull/300',
+            title: 'Some PR'
+        };
+        const transition = { fromStatus: 'review', toStatus: 'done', match: { via: 'issue_ref', ref: 'x' }, eventKey: buildEventKey(event) };
+
+        const result = await applyTransition(db, staleCard, transition, event);
+        check('applyTransition returns null when the guarded UPDATE matches zero rows', result === null);
+        check('no activity row is written for a lost race', db.activity.length === 0);
+        check('the card is left exactly as the DB already had it (archived)', db.cards[0].status === 'archived');
+    }
+
+    // -----------------------------------------------------------------
+    // 10. fetchCandidateCards only ever selects in_progress/review cards.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb([
+            { id: 'a', board_id: 'b', status: 'review' },
+            { id: 'b', board_id: 'b', status: 'in_progress' },
+            { id: 'c', board_id: 'b', status: 'done' },
+            { id: 'd', board_id: 'b', status: 'backlog' }
+        ]);
+        const rows = await fetchCandidateCards(db);
+        check('fetchCandidateCards returns exactly the in_progress/review rows', rows.length === 2, JSON.stringify(rows));
+        check(
+            'fetchCandidateCards never returns done/backlog rows',
+            rows.every((r) => r.status === 'review' || r.status === 'in_progress')
+        );
+    }
+
+    console.log(`\n${pass} passed, ${fail} failed. (github-sync.test.js)`);
+    process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+    console.error('github-sync.test.js crashed:', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes #64.

Implements the local GitHub sync poller per the issue spec: when a merged PR
or a closed issue matches a kanban card's link, the card auto-moves
`in_progress`/`review` -> `done` -- no more manual board grooming after
merging a PR queue.

- `src/mcps/kanban-server/tools/github-sync-lib.js` -- pure, dependency-free
  logic: URL / `owner/repo#N` parsing, `Fixes #N`-style closing-keyword
  extraction (matches GitHub's own auto-close semantics, including the
  "only the token right after the keyword counts" rule), card<->event
  matching (via `issue_ref` or a `url`/`github_issue` link), and the
  conservative status-transition rule (only `in_progress`/`review` -> `done`;
  idempotent via a `metadata.github_sync` stamp).
- `src/mcps/kanban-server/tools/github-sync.js` -- orchestration: `gh api
  search/issues` per watched repo since a persisted watermark
  (`github-sync.state.json`, gitignored), matches against every
  `in_progress`/`review` card, applies moves via the exact same
  `logActivity()` / `notifyKanbanChanged()` helpers every other
  kanban-server tool already uses (so this shows up in the activity feed
  identically to a manual `move_card`). `--dry-run` performs zero writes.
  Every error (a bad `gh` call, a DB hiccup) is caught per repo/card, logged
  to `github-sync.log` (gitignored), and never crashes the run.
- `github-sync.config.json` -- watched repos (`RLRyals/MCP-Electron-App`,
  `RLRyals/MCP-Writing-Servers`, `RLRyals/fictionlab-workflow`).
- `src/mcps/kanban-server/README.md` (new) -- documents the matching rules,
  config, CLI flags, and the Scheduled Task registration as a **documented,
  not auto-registered** one-liner.
- `tests/kanban-server/` -- 112 unit tests, DB and `gh` both mocked (per the
  hard safety rule: automated tests never touch the live DB). Wired into CI
  as a new `kanban-github-sync-tests` job (no postgres service needed).

## Live `--dry-run` verification (real DB, real `gh` auth, zero writes)

Ran against the live `mcp_writing_db` / Docker `fictionlab-postgres`, using
the existing `gh auth login` session, `--since 2026-07-08T00:00:00Z`:

```
github-sync: since=2026-07-08T00:00:00Z dryRun=true watched_repos=[RLRyals/MCP-Electron-App, RLRyals/MCP-Writing-Servers, RLRyals/fictionlab-workflow]
github-sync: 1 card(s) matched an eligible transition.
  [WOULD MOVE] card ca11ab1e-2026-4708-8000-000000000012 (in_progress -> done) via issue_ref=RLRyals/MCP-Electron-App#126 -- PR #200 merged in RLRyals/MCP-Electron-App (https://github.com/RLRyals/MCP-Electron-App/pull/200)
github-sync: --dry-run, watermark NOT advanced, zero writes performed.
```

Confirmed the search window actually captured PRs #199-#203 (`gh api
search/issues` returned all five, plus 12 older merges in the window); only
one currently-open card matched, because PR #200's body ends with `Fixes
#126`, and one real `in_progress` card has `issue_ref =
RLRyals/MCP-Electron-App#126`. The other open card in that window is
literally the card tracking *this* issue (#64) -- it won't match until this
PR merges and closes #64, which is correct.

Verified zero writes: re-queried `fictionlab.kanban_cards` after the
dry-run -- both real `in_progress` cards unchanged (`status`, `metadata`
identical to before).

**Also verified the actual write path against real Postgres**, safely: a
one-off script created a dedicated throwaway `sync-test-*` board, called the
production `applyTransition()` directly against a single card scoped to that
board (never the global `runSync()`, which intentionally scans all boards
system-wide and is therefore unsafe to run in write mode against live data),
confirmed the UPDATE + `kanban_activity` insert + stamp + idempotent-rerun
skip all worked, then deleted the throwaway board and re-diffed the two real
`in_progress` cards byte-for-byte unchanged.

One bug found and fixed during this live verification: `gh api
search/issues -f q=...` 404s unless `--method GET` is passed explicitly (`gh
api` defaults to POST whenever `-f`/`-F` params are present) -- fixed in
`runGhSearch()`.

## Test plan

- [x] `node tests/kanban-server/github-sync-lib.test.js` -- 71/71 passed
      (parsing, closing-keyword extraction, matching, transition rules)
- [x] `node tests/kanban-server/github-sync.test.js` -- 41/41 passed
      (orchestration: dry-run zero-writes, conservative status gating,
      idempotent reruns, cross-event de-dupe, error isolation, lost-race
      guard) -- DB and `gh` both mocked
- [x] Live `--dry-run` against the real DB -- see plan output above
- [x] Live write-path check against a throwaway `sync-test` board only,
      deleted after; real boards verified untouched

## Enabling the Scheduled Task (not done by this PR)

```
schtasks /create /tn "Kanban GitHub Sync" /tr "node C:\github\MCP-Writing-Servers\src\mcps\kanban-server\tools\github-sync.js" /sc minute /mo 15 /f
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)