### PR TITLE
kanban-server: free-text card search (q param on list_cards)

### DIFF
--- a/src/mcps/kanban-server/README.md
+++ b/src/mcps/kanban-server/README.md
@@ -11,6 +11,27 @@ Storage is `fictionlab.kanban_boards` / `kanban_columns` / `kanban_cards` /
 Live-DB integration scripts (ephemeral throwaway board, real gh/DB): `test/kanban-server/`.
 Mocked-DB unit tests (CI-safe): `tests/kanban-server/`.
 
+## Free-text card search (GH issue #66)
+
+`list_cards` accepts an optional `q` (string) parameter that does a
+case-insensitive free-text search across card `title`, card `body`, and every
+`fictionlab.kanban_comments` row for that card (parameterized `ILIKE`, never
+string-interpolated). `q` combines with AND against every other `list_cards`
+filter (`board_key`/`board_id`, `assignee`, `status`, `label`, `priority`,
+etc.).
+
+When `q` is set and neither `board_key` nor `board_id` is given, the search
+runs across **all** boards (it does not implicitly narrow to `dev-backlog`),
+and each returned card includes `board_key` so a hit is attributable to its
+board. Results are ranked title hits first, then body-only hits, then
+comment-only hits, before falling back to the tool's normal ordering
+(due-date, priority/position, etc.) within each rank.
+
+`ILIKE` is sufficient at current scale (hundreds of cards). If the boards grow
+large enough that this gets slow, the upgrade path is `pg_trgm` or Postgres
+full-text search (`tsvector`/`tsquery`) on `title`/`body`/comment `body` — no
+new migration is needed for the current `q` implementation.
+
 ## GitHub Sync (GH issue #64)
 
 `tools/github-sync.js` is a standalone poller (not part of the MCP server

--- a/src/mcps/kanban-server/handlers/card-handlers.js
+++ b/src/mcps/kanban-server/handlers/card-handlers.js
@@ -16,7 +16,7 @@ export class CardHandlers {
     /**
      * list_cards — the workhorse filter. board_key/board_id, assignee, agent,
      * status, label, priority, agent_claimable_only, include_archived,
-     * include_workflow_phase, due_filter, limit.
+     * include_workflow_phase, due_filter, q, limit.
      */
     async handleListCards(args) {
         const {
@@ -31,12 +31,16 @@ export class CardHandlers {
             include_archived = false,
             include_workflow_phase = false,
             due_filter,
+            q,
             limit = 200
         } = args || {};
 
         const conditions = [];
         const params = [];
         let i = 1;
+        // Set below when q is present -- reused (never re-interpolated) in both
+        // the WHERE clause and the ORDER BY rank expression.
+        let qParamIndex = null;
 
         if (board_id) {
             conditions.push(`c.board_id = $${i++}`);
@@ -66,6 +70,27 @@ export class CardHandlers {
         if (priority) {
             conditions.push(`c.priority = $${i++}`);
             params.push(priority);
+        }
+
+        // Free-text search (GH issue #66). Combines with AND against every
+        // other filter above. Matches title OR body OR any comment body --
+        // parameterized throughout, q is NEVER string-interpolated into the
+        // SQL text. When no board_key/board_id filter is given, this already
+        // searches every board (the board conditions above simply add no
+        // predicate in that case) -- no separate "search all boards" branch
+        // needed. ILIKE is sufficient at current scale (hundreds of cards);
+        // pg_trgm/full-text search is the upgrade path if it ever gets slow.
+        if (q) {
+            qParamIndex = i++;
+            conditions.push(`(
+                c.title ILIKE '%' || $${qParamIndex} || '%'
+                OR c.body ILIKE '%' || $${qParamIndex} || '%'
+                OR EXISTS (
+                    SELECT 1 FROM fictionlab.kanban_comments cm
+                    WHERE cm.card_id = c.id AND cm.body ILIKE '%' || $${qParamIndex} || '%'
+                )
+            )`);
+            params.push(q);
         }
 
         // agent_claimable_only MUST exclude every card assigned to an active
@@ -119,22 +144,40 @@ export class CardHandlers {
         // When filtering by due date, the soonest-due card matters more than
         // priority/position ordering -- lead with due_at ascending. Otherwise
         // keep the existing priority-then-position-then-created_at order.
-        const orderClause = due_filter
-            ? 'ORDER BY c.due_at ASC NULLS LAST, c.priority, c.position'
-            : `ORDER BY
-                CASE c.priority
+        const baseOrder = due_filter
+            ? 'c.due_at ASC NULLS LAST, c.priority, c.position'
+            : `CASE c.priority
                     WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 WHEN 'low' THEN 3 ELSE 4
                 END,
                 c.position,
                 c.created_at`;
 
+        // When q is set, title hits outrank body-only hits outrank
+        // comment-only hits; the existing due/priority ordering above is the
+        // secondary sort within each rank. Reuses the same $qParamIndex bound
+        // parameter already used in the WHERE clause -- never re-interpolated.
+        const searchRank = q
+            ? `CASE
+                    WHEN c.title ILIKE '%' || $${qParamIndex} || '%' THEN 0
+                    WHEN c.body ILIKE '%' || $${qParamIndex} || '%' THEN 1
+                    ELSE 2
+                END,
+                `
+            : '';
+
+        const orderClause = `ORDER BY ${searchRank}${baseOrder}`;
+
+        // board_key is always joined in so q's cross-board results are
+        // attributable to a board without a second round trip.
         const result = await this.db.query(
             `SELECT
                 c.*,
+                b.board_key,
                 (SELECT COUNT(*) FROM fictionlab.kanban_comments cm WHERE cm.card_id = c.id) AS comment_count,
                 (SELECT COUNT(*) FROM fictionlab.kanban_card_links l WHERE l.card_id = c.id) AS link_count
                 ${workflowSelect}
              FROM fictionlab.kanban_cards c
+             JOIN fictionlab.kanban_boards b ON b.id = c.board_id
              ${workflowJoin}
              ${whereClause}
              ${orderClause}

--- a/src/mcps/kanban-server/schemas/kanban-tools-schema.js
+++ b/src/mcps/kanban-server/schemas/kanban-tools-schema.js
@@ -25,12 +25,16 @@ export const kanbanToolsSchema = [
     },
     {
         name: 'list_cards',
-        description: 'Lists cards with filters: board, assignee, agent, status, label, priority, agent_claimable_only, include_archived, include_workflow_phase, due_filter. The workhorse read tool.',
+        description: 'Lists cards with filters: board, assignee, agent, status, label, priority, agent_claimable_only, include_archived, include_workflow_phase, due_filter, q. The workhorse read tool.',
         inputSchema: {
             type: 'object',
             properties: {
                 board_key: { type: 'string' },
                 board_id: { type: 'string' },
+                q: {
+                    type: 'string',
+                    description: "Free-text search over card title, body, and comments (case-insensitive, ILIKE). Combines with AND with all other filters. When set and no board_key/board_id is given, searches across ALL boards (not just dev-backlog) and each returned card includes board_key so hits are attributable. Ranks title hits above body-only hits above comment-only hits."
+                },
                 assignee: {
                     type: 'string',
                     description: "Exact match against an identity id (see list_identities), e.g. 'rebecca' (her queue). Special: '__unassigned__' (assignee IS NULL)"

--- a/test/kanban-server/card-search-test.js
+++ b/test/kanban-server/card-search-test.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// test/kanban-server/card-search-test.js
+// Exercises the free-text `q` param on list_cards (GH issue #66) against the
+// LIVE database, over the real stdio transport -- same pattern as
+// test/kanban-server/smoke-test.js (connection setup, check() harness,
+// pass/fail summary, process.exit).
+//
+// Two kinds of coverage:
+//  - Read-only assertions against REAL production data (dev-backlog,
+//    broadquill-business, ffa-system-gaps) for cross-board search, AND-
+//    composition, injection safety, and title-vs-body ranking. These never
+//    write anything.
+//  - One ephemeral throwaway board (created + torn down here, same as
+//    smoke-test.js) for the comment-only-match case, since we don't want to
+//    depend on the exact wording of a real production comment.
+//
+// Run: node test/kanban-server/card-search-test.js
+// Requires: DATABASE_URL in .env, the 042_kanban_tables.sql migration
+// already applied, and the real ffa-system-gaps board's
+// "Marketing Foundation Station — per-book positioning bible" card (created
+// 2026-07-09) still present with its current title/body.
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import pg from 'pg';
+import dotenv from 'dotenv';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+dotenv.config({ path: path.join(repoRoot, '.env') });
+
+const { Pool } = pg;
+
+let passCount = 0;
+let failCount = 0;
+
+function check(label, condition, detail) {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        passCount++;
+    } else {
+        console.log(`  FAIL  ${label}${detail ? ' -- ' + detail : ''}`);
+        failCount++;
+    }
+}
+
+async function callTool(client, name, args) {
+    const result = await client.callTool({ name, arguments: args || {} });
+    if (result.isError) {
+        throw new Error(`Tool ${name} returned an error: ${result.content?.[0]?.text}`);
+    }
+    const text = result.content?.[0]?.text;
+    return text ? JSON.parse(text) : undefined;
+}
+
+async function main() {
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+    // --- Test scaffolding: an ephemeral board, never the real dev-backlog ---
+    const testBoardKey = `kanban-search-test-${Date.now()}`;
+    const boardResult = await pool.query(
+        `INSERT INTO fictionlab.kanban_boards (board_key, name, description)
+         VALUES ($1, 'Kanban Search Test', 'Ephemeral board created by test/kanban-server/card-search-test.js')
+         RETURNING id`,
+        [testBoardKey]
+    );
+    const testBoardId = boardResult.rows[0].id;
+
+    await pool.query(
+        `INSERT INTO fictionlab.kanban_columns (board_id, status_key, name, position, is_agent_pickup)
+         VALUES ($1, 'backlog', 'Backlog', 0, FALSE)`,
+        [testBoardId]
+    );
+
+    console.log(`Created ephemeral test board ${testBoardKey} (${testBoardId})`);
+
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: [path.join(repoRoot, 'src/mcps/kanban-server/stdio-adapter.js')],
+        cwd: repoRoot,
+        env: { ...process.env, MCP_STDIO_MODE: 'true' }
+    });
+
+    const client = new Client({ name: 'kanban-card-search-test', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+    console.log('Connected to kanban-server over stdio.\n');
+
+    try {
+        // --- 1. Cross-board free-text search against REAL data, no board filter ---
+        // "positioning" is a title hit on ffa-system-gaps's Marketing Foundation
+        // Station card AND a body-only hit on three other ffa-system-gaps cards
+        // (Reader Intelligence Loop, Promise Ledger MCP, Launch & Ads Station).
+        // No board_key/board_id is passed -- this must NOT implicitly scope to
+        // dev-backlog (GH issue #66 acceptance criterion).
+        const positioningRes = await callTool(client, 'list_cards', { q: 'positioning' });
+
+        const titleHit = positioningRes.cards.find((c) => c.title.includes('per-book positioning bible'));
+        check(
+            'q="positioning" (no board filter) finds the ffa-system-gaps Marketing Foundation card',
+            !!titleHit,
+            JSON.stringify(positioningRes.cards.map((c) => c.title))
+        );
+        check(
+            'the matched card carries board_key="ffa-system-gaps" (cross-board attribution)',
+            titleHit?.board_key === 'ffa-system-gaps',
+            titleHit?.board_key
+        );
+        check(
+            'every returned row carries a board_key (not just the title-hit row)',
+            positioningRes.cards.every((c) => !!c.board_key)
+        );
+
+        const bodyOnlyHits = positioningRes.cards.filter(
+            (c) => c.id !== titleHit?.id && ['Reader Intelligence Loop', 'Promise Ledger MCP', 'Launch & Ads Station (propose-only)'].includes(c.title)
+        );
+        check(
+            'q="positioning" also surfaces the three known body-only-match cards on the same board',
+            bodyOnlyHits.length === 3,
+            JSON.stringify(positioningRes.cards.map((c) => c.title))
+        );
+
+        // --- 2. Title-ranks-above-body ordering (real data, not code-inspection-only) ---
+        const titleIdx = positioningRes.cards.findIndex((c) => c.id === titleHit?.id);
+        const bodyIdxs = bodyOnlyHits.map((hit) => positioningRes.cards.findIndex((c) => c.id === hit.id));
+        check(
+            'title hit sorts before every body-only hit',
+            titleIdx >= 0 && bodyIdxs.every((idx) => idx > titleIdx),
+            `titleIdx=${titleIdx} bodyIdxs=${JSON.stringify(bodyIdxs)}`
+        );
+
+        // --- 3. AND-composition: q combined with an existing filter (status) ---
+        const qPlusMatchingStatus = await callTool(client, 'list_cards', { q: 'positioning', status: 'backlog' });
+        check(
+            'q + status="backlog" (the real status of the matching cards) still finds the title-hit card',
+            qPlusMatchingStatus.cards.some((c) => c.id === titleHit?.id)
+        );
+        check(
+            'q + status="backlog" results are ALL status=backlog (AND, not OR)',
+            qPlusMatchingStatus.cards.every((c) => c.status === 'backlog')
+        );
+
+        const qPlusNonMatchingStatus = await callTool(client, 'list_cards', { q: 'positioning', status: 'done' });
+        check(
+            'q + status="done" (no matching card has this status) narrows to zero results',
+            qPlusNonMatchingStatus.cards.length === 0,
+            `got ${qPlusNonMatchingStatus.cards.length}`
+        );
+
+        // --- 4. Injection / quote safety ---
+        const totalActiveCardsRes = await pool.query(`SELECT COUNT(*) FROM fictionlab.kanban_cards WHERE status <> 'archived'`);
+        const totalActiveCards = parseInt(totalActiveCardsRes.rows[0].count, 10);
+
+        let injectionThrew = false;
+        let injectionRes;
+        try {
+            injectionRes = await callTool(client, 'list_cards', { q: "test' OR '1'='1" });
+        } catch (e) {
+            injectionThrew = true;
+        }
+        check('q with SQL metacharacters does not error', !injectionThrew);
+        check(
+            'q with SQL metacharacters is treated as an inert literal (zero matches, not "return everything")',
+            !!injectionRes && injectionRes.cards.length === 0 && injectionRes.cards.length < totalActiveCards,
+            `got ${injectionRes?.cards.length} of ${totalActiveCards} total active cards`
+        );
+
+        // --- 5. Comment-only match (ephemeral card, cleaned up in finally) ---
+        const searchToken = `zzqsearchtoken${Date.now()}`;
+        const commentCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'Card with a comment-only search hit',
+            body: 'This body deliberately does not contain the search token.'
+        });
+        const commentCardId = commentCardRes.card.id;
+        await callTool(client, 'comment_card', {
+            card_id: commentCardId,
+            author: 'claude-code:card-search-test',
+            body: `Found it buried in a comment: ${searchToken}`
+        });
+
+        const commentSearchRes = await callTool(client, 'list_cards', { q: searchToken });
+        check(
+            'q matching only a comment body still finds the card (no board filter passed)',
+            commentSearchRes.cards.some((c) => c.id === commentCardId),
+            JSON.stringify(commentSearchRes.cards.map((c) => c.id))
+        );
+        check(
+            'the comment-only hit carries the ephemeral board\'s board_key',
+            commentSearchRes.cards.find((c) => c.id === commentCardId)?.board_key === testBoardKey
+        );
+
+        // Sanity: q for a token nobody typed anywhere returns nothing.
+        const noHitRes = await callTool(client, 'list_cards', { q: `nonexistent-token-${Date.now()}-zzz` });
+        check('q for a token that matches nothing returns an empty array', noHitRes.cards.length === 0);
+
+        // Sanity: list_cards without q behaves exactly as before (no q key at all).
+        const noQRes = await callTool(client, 'list_cards', { board_id: testBoardId });
+        check(
+            'list_cards without q still returns the ephemeral board\'s card (no regression)',
+            noQRes.cards.some((c) => c.id === commentCardId)
+        );
+    } finally {
+        await client.close();
+        // Cascade-delete the ephemeral test board (columns/cards/comments/links/activity all go with it).
+        await pool.query('DELETE FROM fictionlab.kanban_boards WHERE id = $1', [testBoardId]);
+        console.log(`\nCleaned up ephemeral test board ${testBoardKey}`);
+        await pool.end();
+    }
+
+    console.log(`\n${passCount} passed, ${failCount} failed.`);
+    process.exit(failCount > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+    console.error('card-search-test crashed:', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Fixes #66
- Adds an optional `q` (string) param to `list_cards`'s input schema — free-text search over card title, body, and comments (case-insensitive, parameterized `ILIKE`), combined with AND against every other filter.
- When `q` is set and no `board_key`/`board_id` filter is given, the search runs across all boards (never implicitly scoped to `dev-backlog`); every returned row now includes `board_key` so a hit is attributable to its board.
- Adds a `CASE`-based rank (title hit = 0, body-only = 1, comment-only = 2) as the primary `ORDER BY`, falling back to the existing due-date/priority/position ordering as the secondary sort within each rank.
- `q` is bound as a single parameterized placeholder reused across the title/body/comment-`EXISTS` checks — never string-interpolated into the SQL text.
- Updates `src/mcps/kanban-server/README.md` with a new section documenting the `q` param (the README had no pre-existing "tool list" to slot into — see Notes below).

## Test plan
- [x] `node test/kanban-server/smoke-test.js` — 67/67 passed (unchanged pre-existing suite, confirms no regression from the `list_cards` SELECT/JOIN/ORDER BY changes)
- [x] `node test/kanban-server/concurrent-claim-test.js` — 20/20 iterations passed (unchanged pre-existing suite)
- [x] `node test/kanban-server/card-search-test.js` (new) — 14/14 passed, covering:
  - [x] `q:"positioning"` with no board filter finds the real `ffa-system-gaps` "Marketing Foundation Station" card and returns its `board_key` (cross-board search, no default-board regression)
  - [x] AND-composition: `q` + `status` narrows correctly (`status:"backlog"` still matches; `status:"done"` narrows to zero)
  - [x] SQL injection / quote safety: `q:"test' OR '1'='1"` does not error and returns zero rows (not "return everything")
  - [x] Title-ranks-above-body: verified against real data — the title-hit card sorts before three known body-only-hit cards for the same query
  - [x] Comment-only match, using an ephemeral throwaway board/card/comment cleaned up in `finally` (never touches real boards)
- [x] Confirmed no leftover test data in the live DB after all three suites ran (ephemeral boards + cards cascade-deleted; verified via direct query post-run)

## Notes / deviations
- `src/mcps/kanban-server/README.md` currently documents only the GitHub Sync feature (GH #64) — there is no pre-existing per-tool "tool list" section to update. Added a new "Free-text card search" section in the same style instead.
- `board_key` is now joined and returned on **every** `list_cards` row (not only when `q` is set) — simpler than conditionally joining, and additive/non-breaking for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)