### PR TITLE
fix: correct workflow_definitions upsert ON CONFLICT arbiter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,29 @@ jobs:
       - name: Run github-sync orchestration tests (mocked DB + gh client)
         run: node tests/kanban-server/github-sync.test.js
 
+  workflow-manager-server-tests:
+    name: Workflow Manager Server Tests
+    runs-on: ubuntu-latest
+    # GH issue #57: regression test for the workflow_definitions upsert
+    # ON CONFLICT arbiter mismatch. DB is fully mocked (see
+    # tests/workflow-manager-server/), so no postgres service is needed here.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run definition-handlers tests (mocked DB)
+        run: node tests/workflow-manager-server/definition-handlers.test.js
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest

--- a/src/mcps/workflow-manager-server/handlers/definition-handlers.js
+++ b/src/mcps/workflow-manager-server/handlers/definition-handlers.js
@@ -30,8 +30,9 @@ export class DefinitionHandlers {
                 workflow_id, name, version, description, graph_json, dependencies,
                 tags, metadata, created_by, is_system
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, FALSE)
-            ON CONFLICT (workflow_id, version) DO UPDATE SET
+            ON CONFLICT (workflow_id) DO UPDATE SET
                 name = EXCLUDED.name,
+                version = EXCLUDED.version,
                 description = EXCLUDED.description,
                 graph_json = EXCLUDED.graph_json,
                 dependencies = EXCLUDED.dependencies,

--- a/tests/workflow-manager-server/definition-handlers.test.js
+++ b/tests/workflow-manager-server/definition-handlers.test.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// tests/workflow-manager-server/definition-handlers.test.js
+// Regression test for bead mws-1783883496504-9-129d637e / GH issue #57:
+// the workflow_definitions upsert used `ON CONFLICT (workflow_id, version)`
+// but the table's real constraints are PRIMARY KEY (workflow_id) plus a
+// separate UNIQUE (workflow_id, version). Re-importing an existing
+// workflow_id with a bumped version didn't match that conflict arbiter and
+// instead violated the PK, raising a real Postgres error:
+//   ERROR: duplicate key value violates unique constraint "workflow_definitions_pkey"
+//
+// This is a hand-rolled fake DB (no real Postgres connection anywhere in
+// this file) that models exactly those two constraints -- PK on
+// workflow_id, UNIQUE on (workflow_id, version) -- and raises the same kind
+// of error a real Postgres would when an INSERT's ON CONFLICT arbiter
+// doesn't match the row that's actually colliding. That means this test
+// fails against the old `ON CONFLICT (workflow_id, version)` SQL and passes
+// against the fixed `ON CONFLICT (workflow_id)` SQL.
+//
+// Run: node tests/workflow-manager-server/definition-handlers.test.js
+
+import { strict as assert } from 'assert';
+import { DefinitionHandlers } from '../../src/mcps/workflow-manager-server/handlers/definition-handlers.js';
+
+let pass = 0;
+let fail = 0;
+
+function check(label, condition, detail) {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        pass++;
+    } else {
+        console.log(`  FAIL  ${label}${detail ? ' -- ' + detail : ''}`);
+        fail++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fake DB modeling fictionlab.workflow_definitions:
+//   PRIMARY KEY (workflow_id)
+//   UNIQUE (workflow_id, version)
+// Parses the INSERT ... ON CONFLICT (<arbiter columns>) DO UPDATE SET ...
+// text well enough to (a) find an existing row via the real PK, (b) check
+// whether the given ON CONFLICT arbiter actually matches that collision,
+// and (c) either apply the DO UPDATE SET or throw a Postgres-shaped error
+// when the arbiter is wrong -- exactly the bug this test guards against.
+// ---------------------------------------------------------------------------
+function makeFakeDb() {
+    const rows = []; // { workflow_id, name, version, description, graph_json, dependencies, tags, metadata, created_by, is_system, created_at, updated_at }
+    const imports = [];
+
+    return {
+        rows,
+        imports,
+        async query(text, params = []) {
+            const sql = text.trim();
+
+            if (sql.startsWith('INSERT INTO fictionlab.workflow_definitions')) {
+                const [workflow_id, name, version, description, graph_json, dependencies, tags, metadata, created_by] = params;
+
+                const existingByPk = rows.find((r) => r.workflow_id === workflow_id);
+
+                const arbiterMatch = sql.match(/ON CONFLICT \(([^)]+)\)/);
+                const arbiterCols = arbiterMatch[1].split(',').map((c) => c.trim());
+
+                if (existingByPk) {
+                    // A real Postgres PK collision only resolves via ON CONFLICT if
+                    // the arbiter is exactly the PK (workflow_id). An arbiter of
+                    // (workflow_id, version) does NOT match a plain workflow_id
+                    // collision -- Postgres falls through to the unhandled
+                    // duplicate-key error, same as the real bug.
+                    const arbiterIsPk = arbiterCols.length === 1 && arbiterCols[0] === 'workflow_id';
+                    if (!arbiterIsPk) {
+                        const err = new Error(
+                            `duplicate key value violates unique constraint "workflow_definitions_pkey"\n` +
+                            `DETAIL: Key (workflow_id)=(${workflow_id}) already exists.`
+                        );
+                        err.code = '23505';
+                        err.constraint = 'workflow_definitions_pkey';
+                        throw err;
+                    }
+
+                    // Arbiter matches the PK -> DO UPDATE SET applies.
+                    existingByPk.name = name;
+                    existingByPk.version = version;
+                    existingByPk.description = description;
+                    existingByPk.graph_json = graph_json;
+                    existingByPk.dependencies = dependencies;
+                    existingByPk.tags = tags;
+                    existingByPk.metadata = metadata;
+                    existingByPk.updated_at = new Date().toISOString();
+
+                    return {
+                        rows: [{
+                            workflow_id: existingByPk.workflow_id,
+                            version: existingByPk.version,
+                            created_at: existingByPk.created_at
+                        }]
+                    };
+                }
+
+                // No existing row for this workflow_id -> plain insert.
+                const row = {
+                    workflow_id,
+                    name,
+                    version,
+                    description,
+                    graph_json,
+                    dependencies,
+                    tags,
+                    metadata,
+                    created_by,
+                    is_system: false,
+                    created_at: new Date().toISOString(),
+                    updated_at: new Date().toISOString()
+                };
+                rows.push(row);
+                return { rows: [{ workflow_id: row.workflow_id, version: row.version, created_at: row.created_at }] };
+            }
+
+            if (sql.startsWith('INSERT INTO fictionlab.workflow_imports')) {
+                const [workflow_id, source_type, source_path, imported_by, installation_log] = params;
+                imports.push({ workflow_id, source_type, source_path, imported_by, installation_log });
+                return { rows: [] };
+            }
+
+            throw new Error(`makeFakeDb: unhandled query: ${sql}`);
+        }
+    };
+}
+
+async function main() {
+    console.log('definition-handlers.test.js\n');
+
+    // -----------------------------------------------------------------
+    // 1. Importing a brand-new workflow_id inserts a row.
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb();
+        const handlers = new DefinitionHandlers(db);
+
+        const result = await handlers.handleImportWorkflowDefinition({
+            id: 'series-cover-pipeline',
+            name: 'Series Cover Pipeline',
+            version: '1.0.0',
+            description: 'v1',
+            graph_json: { nodes: [], edges: [] },
+            dependencies_json: { agents: [], skills: [], mcpServers: [] },
+            tags: ['cover']
+        });
+
+        check('initial import succeeds', result.workflow_id === 'series-cover-pipeline' && result.version === '1.0.0');
+        check('exactly one row exists after first import', db.rows.length === 1);
+    }
+
+    // -----------------------------------------------------------------
+    // 2. Re-importing the SAME workflow_id with a BUMPED version succeeds
+    //    (this is the acceptance criterion from the bead / issue #57 --
+    //    fails with the old ON CONFLICT (workflow_id, version) SQL).
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb();
+        const handlers = new DefinitionHandlers(db);
+
+        await handlers.handleImportWorkflowDefinition({
+            id: 'series-cover-pipeline',
+            name: 'Series Cover Pipeline',
+            version: '1.0.0',
+            description: 'v1',
+            graph_json: { nodes: [{ id: 'a' }], edges: [] },
+            dependencies_json: { agents: [], skills: [], mcpServers: [] },
+            tags: ['cover']
+        });
+
+        let bumpResult;
+        let bumpError = null;
+        try {
+            bumpResult = await handlers.handleImportWorkflowDefinition({
+                id: 'series-cover-pipeline',
+                name: 'Series Cover Pipeline',
+                version: '1.1.0',
+                description: 'v1.1 adds trend research',
+                graph_json: { nodes: [{ id: 'a' }, { id: 'b' }], edges: [] },
+                dependencies_json: { agents: [], skills: [], mcpServers: [] },
+                tags: ['cover', 'trend-research']
+            });
+        } catch (error) {
+            bumpError = error;
+        }
+
+        check('version bump does not throw a duplicate-key error', bumpError === null, bumpError?.message);
+        check('version bump returns the new version', bumpResult?.version === '1.1.0');
+        check('still exactly one row for this workflow_id (PK, not a second row)', db.rows.length === 1, `rows=${db.rows.length}`);
+        check('the single row now shows the bumped version', db.rows[0].version === '1.1.0');
+        check('the single row now shows the updated graph_json', db.rows[0].graph_json.nodes.length === 2);
+        check('the single row now shows the updated description', db.rows[0].description === 'v1.1 adds trend research');
+    }
+
+    // -----------------------------------------------------------------
+    // 3. Re-importing the SAME workflow_id + SAME version still updates
+    //    in place (existing behavior preserved, per acceptance criteria).
+    // -----------------------------------------------------------------
+    {
+        const db = makeFakeDb();
+        const handlers = new DefinitionHandlers(db);
+
+        await handlers.handleImportWorkflowDefinition({
+            id: 'series-cover-pipeline',
+            name: 'Series Cover Pipeline',
+            version: '1.0.0',
+            description: 'original description',
+            graph_json: { nodes: [], edges: [] },
+            dependencies_json: { agents: [], skills: [], mcpServers: [] },
+            tags: ['cover']
+        });
+
+        const sameVersionResult = await handlers.handleImportWorkflowDefinition({
+            id: 'series-cover-pipeline',
+            name: 'Series Cover Pipeline',
+            version: '1.0.0',
+            description: 'corrected description, same version',
+            graph_json: { nodes: [], edges: [] },
+            dependencies_json: { agents: [], skills: [], mcpServers: [] },
+            tags: ['cover']
+        });
+
+        check('same-version re-import succeeds', sameVersionResult.version === '1.0.0');
+        check('still exactly one row', db.rows.length === 1);
+        check('description was updated in place', db.rows[0].description === 'corrected description, same version');
+    }
+
+    console.log(`\n${pass} passed, ${fail} failed. (definition-handlers.test.js)`);
+    process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+    console.error('definition-handlers.test.js crashed:', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `workflow_definitions` has `PRIMARY KEY (workflow_id)` plus a separate `UNIQUE (workflow_id, version)`. The import upsert's `ON CONFLICT (workflow_id, version) DO UPDATE` arbiter didn't match the real PK, so re-importing an existing `workflow_id` with a bumped `version` violated the PK instead of updating in place (`duplicate key value violates unique constraint "workflow_definitions_pkey"`).
- Changed the arbiter to `ON CONFLICT (workflow_id)` and added `version = EXCLUDED.version` to the `SET` clause, since the definitions table holds the current definition per `workflow_id` (full version history lives separately in `workflow_versions`, whose own upsert was already correct and is unchanged).

## Test plan

- [x] Added `tests/workflow-manager-server/definition-handlers.test.js` — a mocked-DB regression suite (no real Postgres connection) that models the table's actual constraints (PK on `workflow_id`, UNIQUE on `workflow_id, version`) and raises the same duplicate-key error a real Postgres would when the `ON CONFLICT` arbiter doesn't match. Verified the test fails against the old SQL and passes against the fix.
- [x] Covers all three acceptance criteria from the linked issue: version-bump import succeeds and updates in place; same-version re-import still updates in place; `workflow_versions` insert path is untouched.
- [x] Wired the new suite into CI (`.github/workflows/test.yml`) as its own job, following the existing `kanban-github-sync-tests` mocked-DB pattern.
- [x] Ran the full suite locally: new suite (11/11), kanban-server suites (71/71 + 41/41), database-admin-server suite (188/188) — all green, no regressions.

Closes bead: mws-1783883496504-9-129d637e

🤖 Generated with [Claude Code](https://claude.com/claude-code)