### PR TITLE
Fix POST /mcp route shadowed by /:sessionId in single-server-runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,31 @@ jobs:
       - name: Run github-sync orchestration tests (mocked DB + gh client)
         run: node tests/kanban-server/github-sync.test.js
 
+  single-server-runner-tests:
+    name: Single Server Runner Route Tests
+    runs-on: ubuntu-latest
+    # bead mws-1783883496459-8-4a224c2b: regression coverage for Express
+    # route registration order in src/single-server-runner.js. Spawns the
+    # real server as a child process against an unreachable-but-valid
+    # DATABASE_URL (pg.Pool connects lazily, so no postgres service needed)
+    # and hits it over real HTTP.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run route precedence regression test
+        run: node test/single-server-runner/route-precedence-test.js
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest

--- a/src/single-server-runner.js
+++ b/src/single-server-runner.js
@@ -118,98 +118,13 @@ async function startServer() {
             }
         });
 
-        // POST endpoint for SSE message handling
-        app.post('/:sessionId', express.json(), async (req, res) => {
-            const sessionId = req.params.sessionId;
-
-            try {
-                const session = activeTransports.get(sessionId);
-                if (!session) {
-                    return res.status(404).json({
-                        error: 'Session not found',
-                        message: `No active session with id: ${sessionId}`
-                    });
-                }
-
-                // Let the transport handle the incoming message
-                await session.transport.handlePostMessage(req, res, req.body);
-
-            } catch (error) {
-                console.error(`[${serverName}:${port}] Error handling POST:`, error);
-                if (!res.headersSent) {
-                    res.status(500).json({ error: error.message });
-                }
-            }
-        });
-
-        // Health check endpoint
-        app.get('/health', async (req, res) => {
-            try {
-                // Use shared server instance instead of creating new one
-                const health = await sharedMCPServer.db.healthCheck();
-                res.json({
-                    server: serverName,
-                    port: port,
-                    status: 'healthy',
-                    database: health,
-                    activeSessions: activeTransports.size,
-                    timestamp: new Date().toISOString()
-                });
-            } catch (error) {
-                res.status(500).json({
-                    server: serverName,
-                    port: port,
-                    status: 'unhealthy',
-                    error: error.message,
-                    timestamp: new Date().toISOString()
-                });
-            }
-        });
-
-        // Info endpoint
-        app.get('/info', async (req, res) => {
-            try {
-                // Use shared server instance instead of creating new one
-                res.json({
-                    server: serverName,
-                    port: port,
-                    version: sharedMCPServer.serverVersion,
-                    tools: sharedMCPServer.tools.map(tool => ({
-                        name: tool.name,
-                        description: tool.description
-                    })),
-                    endpoints: {
-                        sse: `http://localhost:${port}/`,
-                        health: `http://localhost:${port}/health`,
-                        info: `http://localhost:${port}/info`,
-                        tools: `http://localhost:${port}/tools`,
-                        mcp: `http://localhost:${port}/mcp`
-                    }
-                });
-            } catch (error) {
-                res.status(500).json({
-                    error: 'Failed to get server info',
-                    message: error.message
-                });
-            }
-        });
-
-        // Tools endpoint for Typing Mind and other HTTP clients
-        app.get('/tools', async (req, res) => {
-            try {
-                // Return the raw tools array as expected by some clients
-                res.json({
-                    tools: sharedMCPServer.tools
-                });
-            } catch (error) {
-                res.status(500).json({
-                    error: 'Failed to get tools',
-                    message: error.message
-                });
-            }
-        });
-
         // MCP JSON-RPC endpoint for stdio adapter
+        // NOTE: this literal route MUST be registered before the parameterized
+        // POST /:sessionId route below -- Express matches routes in
+        // registration order, and /:sessionId would otherwise capture
+        // POST /mcp requests (sessionId === 'mcp'), which look up a
+        // non-existent session and 404 instead of reaching the JSON-RPC
+        // handler. See bead mws-1783883496459-8-4a224c2b.
         app.post('/mcp', express.json(), async (req, res) => {
             try {
                 // Use shared server instance instead of creating new one
@@ -322,6 +237,97 @@ async function startServer() {
                             message: error.message
                         }
                     }
+                });
+            }
+        });
+
+        // POST endpoint for SSE message handling
+        app.post('/:sessionId', express.json(), async (req, res) => {
+            const sessionId = req.params.sessionId;
+
+            try {
+                const session = activeTransports.get(sessionId);
+                if (!session) {
+                    return res.status(404).json({
+                        error: 'Session not found',
+                        message: `No active session with id: ${sessionId}`
+                    });
+                }
+
+                // Let the transport handle the incoming message
+                await session.transport.handlePostMessage(req, res, req.body);
+
+            } catch (error) {
+                console.error(`[${serverName}:${port}] Error handling POST:`, error);
+                if (!res.headersSent) {
+                    res.status(500).json({ error: error.message });
+                }
+            }
+        });
+
+        // Health check endpoint
+        app.get('/health', async (req, res) => {
+            try {
+                // Use shared server instance instead of creating new one
+                const health = await sharedMCPServer.db.healthCheck();
+                res.json({
+                    server: serverName,
+                    port: port,
+                    status: 'healthy',
+                    database: health,
+                    activeSessions: activeTransports.size,
+                    timestamp: new Date().toISOString()
+                });
+            } catch (error) {
+                res.status(500).json({
+                    server: serverName,
+                    port: port,
+                    status: 'unhealthy',
+                    error: error.message,
+                    timestamp: new Date().toISOString()
+                });
+            }
+        });
+
+        // Info endpoint
+        app.get('/info', async (req, res) => {
+            try {
+                // Use shared server instance instead of creating new one
+                res.json({
+                    server: serverName,
+                    port: port,
+                    version: sharedMCPServer.serverVersion,
+                    tools: sharedMCPServer.tools.map(tool => ({
+                        name: tool.name,
+                        description: tool.description
+                    })),
+                    endpoints: {
+                        sse: `http://localhost:${port}/`,
+                        health: `http://localhost:${port}/health`,
+                        info: `http://localhost:${port}/info`,
+                        tools: `http://localhost:${port}/tools`,
+                        mcp: `http://localhost:${port}/mcp`
+                    }
+                });
+            } catch (error) {
+                res.status(500).json({
+                    error: 'Failed to get server info',
+                    message: error.message
+                });
+            }
+        });
+
+        // Tools endpoint for Typing Mind and other HTTP clients
+        app.get('/tools', async (req, res) => {
+            try {
+                // Return the raw tools array as expected by some clients
+                res.json({
+                    tools: sharedMCPServer.tools
+                });
+            } catch (error) {
+                res.status(500).json({
+                    error: 'Failed to get tools',
+                    message: error.message
                 });
             }
         });

--- a/test/single-server-runner/route-precedence-test.js
+++ b/test/single-server-runner/route-precedence-test.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// test/single-server-runner/route-precedence-test.js
+// Regression test for bead mws-1783883496459-8-4a224c2b: the literal
+// POST /mcp route in src/single-server-runner.js was registered AFTER the
+// parameterized POST /:sessionId route, so Express matched /mcp requests
+// against :sessionId (sessionId === 'mcp') before they ever reached the
+// JSON-RPC handler -- the session lookup failed and the request 404'd
+// instead of getting a JSON-RPC response.
+//
+// This spawns the real single-server-runner.js as a child process (no
+// mocking of Express) and hits it over real HTTP, same "spawn + PASS/FAIL
+// check() harness" pattern used by test/kanban-server/smoke-test.js. It
+// does NOT touch a live database: DatabaseManager's `pg.Pool` connects
+// lazily, so a syntactically-valid-but-unreachable DATABASE_URL is enough
+// to boot the server and exercise routing without ever opening a real
+// connection (nothing exercised here -- tools/list, initialize, unknown
+// session lookup -- touches the DB).
+//
+// Run: node test/single-server-runner/route-precedence-test.js
+
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const runnerPath = path.join(repoRoot, 'src', 'single-server-runner.js');
+
+let passCount = 0;
+let failCount = 0;
+
+function check(label, condition, detail) {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        passCount++;
+    } else {
+        console.log(`  FAIL  ${label}${detail ? ' -- ' + detail : ''}`);
+        failCount++;
+    }
+}
+
+function postJson(port, urlPath, body) {
+    return fetch(`http://127.0.0.1:${port}${urlPath}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+}
+
+async function waitForServer(port, child, timeoutMs = 15000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (child.exitCode !== null) {
+            throw new Error(`Server process exited early with code ${child.exitCode}`);
+        }
+        try {
+            const res = await fetch(`http://127.0.0.1:${port}/info`);
+            if (res.ok) return;
+        } catch {
+            // Not up yet -- keep polling.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    throw new Error(`Server did not become ready on port ${port} within ${timeoutMs}ms`);
+}
+
+async function main() {
+    const port = 40000 + Math.floor(Math.random() * 5000);
+
+    // A syntactically valid connection string that is never actually
+    // dialed by anything this test exercises (pg.Pool connects lazily).
+    const child = spawn(process.execPath, [runnerPath, 'book-planning', String(port)], {
+        cwd: repoRoot,
+        env: {
+            ...process.env,
+            DATABASE_URL: 'postgresql://user:pass@127.0.0.1:1/route_precedence_test_unused',
+            NODE_ENV: 'test'
+        },
+        stdio: ['ignore', 'ignore', 'ignore']
+    });
+
+    let serverStartFailed = false;
+    child.on('error', () => { serverStartFailed = true; });
+
+    try {
+        await waitForServer(port, child);
+
+        // --- POST /mcp: literal route must win over /:sessionId ---
+        const toolsListRes = await postJson(port, '/mcp', {
+            jsonrpc: '2.0', id: 1, method: 'tools/list'
+        });
+        const toolsListBody = await toolsListRes.json();
+        check(
+            'POST /mcp tools/list reaches the JSON-RPC handler (HTTP 200)',
+            toolsListRes.status === 200,
+            `got HTTP ${toolsListRes.status}`
+        );
+        check(
+            'POST /mcp tools/list returns a JSON-RPC result with a tools array',
+            Array.isArray(toolsListBody?.result?.tools),
+            `body: ${JSON.stringify(toolsListBody)}`
+        );
+        check(
+            'POST /mcp tools/list is NOT the session-not-found shape',
+            toolsListBody?.message !== 'No active session with id: mcp'
+        );
+
+        const initRes = await postJson(port, '/mcp', {
+            jsonrpc: '2.0', id: 2, method: 'initialize'
+        });
+        const initBody = await initRes.json();
+        check(
+            'POST /mcp initialize returns a JSON-RPC result with protocolVersion',
+            typeof initBody?.result?.protocolVersion === 'string',
+            `body: ${JSON.stringify(initBody)}`
+        );
+
+        // --- POST /:sessionId: real (non-"mcp") session ids must still hit ---
+        // --- the session handler, not the JSON-RPC handler.               ---
+        const bogusSessionId = 'not-a-real-session-12345';
+        const sessionRes = await postJson(port, `/${bogusSessionId}`, {});
+        const sessionBody = await sessionRes.json();
+        check(
+            'POST /:sessionId for an unknown session still 404s via the session handler',
+            sessionRes.status === 404,
+            `got HTTP ${sessionRes.status}`
+        );
+        check(
+            'POST /:sessionId 404 body identifies the missing session (not JSON-RPC shaped)',
+            sessionBody?.error === 'Session not found' && sessionBody?.message?.includes(bogusSessionId),
+            `body: ${JSON.stringify(sessionBody)}`
+        );
+
+    } finally {
+        await new Promise((resolve) => {
+            child.once('exit', resolve);
+            child.kill();
+            // Belt-and-suspenders in case the process ignores the signal.
+            setTimeout(resolve, 3000);
+        });
+    }
+
+    check('Server process started without spawn error', !serverStartFailed);
+
+    console.log(`\n${passCount} passed, ${failCount} failed`);
+    // Intentionally NOT calling process.exit() here: forcing exit while an
+    // undici fetch() and a just-killed child_process handle are both still
+    // settling triggers a libuv assertion crash on Windows (unrelated to
+    // this repo's code -- reproduced with a single fetch + child.kill()).
+    // Setting exitCode and letting the event loop drain naturally avoids it.
+    process.exitCode = failCount > 0 ? 1 : 0;
+}
+
+main().catch((error) => {
+    console.error('Test run failed:', error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- In `src/single-server-runner.js`, the literal `POST /mcp` JSON-RPC endpoint was registered *after* the parameterized `POST /:sessionId` session-message route. Express matches routes in registration order, so a request to `POST /mcp` was captured by `/:sessionId` (with `sessionId === "mcp"`), which always missed the active-sessions lookup and returned `404 Session not found` instead of reaching the JSON-RPC handler.
- Fix moves the `/mcp` route registration ahead of `/:sessionId`. No handler logic changed — this is a route-ordering fix only.
- Adds a regression test (`test/single-server-runner/route-precedence-test.js`) that spawns the real server as a child process and exercises both routes over real HTTP: `POST /mcp` (tools/list, initialize) now returns proper JSON-RPC responses, and `POST /:sessionId` for a real (non-"mcp") session id still 404s via the session handler as before. No live database is touched — the DB pool connects lazily, so a syntactically valid but unreachable `DATABASE_URL` is enough.
- Wires the new test into CI as its own job (`single-server-runner-tests`), following the same no-DB pattern as the existing `kanban-github-sync-tests` job.

## Test plan

- [x] `node test/single-server-runner/route-precedence-test.js` — 7/7 checks pass against the fix
- [x] Confirmed the test fails (4/7) when run against the pre-fix route order, proving it actually guards the regression
- [x] Ran an unrelated existing suite (`node tests/kanban-server/github-sync-lib.test.js`) to confirm nothing else broke — 71/71 pass
- [x] No lint script is configured in this repo (no `.eslintrc*`), so none was run

Closes bead: mws-1783883496459-8-4a224c2b

🤖 Generated with [Claude Code](https://claude.com/claude-code)