### PR TITLE
plot-server: enable link_plot_threads, add get_world_systems read tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,29 @@ jobs:
       - name: Run github-sync orchestration tests (mocked DB + gh client)
         run: node tests/kanban-server/github-sync.test.js
 
+  plot-server-tests:
+    name: Plot Server Tests
+    runs-on: ubuntu-latest
+    # bead mws-1783883496416-7-47d7c3e7: link_plot_threads + get_world_systems
+    # coverage. DB is fully mocked (see tests/plot-server/), so no postgres
+    # service is needed here.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run plot-server tests
+        run: node tests/plot-server/run-tests.js
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest

--- a/src/config-mcps/book-planning-server/index.js
+++ b/src/config-mcps/book-planning-server/index.js
@@ -106,6 +106,15 @@ class BookPlanningMCPServer extends BaseMCPServer {
             });
         }
 
+        const linkPlotThreads = plotThreadTools.find(t => t.name === 'link_plot_threads');
+        if (linkPlotThreads) {
+            tools.push({
+                ...linkPlotThreads,
+                name: 'link_plot_threads',
+                description: `${linkPlotThreads.description}`
+            });
+        }
+
         // =============================================
         // 4. TIMELINE EVENT CREATION (Phase-specific)
         // =============================================
@@ -163,6 +172,7 @@ class BookPlanningMCPServer extends BaseMCPServer {
             // Plot thread handlers
             'create_plot_thread': (args) => this.plotThreadHandlers.handleCreatePlotThread(args),
             'update_plot_thread': (args) => this.plotThreadHandlers.handleUpdatePlotThread(args),
+            'link_plot_threads': (args) => this.plotThreadHandlers.handleLinkPlotThreads(args),
 
             // Timeline handlers
             'create_timeline_event': (args) => this.timelineEventHandlers.handleCreateTimelineEvent(args),

--- a/src/config-mcps/core-continuity-server/index.js
+++ b/src/config-mcps/core-continuity-server/index.js
@@ -18,10 +18,12 @@ import { CharacterDetailHandlers } from '../../mcps/character-server/handlers/ch
 import { CharacterKnowledgeHandlers } from '../../mcps/character-server/handlers/character-knowledge-handlers.js';
 import { CharacterTimelineHandlers } from '../../mcps/character-server/handlers/character-timeline-handlers.js';
 import { PlotThreadHandlers } from '../../mcps/plot-server/handlers/plot-thread-handlers.js';
+import { GenreExtensions } from '../../mcps/plot-server/handlers/genre-extensions.js';
 import { RelationshipHandlers } from '../../mcps/relationship-server/handlers/relationship-handlers.js';
 import { EventChapterMappingHandlers } from '../../mcps/timeline-server/handlers/timeline-chapter-mapping-handler.js';
 import { LookupManagementHandlers } from '../../mcps/metadata-server/handlers/lookup-management-handlers.js';
 import { TropeHandlers } from '../../mcps/trope-server/handlers/trope-handlers.js';
+import { genreExtensionToolsSchema } from '../../mcps/plot-server/schemas/plot-tools-schema.js';
 
 class CoreContinuityMCPServer extends BaseMCPServer {
     constructor() {
@@ -43,6 +45,7 @@ class CoreContinuityMCPServer extends BaseMCPServer {
         this.characterKnowledgeHandlers = new CharacterKnowledgeHandlers(this.db);
         this.characterTimelineHandlers = new CharacterTimelineHandlers(this.db);
         this.plotThreadHandlers = new PlotThreadHandlers(this.db);
+        this.genreExtensions = new GenreExtensions(this.db);
         this.relationshipHandlers = new RelationshipHandlers(this.db);
         this.eventChapterMappingHandlers = new EventChapterMappingHandlers(this.db);
         this.lookupHandlers = new LookupManagementHandlers(this.db);
@@ -103,6 +106,16 @@ class CoreContinuityMCPServer extends BaseMCPServer {
                 ...getPlotThreads,
                 name: 'get_plot_threads',
                 description: 'Get plot threads for checking continuity'
+            });
+        }
+
+        // WORLD SYSTEM TOOLS - read-only access for continuity checks
+        const getWorldSystems = genreExtensionToolsSchema.find(t => t.name === 'get_world_systems');
+        if (getWorldSystems) {
+            tools.push({
+                ...getWorldSystems,
+                name: 'get_world_systems',
+                description: 'Get world system definitions for checking power-system continuity'
             });
         }
 
@@ -176,6 +189,7 @@ class CoreContinuityMCPServer extends BaseMCPServer {
 
             // Plot handlers
             'get_plot_threads': (args) => this.plotThreadHandlers.handleGetPlotThreads(args),
+            'get_world_systems': (args) => this.genreExtensions.handleGetWorldSystems(args),
 
             // Relationship handlers
             'get_relationship_arc': (args) => this.relationshipHandlers.handleGetRelationshipArc(args),

--- a/src/config-mcps/series-planning-server/index.js
+++ b/src/config-mcps/series-planning-server/index.js
@@ -115,8 +115,8 @@ class SeriesPlanningMCPServer extends BaseMCPServer {
                 });
             });
 
-        // Plot/Genre extension tools - only define_world_system
-        const neededPlotTools = ['define_world_system'];
+        // Plot/Genre extension tools - define_world_system + get_world_systems
+        const neededPlotTools = ['define_world_system', 'get_world_systems'];
         genreExtensionToolsSchema
             .filter(tool => neededPlotTools.includes(tool.name))
             .forEach(tool => {
@@ -168,6 +168,7 @@ class SeriesPlanningMCPServer extends BaseMCPServer {
 
             // Plot/Genre extension handlers
             'define_world_system': this.genreExtensions.handleDefineWorldSystem.bind(this.genreExtensions),
+            'get_world_systems': this.genreExtensions.handleGetWorldSystems.bind(this.genreExtensions),
 
             // Trope handlers (create only; lookups in core-continuity)
             'create_trope': this.tropeHandlers.handleCreateTrope.bind(this.tropeHandlers)

--- a/src/mcps/plot-server/handlers/genre-extensions.js
+++ b/src/mcps/plot-server/handlers/genre-extensions.js
@@ -326,10 +326,96 @@ export class GenreExtensions {
         }
     }
     
+    async handleGetWorldSystems(args) {
+        try {
+            if (!args.series_id || typeof args.series_id !== 'number' || args.series_id < 1) {
+                throw new Error('series_id must be a positive number');
+            }
+
+            // Validate series exists
+            const seriesCheck = await this.db.query(
+                'SELECT id, title FROM series WHERE id = $1',
+                [args.series_id]
+            );
+
+            if (seriesCheck.rows.length === 0) {
+                throw new Error(`Series with ID ${args.series_id} not found`);
+            }
+
+            let query = `
+                SELECT id, series_id, system_name, system_type, power_source,
+                       access_method, limitations, system_rules, power_scaling,
+                       system_users, created_at, updated_at
+                FROM world_systems
+                WHERE series_id = $1
+            `;
+            const queryParams = [args.series_id];
+
+            if (args.system_type) {
+                query += ' AND system_type = $2';
+                queryParams.push(args.system_type);
+            }
+
+            query += ' ORDER BY system_name';
+
+            const result = await this.db.query(query, queryParams);
+            const systems = result.rows;
+
+            if (systems.length === 0) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `No world systems found for series "${seriesCheck.rows[0].title}"${args.system_type ? ` with type "${args.system_type}"` : ''}.`
+                        }
+                    ]
+                };
+            }
+
+            let output = `# World Systems for "${seriesCheck.rows[0].title}"\n\n`;
+            output += `Found ${systems.length} system(s):\n\n`;
+
+            systems.forEach(system => {
+                output += `### ${system.system_name} (ID: ${system.id})\n`;
+                output += `- **Type:** ${system.system_type}\n`;
+                output += `- **Power Source:** ${system.power_source}\n`;
+                output += `- **Access Method:** ${system.access_method}\n`;
+                if (system.limitations && system.limitations.length > 0) {
+                    output += `- **Limitations:** ${system.limitations.join('; ')}\n`;
+                }
+                if (system.system_rules && system.system_rules.length > 0) {
+                    output += `- **Rules:** ${system.system_rules.join('; ')}\n`;
+                }
+                if (system.power_scaling) {
+                    const scaling = typeof system.power_scaling === 'string'
+                        ? JSON.parse(system.power_scaling)
+                        : system.power_scaling;
+                    if (scaling && (scaling.lowest_level || scaling.highest_level || scaling.progression_method)) {
+                        output += `- **Power Scaling:** ${scaling.lowest_level || '?'} to ${scaling.highest_level || '?'}` +
+                            `${scaling.progression_method ? ` (via ${scaling.progression_method})` : ''}\n`;
+                    }
+                }
+                output += '\n';
+            });
+
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: output
+                    }
+                ]
+            };
+
+        } catch (error) {
+            throw new Error(`Failed to get world systems: ${error.message}`);
+        }
+    }
+
     // =============================================
     // EVIDENCE AND RELATIONSHIP TRACKING
     // =============================================
-    
+
     async handleAddRevealEvidence(args) {
         try {
             // Validate reveal exists

--- a/src/mcps/plot-server/handlers/plot-thread-handlers.js
+++ b/src/mcps/plot-server/handlers/plot-thread-handlers.js
@@ -400,81 +400,83 @@ export class PlotThreadHandlers {
         }
     }
     
-    // async handleLinkPlotThreads(args) {
-    //     try {
-    //         // Validate input
-    //         const validation = PlotValidators.validateThreadRelationship(args);
-    //         if (!validation.valid) {
-    //             throw new Error(`Validation failed: ${validation.errors.join(', ')}`);
-    //         }
-            
-    //         // Check if both threads exist
-    //         const threadsCheck = await this.db.query(
-    //             'SELECT id, title FROM plot_threads WHERE id = ANY($1)',
-    //             [[args.thread_a_id, args.thread_b_id]]
-    //         );
-            
-    //         if (threadsCheck.rows.length !== 2) {
-    //             throw new Error('One or both plot threads not found');
-    //         }
-            
-    //         // Check for existing relationship
-    //         const existingCheck = await this.db.query(
-    //             'SELECT id FROM plot_thread_relationships WHERE thread_a_id = $1 AND thread_b_id = $2',
-    //             [args.thread_a_id, args.thread_b_id]
-    //         );
-            
-    //         if (existingCheck.rows.length > 0) {
-    //             throw new Error('Relationship between these threads already exists');
-    //         }
-            
-    //         // Get relationship type ID from lookup table
-    //         const relationshipTypeResult = await this.db.query(
-    //             'SELECT id, type_name FROM relationship_types WHERE type_name = $1 AND is_active = true',
-    //             [args.relationship_type]
-    //         );
-            
-    //         if (relationshipTypeResult.rows.length === 0) {
-    //             throw new Error(`Invalid relationship type: ${args.relationship_type}. Use get_available_options with option_type='relationship_types' to see valid values.`);
-    //         }
+    async handleLinkPlotThreads(args) {
+        try {
+            // Validate input
+            const validation = PlotValidators.validateThreadRelationship(args);
+            if (!validation.valid) {
+                throw new Error(`Validation failed: ${validation.errors.join(', ')}`);
+            }
 
-    //         // Insert the relationship
-    //         const insertQuery = `
-    //             INSERT INTO plot_thread_relationships (
-    //                 thread_a_id, thread_b_id, relationship_type_id, relationship_description,
-    //                 strength, established_book
-    //             ) VALUES ($1, $2, $3, $4, $5, $6)
-    //             RETURNING id
-    //         `;
-            
-    //         await this.db.query(insertQuery, [
-    //             args.thread_a_id,
-    //             args.thread_b_id,
-    //             relationshipTypeResult.rows[0].relationship_type_id,
-    //             args.relationship_description || null,
-    //             args.strength || 5,
-    //             args.established_book || null
-    //         ]);
-            
-    //         const threadNames = threadsCheck.rows.map(t => t.title);
-            
-    //         return {
-    //             content: [
-    //                 {
-    //                     type: 'text',
-    //                     text: `Successfully linked plot threads!\n\n` +
-    //                           `**Relationship:** "${threadNames[0]}" ${relationshipTypeResult.rows[0].type_name.replace('_', ' ')} "${threadNames[1]}"\n` +
-    //                           `**Strength:** ${args.strength || 5}/10\n` +
-    //                           `${args.relationship_description ? `**Description:** ${args.relationship_description}\n` : ''}` +
-    //                           `${args.established_book ? `**Established in Book:** ${args.established_book}` : ''}`
-    //                 }
-    //             ]
-    //         };
-            
-    //     } catch (error) {
-    //         throw new Error(`Failed to link plot threads: ${error.message}`);
-    //     }
-    // }
+            // Check if both threads exist
+            const threadsCheck = await this.db.query(
+                'SELECT id, title FROM plot_threads WHERE id = ANY($1)',
+                [[args.thread_a_id, args.thread_b_id]]
+            );
+
+            if (threadsCheck.rows.length !== 2) {
+                throw new Error('One or both plot threads not found');
+            }
+
+            // Check for existing relationship (either direction)
+            const existingCheck = await this.db.query(
+                `SELECT id FROM plot_thread_relationships
+                 WHERE (thread_a_id = $1 AND thread_b_id = $2)
+                    OR (thread_a_id = $2 AND thread_b_id = $1)`,
+                [args.thread_a_id, args.thread_b_id]
+            );
+
+            if (existingCheck.rows.length > 0) {
+                throw new Error('Relationship between these threads already exists');
+            }
+
+            // Get relationship type ID from lookup table
+            const relationshipTypeResult = await this.db.query(
+                'SELECT id, type_name FROM relationship_types WHERE type_name = $1 AND is_active = true',
+                [args.relationship_type]
+            );
+
+            if (relationshipTypeResult.rows.length === 0) {
+                throw new Error(`Invalid relationship type: ${args.relationship_type}. Use get_available_options with option_type='relationship_types' to see valid values.`);
+            }
+
+            // Insert the relationship
+            const insertQuery = `
+                INSERT INTO plot_thread_relationships (
+                    thread_a_id, thread_b_id, relationship_type_id, relationship_description,
+                    strength, established_book
+                ) VALUES ($1, $2, $3, $4, $5, $6)
+                RETURNING id
+            `;
+
+            await this.db.query(insertQuery, [
+                args.thread_a_id,
+                args.thread_b_id,
+                relationshipTypeResult.rows[0].id,
+                args.relationship_description || null,
+                args.strength || 5,
+                args.established_book || null
+            ]);
+
+            const threadNames = threadsCheck.rows.map(t => t.title);
+
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `Successfully linked plot threads!\n\n` +
+                              `**Relationship:** "${threadNames[0]}" ${relationshipTypeResult.rows[0].type_name.replace('_', ' ')} "${threadNames[1]}"\n` +
+                              `**Strength:** ${args.strength || 5}/10\n` +
+                              `${args.relationship_description ? `**Description:** ${args.relationship_description}\n` : ''}` +
+                              `${args.established_book ? `**Established in Book:** ${args.established_book}` : ''}`
+                    }
+                ]
+            };
+
+        } catch (error) {
+            throw new Error(`Failed to link plot threads: ${error.message}`);
+        }
+    }
     
     async handleResolvePlotThread(args) {
         try {

--- a/src/mcps/plot-server/index.js
+++ b/src/mcps/plot-server/index.js
@@ -69,12 +69,13 @@ class PlotMCPServer extends BaseMCPServer {
             this.handleCreatePlotThread = this.plotThreadHandlers.handleCreatePlotThread.bind(this.plotThreadHandlers);
             this.handleUpdatePlotThread = this.plotThreadHandlers.handleUpdatePlotThread.bind(this.plotThreadHandlers);
             this.handleGetPlotThreads = this.plotThreadHandlers.handleGetPlotThreads.bind(this.plotThreadHandlers);
-            //this.handleLinkPlotThreads = this.plotThreadHandlers.handleLinkPlotThreads.bind(this.plotThreadHandlers);
+            this.handleLinkPlotThreads = this.plotThreadHandlers.handleLinkPlotThreads.bind(this.plotThreadHandlers);
             this.handleResolvePlotThread = this.plotThreadHandlers.handleResolvePlotThread.bind(this.plotThreadHandlers);
 
             // Bind universal genre extension methods
             this.handleCreateInformationReveal = this.genreExtensions.handleCreateInformationReveal.bind(this.genreExtensions);
             this.handleDefineWorldSystem = this.genreExtensions.handleDefineWorldSystem.bind(this.genreExtensions);
+            this.handleGetWorldSystems = this.genreExtensions.handleGetWorldSystems.bind(this.genreExtensions);
             this.handleAddRevealEvidence = this.genreExtensions.handleAddRevealEvidence.bind(this.genreExtensions);
             this.handleTrackSystemProgression = this.genreExtensions.handleTrackSystemProgression.bind(this.genreExtensions);
 
@@ -139,12 +140,13 @@ class PlotMCPServer extends BaseMCPServer {
             'create_plot_thread': this.handleCreatePlotThread,
             'update_plot_thread': this.handleUpdatePlotThread,
             'get_plot_threads': this.handleGetPlotThreads,
-            //'link_plot_threads': this.handleLinkPlotThreads,
+            'link_plot_threads': this.handleLinkPlotThreads,
             'resolve_plot_thread': this.handleResolvePlotThread,
 
             // Universal Genre Handlers (replaces old genre-specific ones)
             'create_information_reveal': this.handleCreateInformationReveal,
             'define_world_system': this.handleDefineWorldSystem,
+            'get_world_systems': this.handleGetWorldSystems,
             'add_reveal_evidence': this.handleAddRevealEvidence,
             'track_system_progression': this.handleTrackSystemProgression
         };

--- a/src/mcps/plot-server/schemas/plot-tools-schema.js
+++ b/src/mcps/plot-server/schemas/plot-tools-schema.js
@@ -80,31 +80,31 @@ export const plotThreadToolsSchema = [
             required: ['series_id']
         }
     },
-    // {
-    //     name: 'link_plot_threads',
-    //     description: 'Create relationships between plot threads',
-    //     inputSchema: {
-    //         type: 'object',
-    //         properties: {
-    //             thread_a_id: { type: 'integer', description: 'First thread ID' },
-    //             thread_b_id: { type: 'integer', description: 'Second thread ID' },
-    //             relationship_type: { 
-    //                 type: 'string', 
-    //                 description: 'Type of relationship (use get_available_options with option_type="relationship_types" to see valid values)'
-    //             },
-    //             relationship_description: { type: 'string', description: 'Description of the relationship' },
-    //             strength: { 
-    //                 type: 'integer', 
-    //                 minimum: 1, 
-    //                 maximum: 10, 
-    //                 default: 5,
-    //                 description: 'Relationship strength (1-10)'
-    //             },
-    //             established_book: { type: 'integer', description: 'Book where relationship is established' }
-    //         },
-    //         required: ['thread_a_id', 'thread_b_id', 'relationship_type']
-    //     }
-    // },
+    {
+        name: 'link_plot_threads',
+        description: 'Create relationships between plot threads',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                thread_a_id: { type: 'integer', description: 'First thread ID' },
+                thread_b_id: { type: 'integer', description: 'Second thread ID' },
+                relationship_type: {
+                    type: 'string',
+                    description: 'Type of relationship (use get_available_options with option_type="relationship_types" to see valid values)'
+                },
+                relationship_description: { type: 'string', description: 'Description of the relationship' },
+                strength: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: 10,
+                    default: 5,
+                    description: 'Relationship strength (1-10)'
+                },
+                established_book: { type: 'integer', description: 'Book where relationship is established' }
+            },
+            required: ['thread_a_id', 'thread_b_id', 'relationship_type']
+        }
+    },
     {
         name: 'resolve_plot_thread',
         description: 'Resolve plot thread',
@@ -228,6 +228,22 @@ export const genreExtensionToolsSchema = [
                 }
             },
             required: ['series_id', 'system_name', 'system_type', 'power_source', 'access_method']
+        }
+    },
+    {
+        name: 'get_world_systems',
+        description: 'Get world system definitions (magic/tech/power systems) for a series',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                series_id: { type: 'integer', description: 'Series ID' },
+                system_type: {
+                    type: 'string',
+                    enum: ['magic', 'psionics', 'technology', 'divine', 'supernatural', 'mutation', 'alchemy'],
+                    description: 'Filter by system type?'
+                }
+            },
+            required: ['series_id']
         }
     },
     {

--- a/tests/plot-server/genre-extensions.test.js
+++ b/tests/plot-server/genre-extensions.test.js
@@ -1,0 +1,190 @@
+// tests/plot-server/genre-extensions.test.js
+// Tests for GenreExtensions.handleGetWorldSystems (bead mws-7 acceptance
+// criteria #2): define_world_system was write-only with no way to read
+// back what it wrote. These tests exercise the new read tool against a
+// mocked db (no live database required).
+
+import { fileURLToPath } from 'url';
+import { GenreExtensions } from '../../src/mcps/plot-server/handlers/genre-extensions.js';
+
+// Mock database for testing - matches the pattern used in
+// tests/database-admin-server/schema-introspection.test.js
+class MockDatabase {
+    constructor() {
+        this.queryResults = new Map();
+        this.queries = [];
+    }
+
+    setQueryResult(queryPattern, rows) {
+        this.queryResults.set(queryPattern, { rows });
+    }
+
+    async query(text, params = []) {
+        this.queries.push({ text, params });
+        for (const [pattern, result] of this.queryResults.entries()) {
+            if (text.includes(pattern)) {
+                return result;
+            }
+        }
+        return { rows: [] };
+    }
+}
+
+const tests = { passed: 0, failed: 0, total: 0 };
+
+function assert(condition, message) {
+    tests.total++;
+    if (condition) {
+        tests.passed++;
+        console.log(`  ✓ ${message}`);
+    } else {
+        tests.failed++;
+        console.error(`  ✗ ${message}`);
+        throw new Error(`Assertion failed: ${message}`);
+    }
+}
+
+async function assertRejects(promise, messageIncludes, description) {
+    tests.total++;
+    try {
+        await promise;
+        tests.failed++;
+        console.error(`  ✗ ${description} (expected rejection, got success)`);
+    } catch (error) {
+        if (error.message.includes(messageIncludes)) {
+            tests.passed++;
+            console.log(`  ✓ ${description}`);
+        } else {
+            tests.failed++;
+            console.error(`  ✗ ${description} (wrong error: ${error.message})`);
+        }
+    }
+}
+
+export async function runTests() {
+    console.log('\n=== GenreExtensions: get_world_systems Test Suite ===\n');
+
+    await testGetWorldSystemsRoundTrip();
+    await testGetWorldSystemsFilterByType();
+    await testGetWorldSystemsEmpty();
+    await testGetWorldSystemsMissingSeries();
+    await testGetWorldSystemsValidation();
+
+    console.log('\n=== Test Summary ===');
+    console.log(`Total: ${tests.total}`);
+    console.log(`Passed: ${tests.passed}`);
+    console.log(`Failed: ${tests.failed}`);
+
+    if (tests.failed > 0) {
+        console.error('\n❌ Some tests failed!');
+    } else {
+        console.log('\n✅ All tests passed!');
+    }
+
+    return tests.failed === 0;
+}
+
+async function testGetWorldSystemsRoundTrip() {
+    console.log('\n--- get_world_systems: round-trips what define_world_system wrote ---');
+    const mockDb = new MockDatabase();
+
+    mockDb.setQueryResult('SELECT id, title FROM series', [{ id: 5, title: 'Test Series' }]);
+    mockDb.setQueryResult('FROM world_systems', [
+        {
+            id: 10,
+            series_id: 5,
+            system_name: 'Elemental Magic',
+            system_type: 'magic',
+            power_source: 'ambient elemental energy',
+            access_method: 'ritual attunement',
+            limitations: ['requires physical contact', 'exhausting'],
+            system_rules: ['cannot create matter, only transform it'],
+            power_scaling: { lowest_level: 'spark', highest_level: 'storm-caller', progression_method: 'training' },
+            system_users: [1, 2],
+            created_at: new Date(),
+            updated_at: new Date()
+        }
+    ]);
+
+    const genreExtensions = new GenreExtensions(mockDb);
+    const result = await genreExtensions.handleGetWorldSystems({ series_id: 5 });
+
+    const text = result.content[0].text;
+    assert(text.includes('Elemental Magic'), 'includes the system name written by define_world_system');
+    assert(text.includes('magic'), 'includes the system type');
+    assert(text.includes('ambient elemental energy'), 'includes the power source');
+    assert(text.includes('ritual attunement'), 'includes the access method');
+    assert(text.includes('requires physical contact'), 'includes limitations');
+    assert(text.includes('cannot create matter'), 'includes system rules');
+    assert(text.includes('spark'), 'includes power scaling');
+
+    const seriesQuery = mockDb.queries.find(q => q.text.includes('SELECT id, title FROM series'));
+    assert(seriesQuery.params[0] === 5, 'series_id passed through to series existence check');
+}
+
+async function testGetWorldSystemsFilterByType() {
+    console.log('\n--- get_world_systems: filters by system_type ---');
+    const mockDb = new MockDatabase();
+    mockDb.setQueryResult('SELECT id, title FROM series', [{ id: 5, title: 'Test Series' }]);
+    mockDb.setQueryResult('FROM world_systems', [
+        { id: 10, series_id: 5, system_name: 'Elemental Magic', system_type: 'magic', power_source: 'x', access_method: 'y', limitations: [], system_rules: [], power_scaling: null }
+    ]);
+
+    const genreExtensions = new GenreExtensions(mockDb);
+    await genreExtensions.handleGetWorldSystems({ series_id: 5, system_type: 'magic' });
+
+    const worldQuery = mockDb.queries.find(q => q.text.includes('FROM world_systems'));
+    assert(worldQuery.text.includes('system_type = $2'), 'query includes system_type filter clause');
+    assert(worldQuery.params[1] === 'magic', 'system_type filter value bound correctly');
+}
+
+async function testGetWorldSystemsEmpty() {
+    console.log('\n--- get_world_systems: handles no systems defined yet ---');
+    const mockDb = new MockDatabase();
+    mockDb.setQueryResult('SELECT id, title FROM series', [{ id: 5, title: 'Test Series' }]);
+    mockDb.setQueryResult('FROM world_systems', []);
+
+    const genreExtensions = new GenreExtensions(mockDb);
+    const result = await genreExtensions.handleGetWorldSystems({ series_id: 5 });
+
+    assert(result.content[0].text.includes('No world systems found'), 'reports no world systems found');
+}
+
+async function testGetWorldSystemsMissingSeries() {
+    console.log('\n--- get_world_systems: rejects unknown series ---');
+    const mockDb = new MockDatabase();
+    mockDb.setQueryResult('SELECT id, title FROM series', []); // series lookup miss
+
+    const genreExtensions = new GenreExtensions(mockDb);
+
+    await assertRejects(
+        genreExtensions.handleGetWorldSystems({ series_id: 999 }),
+        'not found',
+        'rejects a series_id that does not exist'
+    );
+}
+
+async function testGetWorldSystemsValidation() {
+    console.log('\n--- get_world_systems: input validation ---');
+    const mockDb = new MockDatabase();
+    const genreExtensions = new GenreExtensions(mockDb);
+
+    await assertRejects(
+        genreExtensions.handleGetWorldSystems({}),
+        'series_id must be a positive number',
+        'rejects missing series_id'
+    );
+
+    await assertRejects(
+        genreExtensions.handleGetWorldSystems({ series_id: -1 }),
+        'series_id must be a positive number',
+        'rejects a negative series_id'
+    );
+}
+
+// Allow running this file standalone: `node tests/plot-server/genre-extensions.test.js`
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+    runTests().then(ok => {
+        process.exitCode = ok ? 0 : 1;
+    });
+}

--- a/tests/plot-server/plot-thread-handlers.test.js
+++ b/tests/plot-server/plot-thread-handlers.test.js
@@ -1,0 +1,226 @@
+// tests/plot-server/plot-thread-handlers.test.js
+// Tests for PlotThreadHandlers, focused on link_plot_threads (bead mws-7):
+// the tool was fully defined but commented out with no live write path to
+// plot_thread_relationships. These tests exercise the re-enabled handler
+// against a mocked db (no live database required).
+
+import { fileURLToPath } from 'url';
+import { PlotThreadHandlers } from '../../src/mcps/plot-server/handlers/plot-thread-handlers.js';
+
+// Mock database for testing - matches the pattern used in
+// tests/database-admin-server/schema-introspection.test.js
+class MockDatabase {
+    constructor() {
+        this.queryResults = new Map();
+        this.queries = [];
+    }
+
+    setQueryResult(queryPattern, rows) {
+        this.queryResults.set(queryPattern, { rows });
+    }
+
+    async query(text, params = []) {
+        this.queries.push({ text, params });
+        for (const [pattern, result] of this.queryResults.entries()) {
+            if (text.includes(pattern)) {
+                return typeof result === 'function' ? result(params) : result;
+            }
+        }
+        return { rows: [] };
+    }
+}
+
+// Test results tracking
+const tests = { passed: 0, failed: 0, total: 0 };
+
+function assert(condition, message) {
+    tests.total++;
+    if (condition) {
+        tests.passed++;
+        console.log(`  ✓ ${message}`);
+    } else {
+        tests.failed++;
+        console.error(`  ✗ ${message}`);
+        throw new Error(`Assertion failed: ${message}`);
+    }
+}
+
+async function assertRejects(promise, messageIncludes, description) {
+    tests.total++;
+    try {
+        await promise;
+        tests.failed++;
+        console.error(`  ✗ ${description} (expected rejection, got success)`);
+    } catch (error) {
+        if (error.message.includes(messageIncludes)) {
+            tests.passed++;
+            console.log(`  ✓ ${description}`);
+        } else {
+            tests.failed++;
+            console.error(`  ✗ ${description} (wrong error: ${error.message})`);
+        }
+    }
+}
+
+export async function runTests() {
+    console.log('\n=== PlotThreadHandlers: link_plot_threads Test Suite ===\n');
+
+    await testLinkPlotThreadsRoundTrip();
+    await testLinkPlotThreadsInvalidRelationshipType();
+    await testLinkPlotThreadsMissingThread();
+    await testLinkPlotThreadsDuplicateRelationship();
+    await testLinkPlotThreadsValidation();
+
+    console.log('\n=== Test Summary ===');
+    console.log(`Total: ${tests.total}`);
+    console.log(`Passed: ${tests.passed}`);
+    console.log(`Failed: ${tests.failed}`);
+
+    if (tests.failed > 0) {
+        console.error('\n❌ Some tests failed!');
+    } else {
+        console.log('\n✅ All tests passed!');
+    }
+
+    return tests.failed === 0;
+}
+
+async function testLinkPlotThreadsRoundTrip() {
+    console.log('\n--- link_plot_threads: create two threads, link parent/child ---');
+    const mockDb = new MockDatabase();
+
+    mockDb.setQueryResult('SELECT id, title FROM plot_threads WHERE id = ANY', [
+        { id: 1, title: 'Thread A' },
+        { id: 2, title: 'Thread B' }
+    ]);
+    mockDb.setQueryResult('FROM plot_thread_relationships', []); // no existing relationship
+    mockDb.setQueryResult('FROM relationship_types', [
+        { id: 42, type_name: 'depends_on' }
+    ]);
+    mockDb.setQueryResult('INSERT INTO plot_thread_relationships', [{ id: 100 }]);
+
+    const handlers = new PlotThreadHandlers(mockDb);
+
+    const result = await handlers.handleLinkPlotThreads({
+        thread_a_id: 1,
+        thread_b_id: 2,
+        relationship_type: 'depends_on',
+        relationship_description: 'B needs A resolved first',
+        strength: 7,
+        established_book: 2
+    });
+
+    assert(result.content[0].text.includes('Successfully linked plot threads'), 'returns success message');
+    assert(result.content[0].text.includes('Thread A'), 'includes thread A title');
+    assert(result.content[0].text.includes('Thread B'), 'includes thread B title');
+    assert(result.content[0].text.includes('7/10'), 'includes strength');
+
+    // Verify the INSERT wrote a real row using the resolved relationship_type_id (not undefined)
+    const insertCall = mockDb.queries.find(q => q.text.includes('INSERT INTO plot_thread_relationships'));
+    assert(insertCall !== undefined, 'issued an INSERT into plot_thread_relationships');
+    assert(insertCall.params[0] === 1, 'thread_a_id bound correctly');
+    assert(insertCall.params[1] === 2, 'thread_b_id bound correctly');
+    assert(insertCall.params[2] === 42, 'relationship_type_id resolved from lookup (id, not undefined)');
+    assert(insertCall.params[3] === 'B needs A resolved first', 'relationship_description bound correctly');
+    assert(insertCall.params[4] === 7, 'strength bound correctly');
+    assert(insertCall.params[5] === 2, 'established_book bound correctly');
+}
+
+async function testLinkPlotThreadsInvalidRelationshipType() {
+    console.log('\n--- link_plot_threads: rejects unknown relationship_type ---');
+    const mockDb = new MockDatabase();
+    mockDb.setQueryResult('SELECT id, title FROM plot_threads WHERE id = ANY', [
+        { id: 1, title: 'Thread A' },
+        { id: 2, title: 'Thread B' }
+    ]);
+    mockDb.setQueryResult('FROM plot_thread_relationships', []);
+    mockDb.setQueryResult('FROM relationship_types', []); // lookup miss
+
+    const handlers = new PlotThreadHandlers(mockDb);
+
+    await assertRejects(
+        handlers.handleLinkPlotThreads({
+            thread_a_id: 1,
+            thread_b_id: 2,
+            relationship_type: 'not_a_real_type'
+        }),
+        'Invalid relationship type',
+        'rejects an unknown relationship_type'
+    );
+}
+
+async function testLinkPlotThreadsMissingThread() {
+    console.log('\n--- link_plot_threads: rejects when a thread does not exist ---');
+    const mockDb = new MockDatabase();
+    // Only one of the two threads exists
+    mockDb.setQueryResult('SELECT id, title FROM plot_threads WHERE id = ANY', [
+        { id: 1, title: 'Thread A' }
+    ]);
+
+    const handlers = new PlotThreadHandlers(mockDb);
+
+    await assertRejects(
+        handlers.handleLinkPlotThreads({
+            thread_a_id: 1,
+            thread_b_id: 999,
+            relationship_type: 'enables'
+        }),
+        'One or both plot threads not found',
+        'rejects when one thread is missing'
+    );
+}
+
+async function testLinkPlotThreadsDuplicateRelationship() {
+    console.log('\n--- link_plot_threads: rejects duplicate relationship (either direction) ---');
+    const mockDb = new MockDatabase();
+    mockDb.setQueryResult('SELECT id, title FROM plot_threads WHERE id = ANY', [
+        { id: 1, title: 'Thread A' },
+        { id: 2, title: 'Thread B' }
+    ]);
+    mockDb.setQueryResult('FROM plot_thread_relationships', [{ id: 55 }]); // already exists
+
+    const handlers = new PlotThreadHandlers(mockDb);
+
+    await assertRejects(
+        handlers.handleLinkPlotThreads({
+            thread_a_id: 1,
+            thread_b_id: 2,
+            relationship_type: 'enables'
+        }),
+        'already exists',
+        'rejects a duplicate relationship'
+    );
+}
+
+async function testLinkPlotThreadsValidation() {
+    console.log('\n--- link_plot_threads: input validation ---');
+    const mockDb = new MockDatabase();
+    const handlers = new PlotThreadHandlers(mockDb);
+
+    await assertRejects(
+        handlers.handleLinkPlotThreads({
+            thread_a_id: 1,
+            thread_b_id: 1, // same thread
+            relationship_type: 'enables'
+        }),
+        'must be different',
+        'rejects linking a thread to itself'
+    );
+
+    await assertRejects(
+        handlers.handleLinkPlotThreads({
+            thread_a_id: 1,
+            thread_b_id: 2
+            // missing relationship_type
+        }),
+        'relationship_type must be a non-empty string',
+        'rejects missing relationship_type'
+    );
+}
+
+// Allow running this file standalone: `node tests/plot-server/plot-thread-handlers.test.js`
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+    runTests().then(ok => {
+        process.exitCode = ok ? 0 : 1;
+    });
+}

--- a/tests/plot-server/run-tests.js
+++ b/tests/plot-server/run-tests.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// tests/plot-server/run-tests.js
+// Test runner for plot-server tests (bead mws-1783883496416-7-47d7c3e7):
+// link_plot_threads round-trip + get_world_systems round-trip.
+// Both suites use a mocked db - no live database connection required.
+
+import { runTests as runPlotThreadHandlerTests } from './plot-thread-handlers.test.js';
+import { runTests as runGenreExtensionTests } from './genre-extensions.test.js';
+
+console.log('🧪 Running Plot Server Tests\n');
+console.log('═'.repeat(70));
+
+let ok = true;
+
+try {
+    ok = (await runPlotThreadHandlerTests()) && ok;
+} catch (error) {
+    console.error('Fatal error running plot-thread-handlers tests:', error);
+    ok = false;
+}
+
+try {
+    ok = (await runGenreExtensionTests()) && ok;
+} catch (error) {
+    console.error('Fatal error running genre-extensions tests:', error);
+    ok = false;
+}
+
+console.log('\n' + '═'.repeat(70));
+process.exitCode = ok ? 0 : 1;


### PR DESCRIPTION
## Summary

`plot_thread_relationships` had no live write path: `link_plot_threads` was fully defined in the plot-server schema but commented out, and its handler-map entry was also commented out (and malformed). Separately, the genre-extension write tools had no read counterpart for world systems, so `define_world_system` output could not be read back via any MCP tool.

- Re-enabled `link_plot_threads`: uncommented the schema block, fixed the handler-map entry, and fixed a latent bug in the handler implementation that referenced a non-existent `relationship_type_id` field on the lookup query result (it selects `id, type_name`) — this would have thrown/inserted `undefined` into a `NOT NULL` column on first real use. Also hardened the duplicate-relationship check to look in both directions.
- Added `get_world_systems` (read, series-scoped, with optional `system_type` filter) so `define_world_system`'s output is consumable.
- Wired both tools through the same handler/schema/registration path used by the other live plot-server tools:
  - `link_plot_threads` → `book-planning-server` (alongside `create_plot_thread` / `update_plot_thread`)
  - `get_world_systems` → `series-planning-server` (paired with `define_world_system`) and `core-continuity-server` (for downstream world-canon consumers during writing)
- Added unit tests against a mocked db (no live database required) covering: link round-trip (create two threads, link them, verify the resolved `relationship_type_id` is bound correctly instead of `undefined`), invalid relationship type, missing thread, duplicate relationship, and input validation; plus `get_world_systems` round-trip, type filtering, empty result, missing series, and input validation.
- Added a CI job (`plot-server-tests`) that runs these tests.

## Test plan

- [x] `node tests/plot-server/run-tests.js` — 30/30 assertions pass (16 `link_plot_threads`, 14 `get_world_systems`)
- [x] `node --check` on every modified file (syntax verification)
- [ ] Reviewer: confirm tool routing in `book-planning-server` / `series-planning-server` / `core-continuity-server` matches where you expect these tools to live in the writing-step workflow

No live containers or the live database were touched — tests run entirely against a mocked db per the existing `tests/database-admin-server/schema-introspection.test.js` pattern.

Closes bead: mws-1783883496416-7-47d7c3e7

🤖 Generated with [Claude Code](https://claude.com/claude-code)