### PR TITLE
fix(kanban-server): stop concurrent-claim-test.js from polluting the identity registry

### DIFF
--- a/migrations/045_kanban_identities_cleanup_race_test_pollution.sql
+++ b/migrations/045_kanban_identities_cleanup_race_test_pollution.sql
@@ -1,0 +1,53 @@
+-- Migration: 045_kanban_identities_cleanup_race_test_pollution
+-- Description: One-time, idempotent cleanup for the identity pollution bug
+-- fixed in bead mws-1783883496146-1 (GH issue #76). Before that fix,
+-- test/kanban-server/concurrent-claim-test.js minted 40 throwaway agent ids
+-- per run (claim_card auto-registers any first-seen claiming agent id as a
+-- permanent kind='agent' row -- see claim-handlers.js / migration 044) and
+-- never cleaned them up, so any run against a real database permanently
+-- polluted the fictionlab.kanban_identities dropdown with rows like
+-- 'claude-code:race-a-7' / 'local-qwen3-14b:race-b-7'.
+--
+-- This is a DOCUMENTED, RE-RUNNABLE migration for any deployment that still
+-- carries that pollution (the specific instance this bug was filed from was
+-- already hand-cleaned per the bead's "Already done" note -- this migration
+-- exists so every OTHER clone/environment gets the same cleanup through the
+-- normal migration path instead of someone hand-running DELETEs against a
+-- live database again).
+--
+-- Matches BOTH the old un-namespaced ids the test used to mint
+-- ('claude-code:race-a-<n>', 'local-qwen3-14b:race-b-<n>') and the new
+-- 'test:'-namespaced ids the fixed test now mints, in case a test run was
+-- ever interrupted before its own in-process cleanup (concurrent-claim-test.js
+-- finally block) could run. Scoped tightly to kind='agent' and the exact
+-- race-[ab]-<n> suffix pattern -- this can never touch a real
+-- human/persona/agent identity, whose ids don't match this shape.
+
+DO $$
+DECLARE
+    deleted_count INT;
+BEGIN
+    IF EXISTS (SELECT 1 FROM migrations WHERE filename = '045_kanban_identities_cleanup_race_test_pollution.sql') THEN
+        RAISE NOTICE 'Migration 045_kanban_identities_cleanup_race_test_pollution.sql already applied, skipping.';
+        RETURN;
+    END IF;
+
+    DELETE FROM fictionlab.kanban_identities
+     WHERE kind = 'agent'
+       AND (
+            id ~ '^claude-code:race-[ab]-[0-9]+$'
+         OR id ~ '^local-qwen3-14b:race-[ab]-[0-9]+$'
+         OR id ~ '^test:claude-code:race-[ab]-[0-9]+$'
+         OR id ~ '^test:local-qwen3-14b:race-[ab]-[0-9]+$'
+       );
+
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+    INSERT INTO migrations (filename) VALUES ('045_kanban_identities_cleanup_race_test_pollution.sql')
+    ON CONFLICT (filename) DO NOTHING;
+
+    RAISE NOTICE '=================================================================';
+    RAISE NOTICE 'Migration 045_kanban_identities_cleanup_race_test_pollution.sql completed';
+    RAISE NOTICE 'Deleted % stray concurrent-claim-test.js identity row(s)', deleted_count;
+    RAISE NOTICE '=================================================================';
+END $$;

--- a/src/mcps/kanban-server/handlers/identity-handlers.js
+++ b/src/mcps/kanban-server/handlers/identity-handlers.js
@@ -10,6 +10,13 @@
 
 const IDENTITY_KINDS = ['human', 'persona', 'agent'];
 
+// Reserved id namespace for throwaway ids minted by tests (bead
+// mws-1783883496146-1). Any test that mints an agent/persona id it doesn't
+// permanently want in the registry MUST prefix it 'test:' — list_identities
+// unconditionally filters this namespace out (see handleListIdentities)
+// regardless of whether the row ever gets cleaned up.
+export const TEST_NAMESPACE_PREFIX = 'test:';
+
 export class IdentityHandlers {
     constructor(db) {
         this.db = db;
@@ -18,6 +25,13 @@ export class IdentityHandlers {
     /**
      * list_identities — all registered identities, optionally filtered by
      * kind, optionally including inactive ones (default: active only).
+     *
+     * Always excludes the `test:` id namespace (bead mws-1783883496146-1 —
+     * concurrent-claim-test.js and any other test that mints throwaway agent
+     * ids MUST prefix them 'test:...'). This is unconditional, not an
+     * include_inactive-style opt-in: the assignee dropdown this feeds must
+     * never surface test junk, and there is no legitimate caller that needs
+     * test: ids back.
      */
     async handleListIdentities(args) {
         const { kind, include_inactive = false } = args || {};
@@ -25,6 +39,9 @@ export class IdentityHandlers {
         const conditions = [];
         const params = [];
         let i = 1;
+
+        conditions.push(`id NOT LIKE $${i++}`);
+        params.push(`${TEST_NAMESPACE_PREFIX}%`);
 
         if (kind) {
             if (!IDENTITY_KINDS.includes(kind)) {
@@ -76,5 +93,36 @@ export class IdentityHandlers {
         );
 
         return { identity: result.rows[0] };
+    }
+
+    /**
+     * delete_identity — hard-remove an identity row (bead
+     * mws-1783883496146-1, acceptance criterion: "a supported path to
+     * remove or hide an identity that should not be offered as an
+     * assignee"). upsert_identity(active:false) already gives a soft-hide
+     * path (list_identities excludes inactive rows by default), but there
+     * was previously no way to remove a row outright — this is that path,
+     * for cleanup scripts and mis-registered/throwaway ids alike.
+     *
+     * No FK enforced against kanban_cards.assignee (migration 044, by
+     * design), so this never fails on a foreign-key violation; any card
+     * still pointing at a deleted id simply falls through
+     * kanban_enforce_human_reserve's fail-safe branch (unrecognized
+     * assignee -> treated as human, not agent-claimable) the next time that
+     * card is written.
+     */
+    async handleDeleteIdentity(args) {
+        const { id } = args || {};
+
+        if (!id) {
+            throw new Error('id is required');
+        }
+
+        const result = await this.db.query(
+            'DELETE FROM fictionlab.kanban_identities WHERE id = $1 RETURNING *',
+            [id]
+        );
+
+        return { deleted: result.rows.length > 0, identity: result.rows[0] || null };
     }
 }

--- a/src/mcps/kanban-server/index.js
+++ b/src/mcps/kanban-server/index.js
@@ -90,9 +90,11 @@ class KanbanMCPServer extends BaseMCPServer {
             'claim_card': this.claimHandlers.handleClaimCard.bind(this.claimHandlers),
             // Comment handler (1 tool)
             'comment_card': this.commentHandlers.handleCommentCard.bind(this.commentHandlers),
-            // Identity handlers (2 tools) — GH issue #62 identities model
+            // Identity handlers (3 tools) — GH issue #62 identities model;
+            // delete_identity added by bead mws-1783883496146-1
             'list_identities': this.identityHandlers.handleListIdentities.bind(this.identityHandlers),
-            'upsert_identity': this.identityHandlers.handleUpsertIdentity.bind(this.identityHandlers)
+            'upsert_identity': this.identityHandlers.handleUpsertIdentity.bind(this.identityHandlers),
+            'delete_identity': this.identityHandlers.handleDeleteIdentity.bind(this.identityHandlers)
         };
         return handlers[toolName];
     }

--- a/src/mcps/kanban-server/schemas/kanban-tools-schema.js
+++ b/src/mcps/kanban-server/schemas/kanban-tools-schema.js
@@ -236,10 +236,11 @@ export const kanbanToolsSchema = [
         }
     },
 
-    // ---- 2 identity tools (GH issue #62 — identities model) ----
+    // ---- 3 identity tools (GH issue #62 — identities model; delete_identity
+    // added by bead mws-1783883496146-1) ----
     {
         name: 'list_identities',
-        description: "Lists registered kanban identities (human/persona/agent) — the set of ids create_card/update_card will accept as assignee. Defaults to active only.",
+        description: "Lists registered kanban identities (human/persona/agent) — the set of ids create_card/update_card will accept as assignee. Defaults to active only. Always excludes the 'test:' id namespace (reserved for throwaway ids minted by tests).",
         inputSchema: {
             type: 'object',
             properties: {
@@ -264,6 +265,17 @@ export const kanbanToolsSchema = [
                 active: { type: 'boolean', default: true }
             },
             required: ['id', 'kind']
+        }
+    },
+    {
+        name: 'delete_identity',
+        description: "Hard-removes an identity row (e.g. a mis-registered or throwaway id). upsert_identity(active:false) is the softer 'hide from the dropdown' path (list_identities excludes inactive by default) — use delete_identity when the row should not exist at all. Not FK-enforced against kanban_cards.assignee: a card still pointing at a deleted id falls through the human-reserve fail-safe (treated as not agent-claimable) on its next write.",
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { type: 'string', description: 'The identity id to delete.' }
+            },
+            required: ['id']
         }
     }
 ];

--- a/test/kanban-server/concurrent-claim-test.js
+++ b/test/kanban-server/concurrent-claim-test.js
@@ -12,13 +12,33 @@
 // Uses its own ephemeral board (never dev-backlog); deletes it at the end
 // (ON DELETE CASCADE takes every card/activity row with it).
 //
+// Identity cleanup (bead mws-1783883496146-1): claim_card auto-registers any
+// first-seen claiming agent id as a permanent kind='agent' row in
+// fictionlab.kanban_identities (claim-handlers.js). 20 iterations x 2 racing
+// agents = 40 ids minted per run. This test:
+//   1. Prefixes every minted id with the reserved 'test:' namespace
+//      (identity-handlers.js TEST_NAMESPACE_PREFIX) so a stray row is
+//      trivially identifiable and list_identities excludes it unconditionally
+//      even if cleanup below never ran.
+//   2. Deletes every id it minted in a `finally` block, so cleanup runs even
+//      if an assertion throws mid-run.
+//   3. Snapshots the identity count before the run and asserts it's back to
+//      that exact value after cleanup -- a regression guard against this bug
+//      recurring (acceptance criteria: run leaves the count unchanged, and
+//      the test asserts this itself).
+//
 // Run: node test/kanban-server/concurrent-claim-test.js
+// For a disposable-DB run (recommended for verifying this file's own
+// behavior without touching a real dev database), point DATABASE_URL at a
+// throwaway postgres with migrations applied -- see .github/workflows/test.yml
+// for the postgres-service pattern this repo already uses in CI.
 
 import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { DatabaseManager } from '../../src/shared/database.js';
 import { ClaimHandlers } from '../../src/mcps/kanban-server/handlers/claim-handlers.js';
+import { TEST_NAMESPACE_PREFIX } from '../../src/mcps/kanban-server/handlers/identity-handlers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.join(__dirname, '../../.env') });
@@ -29,77 +49,110 @@ async function main() {
     const db = new DatabaseManager();
     const claimHandlers = new ClaimHandlers(db);
 
-    const boardResult = await db.query(
-        `INSERT INTO fictionlab.kanban_boards (board_key, name, description)
-         VALUES ($1, 'Concurrent Claim Test', 'Ephemeral board created by test/kanban-server/concurrent-claim-test.js')
-         RETURNING id`,
-        [`kanban-claim-race-test-${Date.now()}`]
-    );
-    const testBoardId = boardResult.rows[0].id;
+    const mintedAgentIds = new Set();
+    let testBoardId;
+    let preRunIdentityCount;
 
     let wins = 0;
     let denials = 0;
     let failures = [];
 
-    for (let iteration = 1; iteration <= ITERATIONS; iteration++) {
-        const cardResult = await db.query(
-            `INSERT INTO fictionlab.kanban_cards (board_id, title, status, assignee, agent_claimable, created_by)
-             VALUES ($1, $2, 'ready', NULL, TRUE, 'rebecca')
+    try {
+        const preRunCountResult = await db.query('SELECT COUNT(*)::int AS count FROM fictionlab.kanban_identities');
+        preRunIdentityCount = preRunCountResult.rows[0].count;
+
+        const boardResult = await db.query(
+            `INSERT INTO fictionlab.kanban_boards (board_key, name, description)
+             VALUES ($1, 'Concurrent Claim Test', 'Ephemeral board created by test/kanban-server/concurrent-claim-test.js')
              RETURNING id`,
-            [testBoardId, `Race card #${iteration}`]
+            [`kanban-claim-race-test-${Date.now()}`]
         );
-        const cardId = cardResult.rows[0].id;
+        testBoardId = boardResult.rows[0].id;
 
-        const agentA = `claude-code:race-a-${iteration}`;
-        const agentB = `local-qwen3-14b:race-b-${iteration}`;
-
-        // Fire both claims truly in parallel -- Promise.all schedules both
-        // before either resolves, and DatabaseManager.query() checks out a
-        // separate pool connection per call, so both UPDATEs can genuinely
-        // race at the Postgres engine level.
-        const [resultA, resultB] = await Promise.all([
-            claimHandlers.handleClaimCard({ card_id: cardId, agent: agentA }),
-            claimHandlers.handleClaimCard({ card_id: cardId, agent: agentB })
-        ]);
-
-        const claimedResults = [resultA, resultB].filter((r) => r.claimed);
-        const deniedResults = [resultA, resultB].filter((r) => !r.claimed);
-
-        const iterationOk =
-            claimedResults.length === 1 &&
-            deniedResults.length === 1 &&
-            deniedResults[0].reason === 'already_claimed';
-
-        if (claimedResults.length === 1) wins++;
-        if (deniedResults.length === 1 && deniedResults[0].reason === 'already_claimed') denials++;
-
-        if (!iterationOk) {
-            failures.push({ iteration, resultA, resultB });
-        } else {
-            const winnerAgent = claimedResults[0].card.assignee;
-            const finalCard = await db.query('SELECT claimed_by, assignee, status FROM fictionlab.kanban_cards WHERE id = $1', [cardId]);
-            const activityRows = await db.query(
-                `SELECT action, COUNT(*) AS count FROM fictionlab.kanban_activity WHERE card_id = $1 GROUP BY action`,
-                [cardId]
+        for (let iteration = 1; iteration <= ITERATIONS; iteration++) {
+            const cardResult = await db.query(
+                `INSERT INTO fictionlab.kanban_cards (board_id, title, status, assignee, agent_claimable, created_by)
+                 VALUES ($1, $2, 'ready', NULL, TRUE, 'rebecca')
+                 RETURNING id`,
+                [testBoardId, `Race card #${iteration}`]
             );
-            const claimedCount = activityRows.rows.find((r) => r.action === 'claimed')?.count || 0;
-            const deniedCount = activityRows.rows.find((r) => r.action === 'claim_denied')?.count || 0;
+            const cardId = cardResult.rows[0].id;
 
-            if (finalCard.rows[0].claimed_by !== winnerAgent) {
-                failures.push({ iteration, reason: 'claimed_by mismatch', finalCard: finalCard.rows[0], winnerAgent });
-            } else if (parseInt(claimedCount, 10) !== 1 || parseInt(deniedCount, 10) !== 1) {
-                failures.push({ iteration, reason: 'activity row count mismatch', claimedCount, deniedCount });
+            const agentA = `${TEST_NAMESPACE_PREFIX}claude-code:race-a-${iteration}`;
+            const agentB = `${TEST_NAMESPACE_PREFIX}local-qwen3-14b:race-b-${iteration}`;
+            mintedAgentIds.add(agentA);
+            mintedAgentIds.add(agentB);
+
+            // Fire both claims truly in parallel -- Promise.all schedules both
+            // before either resolves, and DatabaseManager.query() checks out a
+            // separate pool connection per call, so both UPDATEs can genuinely
+            // race at the Postgres engine level.
+            const [resultA, resultB] = await Promise.all([
+                claimHandlers.handleClaimCard({ card_id: cardId, agent: agentA }),
+                claimHandlers.handleClaimCard({ card_id: cardId, agent: agentB })
+            ]);
+
+            const claimedResults = [resultA, resultB].filter((r) => r.claimed);
+            const deniedResults = [resultA, resultB].filter((r) => !r.claimed);
+
+            const iterationOk =
+                claimedResults.length === 1 &&
+                deniedResults.length === 1 &&
+                deniedResults[0].reason === 'already_claimed';
+
+            if (claimedResults.length === 1) wins++;
+            if (deniedResults.length === 1 && deniedResults[0].reason === 'already_claimed') denials++;
+
+            if (!iterationOk) {
+                failures.push({ iteration, resultA, resultB });
             } else {
-                console.log(`  iteration ${iteration}: OK (winner=${winnerAgent})`);
+                const winnerAgent = claimedResults[0].card.assignee;
+                const finalCard = await db.query('SELECT claimed_by, assignee, status FROM fictionlab.kanban_cards WHERE id = $1', [cardId]);
+                const activityRows = await db.query(
+                    `SELECT action, COUNT(*) AS count FROM fictionlab.kanban_activity WHERE card_id = $1 GROUP BY action`,
+                    [cardId]
+                );
+                const claimedCount = activityRows.rows.find((r) => r.action === 'claimed')?.count || 0;
+                const deniedCount = activityRows.rows.find((r) => r.action === 'claim_denied')?.count || 0;
+
+                if (finalCard.rows[0].claimed_by !== winnerAgent) {
+                    failures.push({ iteration, reason: 'claimed_by mismatch', finalCard: finalCard.rows[0], winnerAgent });
+                } else if (parseInt(claimedCount, 10) !== 1 || parseInt(deniedCount, 10) !== 1) {
+                    failures.push({ iteration, reason: 'activity row count mismatch', claimedCount, deniedCount });
+                } else {
+                    console.log(`  iteration ${iteration}: OK (winner=${winnerAgent})`);
+                }
             }
+        }
+    } finally {
+        // Cleanup runs even if the loop above threw or an assertion failed
+        // above -- this test must never leave state behind, win or lose.
+        if (testBoardId) {
+            // Cascade-delete the ephemeral test board (cards + activity go with it).
+            await db.query('DELETE FROM fictionlab.kanban_boards WHERE id = $1', [testBoardId]);
+        }
+        if (mintedAgentIds.size > 0) {
+            await db.query('DELETE FROM fictionlab.kanban_identities WHERE id = ANY($1::text[])', [
+                Array.from(mintedAgentIds)
+            ]);
         }
     }
 
-    // Cascade-delete the ephemeral test board (cards + activity go with it).
-    await db.query('DELETE FROM fictionlab.kanban_boards WHERE id = $1', [testBoardId]);
+    const postRunCountResult = await db.query('SELECT COUNT(*)::int AS count FROM fictionlab.kanban_identities');
+    const postRunIdentityCount = postRunCountResult.rows[0].count;
     await db.close();
 
     console.log(`\n${ITERATIONS} iterations: ${wins} exactly-one-winner, ${denials} exactly-one-already_claimed-denial.`);
+    console.log(`Identity count: ${preRunIdentityCount} before -> ${postRunIdentityCount} after cleanup (minted ${mintedAgentIds.size} throwaway ids).`);
+
+    if (postRunIdentityCount !== preRunIdentityCount) {
+        failures.push({
+            reason: 'identity_count_regression',
+            preRunIdentityCount,
+            postRunIdentityCount,
+            detail: 'concurrent-claim-test.js must leave fictionlab.kanban_identities exactly as it found it -- see bead mws-1783883496146-1'
+        });
+    }
 
     if (failures.length > 0) {
         console.log(`\n${failures.length} FAILURE(S):`);
@@ -109,7 +162,7 @@ async function main() {
         process.exit(1);
     }
 
-    console.log('All 20 iterations: exactly one winner, one denial, one claimed_by match, one claimed + one claim_denied activity row.');
+    console.log('All 20 iterations: exactly one winner, one denial, one claimed_by match, one claimed + one claim_denied activity row. Identity registry left unchanged.');
     process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

- `test/kanban-server/concurrent-claim-test.js` minted 40 throwaway agent ids per run (`claim_card` auto-registers any first-seen claiming agent id as a permanent `kind='agent'` row in `fictionlab.kanban_identities`) and never cleaned them up, permanently crowding the assignee dropdown with race-test junk.
- Namespaced every id the test mints under a reserved `test:` prefix (`identity-handlers.js` exports `TEST_NAMESPACE_PREFIX`) and delete them in a `finally` block so cleanup runs even on assertion failure. The test now snapshots the identity count before the run and asserts it matches after cleanup — a regression guard against this recurring.
- `list_identities` unconditionally excludes the `test:` namespace, so a stray row from an interrupted run still never reaches the dropdown even if in-test cleanup never ran.
- Added `delete_identity` (list/upsert already existed) as the supported path to remove a mis-registered or throwaway identity outright.
- Added migration `045_kanban_identities_cleanup_race_test_pollution.sql`: an idempotent, documented cleanup for any other deployment/clone still carrying the old un-namespaced `race-a`/`race-b` pollution, scoped tightly to that exact id shape (`kind='agent'` + the `race-[ab]-<n>` suffix) so it can never touch a real identity. The specific instance this bug was filed from was already hand-cleaned per the issue's own notes; this migration exists so every other environment gets the same fix through the normal migration path.

## Test plan

Verified against a disposable, throwaway postgres container (schema + all migrations applied fresh) — never the live database:

- [x] `node test/kanban-server/concurrent-claim-test.js` — 20/20 iterations pass, exactly one winner + one denial each, identity count unchanged before/after (1 -> 1, 40 ids minted and cleaned)
- [x] `node test/kanban-server/smoke-test.js` — 67/67 assertions pass, no regression
- [x] Ad-hoc verification of `list_identities` excluding the `test:` namespace (with and without `include_inactive`) and `delete_identity` actually removing the row from the DB
- [x] `card-search-test.js` intentionally skipped against the disposable DB — its own header documents it requires real production board/card data by design; unrelated to this change

Closes bead: mws-1783883496146-1-ec271119

🤖 Generated with [Claude Code](https://claude.com/claude-code)