### PR TITLE
docs: route agents to purpose-built writing servers, not generic CRUD

### DIFF
--- a/DATABASE-CRUD-SPECIFICATION.md
+++ b/DATABASE-CRUD-SPECIFICATION.md
@@ -1,5 +1,7 @@
 # Database CRUD Operations Specification
 
+> **Scope note:** this spec covers `database-admin-server` — the generic, whitelisted-table CRUD/batch/admin layer. It is the admin/migration/bulk-repair layer, not the normal authoring path for chapters, characters, scenes, plot threads, etc. — those go through the purpose-built domain servers. See the [routing map in the root README](README.md#which-server-for-which-task).
+
 ## Overview
 
 This document specifies the design and implementation requirements for database CRUD (Create, Read, Update, Delete) operations and batch actions for the MCP Writing System. These operations should be implemented in the **MCP-Writing-Servers** repository as they involve business logic and direct database access.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# MCP Writing Servers
+
+MCP tool servers backing `mcp_writing_db` (the story database) for AI writing-team
+agents: series/book/character/scene/continuity data, plus narrative-physics (NPE)
+validation and project/kanban tooling.
+
+## The one rule
+
+**Write to the story database through the purpose-built domain servers below —
+not through `database-admin-server`'s raw CRUD tools.**
+
+`database-admin-server` (`db_query_records` / `db_insert_record` / `db_update_records`
+/ `db_delete_records`, plus batch/schema/backup tools — see
+[`src/mcps/database-admin-server/README.md`](src/mcps/database-admin-server/README.md))
+talks directly to whitelisted tables. It has no idea a character already knows a
+secret, that a chapter's word count should roll up from its scenes, or that a plot
+thread needs a `resolved_at`. Writing through it is easy to reach for — the docs
+under `docs/` document almost nothing else — but it silently skips every
+continuity/knowledge-state/arc invariant the domain servers exist to enforce.
+
+`database-admin-server` is legitimate for: one-off admin fixes, bulk data
+repair/migration, and schema introspection. It is **not** the normal authoring
+path. If you're about to `db_insert_record` into `chapters`, `characters`,
+`scenes`, `plot_threads`, or similar, stop and find the matching tool below first.
+
+## Which server for which task
+
+These are the phase-oriented MCP servers agents actually connect to (per
+[`mcp-config/mcp-config.json`](mcp-config/mcp-config.json)). Each aggregates tools
+from one or more domain modules in `src/mcps/*` behind a single SSE endpoint — see
+each server's own readme for the full tool list and args.
+
+| Task | Server | Config dir | Representative tools |
+|---|---|---|---|
+| Create/update a series, series-level world (locations, orgs, world elements), assign series genres, define a trope | **series-planning** | [`src/config-mcps/series-planning-server`](src/config-mcps/series-planning-server/readme.md) | `create_series`, `update_series`, `create_location`, `create_organization`, `create_world_element`, `define_world_system`, `create_trope` |
+| Create/update a book, open a plot thread, log a timeline event, assign genres | **book-planning** | [`src/config-mcps/book-planning-server`](src/config-mcps/book-planning-server/readme.md) | `create_book`, `update_book`, `create_plot_thread`, `update_plot_thread`, `create_timeline_event` |
+| Create/update a chapter, track world/location/org usage in a chapter, map a timeline event to a chapter, log a character-knowledge reveal tied to a chapter, resolve a plot thread | **chapter-planning** | [`src/config-mcps/chapter-planning-server`](src/config-mcps/chapter-planning-server/readme.md) | `book_create_chapter`, `book_update_chapter`, `track_character_presence`, `character_add_character_knowledge_with_chapter`, `resolve_plot_thread` |
+| Create/update a character, add book-specific character details, create/update a character arc, create/update a relationship arc | **character-planning** | [`src/config-mcps/character-planning-server`](src/config-mcps/character-planning-server/readme.md) | `create_character`, `update_character`, `add_character_detail`, `create_character_arc`, `create_relationship_arc` |
+| Write a scene, track a character's presence/word count in it, validate structure/beats before moving on | **scene** | [`src/config-mcps/scene-server`](src/config-mcps/scene-server/readme.md) | `create_scene`, `update_scene`, `get_characters_in_chapter`, `validate_chapter_structure`, `word_count_tracking`, `log_writing_session` |
+| **Read-only** checks while drafting: what does this character know, is this consistent with earlier chapters, what are the open plot threads, what lookup values exist | **core-continuity** | [`src/config-mcps/core-continuity-server`](src/config-mcps/core-continuity-server/readme.md) | `check_character_knowledge`, `check_character_continuity`, `get_plot_threads`, `get_available_options` |
+| Editing-pass checks (structure/beats/world consistency), manuscript export, writing goals/productivity | **review** | [`src/config-mcps/review-server`](src/config-mcps/review-server/readme.md) | `check_structure_violations`, `check_world_consistency`, `export_manuscript`, `get_productivity_analytics` |
+| Roll up a report across series/book entities | **reporting** | [`src/config-mcps/reporting-server`](src/config-mcps/reporting-server/readme.md) | `generate_report` |
+| Manage author records | **author** | [`src/config-mcps/author-server`](src/config-mcps/author-server/readme.md) | `create_author`, `update_author`, `get_author`, `list_authors` |
+| Per-scene story-bible: outline tree, facts, promises (setups/payoffs), evidence chain, scene events, scene briefs | **outline** | [`src/config-mcps/outline-server`](src/config-mcps/outline-server/readme.md) | `create_work`, `record_scene_events`, `create_promise`, `create_evidence`, `get_scene_brief`, `what_does_character_know_at` |
+| Kanban board / card / claim workflow for agent task coordination | **kanban** | [`src/mcps/kanban-server`](src/mcps/kanban-server/README.md) | `list_cards`, `claim_card`, `comment_card`, `move_card` |
+| Admin/migration/bulk-repair CRUD; **not** normal authoring | **database-admin** | [`src/mcps/database-admin-server`](src/mcps/database-admin-server/README.md) | `db_query_records`, `db_insert_record`, `db_update_records`, `db_delete_records` |
+
+Two servers exist in the codebase but are **not** part of the standard
+agent-facing deployment above (`mcp-config/mcp-config.json`) as of this writing —
+confirm with whoever runs your MCP client config before assuming either is live:
+
+- **npe** ([`src/config-mcps/npe-server`](src/config-mcps/npe-server/README.md)) —
+  unified Narrative Physics Engine tools (causality chains, character-decision
+  validation, scene/dialogue validation, pacing & stakes analysis). Already has a
+  good readme — read it before using any `npe_*`-flavored tool.
+- **workflow-manager** (`src/mcps/workflow-manager-server`) — workflow
+  definition/execution graph tools.
+
+### `outline` vs `plot_*` tools — don't conflate them
+
+The `outline` server's own tree (`outline_works`, `outline_facts`,
+`outline_promises`, `outline_evidence_chain`, scene events) and the
+`plot_create_plot_thread` / `plot_update_plot_thread` / `create_information_reveal`
+tools folded into `book-planning` and `chapter-planning` are **two different
+systems with two different ID spaces** — do not pass an `outline_works.id` where a
+plot tool expects a `series_id`/`chapter_id`, or vice versa. A full decision guide
+(what each owns, where they overlap, when to use which) is tracked in
+[RLRyals/MCP-Writing-Servers#74](https://github.com/RLRyals/MCP-Writing-Servers/issues/74)
+and will land at `docs/outline-vs-plot.md`. Until that lands: outline = per-scene
+manuscript structure + character-knowledge replay; plot = multi-book arcs,
+series-level reveals, and world-systems.
+
+## Everything under `docs/`
+
+Everything in [`docs/`](docs/) — `ARCHITECTURE.md`, `API-REFERENCE.md`,
+`USER-GUIDES.md`, `TUTORIALS.md`, `EXAMPLES.md`, `OPERATIONS-GUIDE.md`,
+`SECURITY-GUIDE.md` — is the **`database-admin-server` manual**, not general
+project documentation. Each of those pages carries a banner pointing back here.
+Use them when you're actually doing admin/migration work against
+`database-admin-server`; don't use `EXAMPLES.md` as a model for how to write a
+chapter or character.
+
+## Running the servers
+
+- `node server.js` — orchestrator; spawns `book-planning`, `series-planning`,
+  `chapter-planning`, `character-planning`, `scene`, `core-continuity`, `review`,
+  `reporting`, `author`, `database-admin`, and `workflow-manager` as child
+  processes (see [`server.js`](server.js)).
+- `node src/single-server-runner.js <server-name> <port>` — run one server
+  standalone (also how `outline` and `kanban` get run in this deployment; see
+  [`src/single-server-runner.js`](src/single-server-runner.js) for the full
+  `server-name` → module map).
+- [`docker-compose.yml`](docker-compose.yml) — full production stack (Postgres,
+  PgBouncer, the 13-port server set, Prometheus, Grafana).
+
+## Docs index
+
+- [`DATABASE-CRUD-SPECIFICATION.md`](DATABASE-CRUD-SPECIFICATION.md) — design spec
+  for `database-admin-server` itself (admin/migration layer, not the authoring path).
+- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) — production deployment for the whole
+  server ecosystem.
+- [`docs/MCP-ELECTRON-INTEGRATION.md`](docs/MCP-ELECTRON-INTEGRATION.md) —
+  wiring these servers into the MCP-Electron desktop app.
+- `src/config-mcps/*/readme.md` and `src/mcps/*/README.md` — per-server tool
+  reference (linked in the table above).

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ The `outline` server's own tree (`outline_works`, `outline_facts`,
 `plot_create_plot_thread` / `plot_update_plot_thread` / `create_information_reveal`
 tools folded into `book-planning` and `chapter-planning` are **two different
 systems with two different ID spaces** — do not pass an `outline_works.id` where a
-plot tool expects a `series_id`/`chapter_id`, or vice versa. A full decision guide
-(what each owns, where they overlap, when to use which) is tracked in
-[RLRyals/MCP-Writing-Servers#74](https://github.com/RLRyals/MCP-Writing-Servers/issues/74)
-and will land at `docs/outline-vs-plot.md`. Until that lands: outline = per-scene
-manuscript structure + character-knowledge replay; plot = multi-book arcs,
-series-level reveals, and world-systems.
+plot tool expects a `series_id`/`chapter_id`, or vice versa (the one exception:
+both share `characters.id`). See
+[`docs/outline-vs-plot.md`](docs/outline-vs-plot.md) for the full decision table
+— what each owns, where they overlap, known dead code. Short version: outline =
+per-scene manuscript structure + character-knowledge replay; plot = multi-book
+arcs, series-level reveals, and world-systems.
 
 ## Everything under `docs/`
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -4,6 +4,8 @@ Version: 1.0.0
 Last Updated: 2024
 Coverage: All 25 MCP Tools
 
+> **This is the generic-CRUD server, not the authoring path.** `database-admin-server` is for admin, migration, and bulk-repair work against whitelisted tables. For normal authoring (chapters, characters, scenes, plot threads, …), use the purpose-built domain servers instead — see the [routing map in the root README](../README.md#which-server-for-which-task).
+
 ---
 
 ## Table of Contents

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 Comprehensive system architecture and design documentation
 
+> **Scope note:** this page (and the rest of `docs/`) documents `database-admin-server` — the generic, whitelisted-table CRUD layer for admin/migration/bulk-repair work. It is not the normal authoring path. For the purpose-built domain servers (and which one to use for a given writing task), see the [routing map in the root README](../README.md#which-server-for-which-task).
+
 ---
 
 ## Table of Contents

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -2,6 +2,8 @@
 
 A collection of 50+ real-world code examples for all 25 database admin server tools, organized by use case and featuring a writing/publishing database schema.
 
+> **Anti-pattern warning:** The examples below that insert/update `chapters`, `characters`, `scenes`, `plot_threads`, and similar writing tables via `db_insert_record` / `db_update_records` are **admin/migration/bulk-repair patterns, not the normal authoring path**. For normal authoring, use the purpose-built domain servers (`character-planning`, `chapter-planning`, `scene`, `book-planning`, …) — see the [routing map in the root README](../README.md#which-server-for-which-task). Reaching for raw CRUD on these tables bypasses continuity/knowledge-state/arc invariants the domain servers enforce.
+
 ---
 
 ## Table of Contents

--- a/docs/OPERATIONS-GUIDE.md
+++ b/docs/OPERATIONS-GUIDE.md
@@ -2,6 +2,8 @@
 
 Comprehensive guide for production operations and data migrations
 
+> **Scope note:** this is genuinely `database-admin-server`'s home turf — ops and data migration are exactly what it's for. Just don't extrapolate from this guide to normal authoring; for writing chapters/characters/scenes day-to-day, use the purpose-built domain servers — see the [routing map in the root README](../README.md#which-server-for-which-task).
+
 ---
 
 ## Table of Contents

--- a/docs/SECURITY-GUIDE.md
+++ b/docs/SECURITY-GUIDE.md
@@ -2,6 +2,8 @@
 
 Comprehensive security documentation and best practices
 
+> **Scope note:** this page (and the rest of `docs/`) documents `database-admin-server` — the generic, whitelisted-table CRUD layer for admin/migration/bulk-repair work. It is not the normal authoring path. For the purpose-built domain servers (and which one to use for a given writing task), see the [routing map in the root README](../README.md#which-server-for-which-task).
+
 ---
 
 ## Table of Contents

--- a/docs/TUTORIALS.md
+++ b/docs/TUTORIALS.md
@@ -2,6 +2,8 @@
 
 Comprehensive step-by-step tutorials for mastering the database admin server
 
+> **Scope note:** this page (and the rest of `docs/`) documents `database-admin-server` — the generic, whitelisted-table CRUD layer for admin/migration/bulk-repair work. It is not the normal authoring path. For the purpose-built domain servers (and which one to use for a given writing task), see the [routing map in the root README](../README.md#which-server-for-which-task).
+
 ---
 
 ## Table of Contents

--- a/docs/USER-GUIDES.md
+++ b/docs/USER-GUIDES.md
@@ -2,6 +2,8 @@
 
 Comprehensive guides for different user personas
 
+> **Scope note:** this page (and the rest of `docs/`) documents `database-admin-server` — the generic, whitelisted-table CRUD layer for admin/migration/bulk-repair work. It is not the normal authoring path, including for the "For AI Agents" section below. For the purpose-built domain servers (and which one to use for a given writing task), see the [routing map in the root README](../README.md#which-server-for-which-task).
+
 ---
 
 ## Table of Contents

--- a/docs/outline-vs-plot.md
+++ b/docs/outline-vs-plot.md
@@ -1,0 +1,334 @@
+# outline-server vs plot-server
+
+Two MCP servers both claim territory that sounds like "the plot." They are not
+interchangeable, they do not share a primary-key space, and one word —
+`evidence` — means two structurally different things depending on which one
+you're talking to. This doc is the disambiguation guide.
+
+Grounded against source as of 2026-07-11 (repo `MCP-Writing-Servers`, branch
+`main`). Every tool name, file path, and line reference below was re-verified
+by reading the actual handler/schema files, not inferred from naming
+conventions. Where the original GH #74 first-pass analysis turned out to be
+imprecise, that's called out explicitly in [Corrections to the original
+analysis](#corrections-to-the-original-analysis-gh-74).
+
+## TL;DR
+
+- **outline-server** = the bottom-up scene tree for ONE manuscript: series →
+  book → act → beat → chapter → scene, plus the facts/promises/evidence/events
+  that live at specific nodes in that tree. Everything it owns is keyed off
+  its own `outline_works.id`.
+- **plot-server** = top-down, multi-book bookkeeping: named plot threads that
+  span `start_book..end_book`, information reveals, world-system rules, and
+  character power progression. Everything it owns is keyed off `plot_threads`,
+  `information_reveals`, etc. — separate tables, separate ID sequences.
+- They do not interoperate by ID. An `outline_works.id` is meaningless to
+  plot-server; a `plot_threads.id` is meaningless to outline-server. The one
+  ID space they genuinely share is the **canonical** `characters.id` (both
+  reference the same `characters` table), and, more weakly, `series`/`books`/
+  `chapters` (see [Disjoint ID spaces](#disjoint-id-spaces) for the asterisk).
+- Both servers have a concept casually called "evidence." They are not the
+  same concept, don't share a table, and don't share a tool name — but they
+  will absolutely get conflated by anyone skimming both schemas. See
+  [The `evidence` collision](#the-evidence-collision).
+
+## At a glance
+
+| | outline-server | plot-server |
+|---|---|---|
+| Altitude | Bottom-up: per-scene/chapter structure + drafting context | Top-down: multi-book arcs and reveals |
+| Spine table | `outline_works` (self-referential tree: `parent_id`) | `plot_threads` (flat, keyed to `series_id`, spans `start_book`/`end_book`) |
+| Primary ID | `outline_works.id` (own SERIAL sequence, own tree) | `plot_threads.id`, `information_reveals.id`, `reveal_evidence.id`, `world_systems.id`, `character_system_progression.id` (each its own SERIAL sequence) |
+| Tool count | 22 (verified: 9 works + 4 facts + 3 promises + 3 evidence + 2 scene-events + 1 brief) | 8 (verified: 4 plot-thread + 4 genre-extension; a 5th plot-thread tool exists in code but is commented out — see [Dead code](#known-dead-code)) |
+| Also owns | facts (atomic truths), promises (clue/setup/payoff ledger), evidence-chain (finding→conversion gap), scene-events (polymorphic event log), `get_scene_brief` (one-call drafting context) | information-reveals, reveal-evidence (child of a reveal), world-systems (magic/tech rules), character-system-progression (power levels) |
+| Server class / file | `OutlineMCPServer`, `src/mcps/outline-server/index.js` | `PlotMCPServer`, `src/mcps/plot-server/index.js` |
+| Standalone MCP name | `outline-manager` | `plot-management` |
+
+## Tool inventory (verified against source)
+
+### outline-server — 22 tools
+
+Registered in `src/mcps/outline-server/index.js:42-51` (`getTools()`), dispatched
+`53-85` (`getToolHandler()`). Schemas: `src/mcps/outline-server/schemas/outline-tools-schema.js`.
+
+| Group | Tools | Handler file |
+|---|---|---|
+| works (9) | `create_work`, `update_work`, `move_work`, `delete_work`, `get_outline`, `get_ancestry`, `list_series_roots`, `list_works`, `search_works` | `handlers/works-handlers.js` |
+| facts (4) | `create_fact`, `list_facts`, `update_fact`, `delete_fact` | `handlers/facts-handlers.js` |
+| promises (3) | `create_promise`, `update_promise`, `list_open_promises` | `handlers/promises-handlers.js` |
+| evidence (3) | `create_evidence`, `update_evidence`, `list_unconverted_evidence` | `handlers/evidence-handlers.js` |
+| scene-events (2) | `record_scene_events`, `what_does_character_know_at` | `handlers/scene-events-handlers.js` |
+| brief (1) | `get_scene_brief` | `handlers/brief-handlers.js` |
+
+### plot-server — 8 tools
+
+Registered in `src/mcps/plot-server/index.js:111-131` (`getTools()`), dispatched
+`136-157` (`getToolHandler()`). Schemas: `src/mcps/plot-server/schemas/plot-tools-schema.js`.
+
+| Group | Tools | Handler file |
+|---|---|---|
+| plot-thread (4 live + 1 dead) | `create_plot_thread`, `update_plot_thread`, `get_plot_threads`, `resolve_plot_thread`, ~~`link_plot_threads`~~ (commented out) | `handlers/plot-thread-handlers.js` |
+| genre-extension (4) | `create_information_reveal`, `define_world_system`, `add_reveal_evidence`, `track_system_progression` | `handlers/genre-extensions.js` |
+| lookup (0) | — `lookupSystemToolsSchema` is an empty array. Lookup vocabulary (thread types, statuses, etc.) now lives in `metadata-server`'s `get_available_options`. | — |
+
+**Note on plot-server's file naming:** the actual, imported file is
+`src/mcps/plot-server/handlers/genre-extensions.js` (confirmed via the
+`index.js` import and `ls`), even though its internal header comment says
+`universal-genre-extensions.js`. That's a stale comment, not a real filename —
+don't go looking for a file that doesn't exist.
+
+### Where these tools actually surface to agents
+
+Neither raw server is the only way an agent sees these tools — several
+`config-mcps/*` aggregators bundle subsets under a shared DB connection:
+
+- `config-mcps/outline-server` (`outline-phase`) — re-exports **all 22**
+  outline tools verbatim, no renaming.
+- `config-mcps/series-planning-server` — pulls in exactly one plot-server
+  tool, `define_world_system`, from `genreExtensionToolsSchema`. No outline
+  tools present.
+- `config-mcps/chapter-planning-server` — pulls in `create_information_reveal`
+  and `add_reveal_evidence` from plot-server's genre extensions, but
+  **renames them** to `plot_create_information_reveal` and
+  `plot_add_reveal_evidence`, plus `resolve_plot_thread` (unrenamed). No
+  outline-server tools present.
+- `config-mcps/core-continuity-server` — pulls in `get_plot_threads`
+  (unrenamed) for read-only continuity checks. No outline-server tools
+  present.
+
+Practical upshot: **as of this analysis, no aggregator currently exposes an
+outline-server tool and a plot-server "evidence" tool side by side under
+unprefixed names.** The collision risk documented below is about an agent
+holding both the standalone `outline-manager` and `plot-management` servers
+(or `outline-phase` + `chapter-planning-phase`) connected at once, or a human
+skimming both schema files — not a live MCP tool-name clash today. See
+[Corrections](#corrections-to-the-original-analysis-gh-74).
+
+## The `evidence` collision
+
+Both servers have something informally called "evidence." They are **not**
+the same tool name (`create_evidence`/`update_evidence`/
+`list_unconverted_evidence` vs. `add_reveal_evidence`), so there's no literal
+MCP namespace clash — but the *concept* collides hard enough that an agent
+(or Rebecca, skimming two schema files six weeks apart) will conflate them.
+
+| | outline-server `create_evidence` | plot-server `add_reveal_evidence` |
+|---|---|---|
+| Table | `outline_evidence_chain` | `reveal_evidence` |
+| What it models | A finding the **protagonist produces but cannot act on directly** — a forensic-tech agency gap. Forces you to name `who_acts_on_it` and the `action_gap_note` (the cost of converting a finding into plot action: off-books, social capital, etc.). | Corroborating detail attached to an **existing information reveal** (`information_reveals.id`) — one piece of support for something already established as "revealed." |
+| Key fields | `finding` (text), `who_acts_on_it` (text), `action_gap_note` (text), `converted_work_id` (→ `outline_works.id`), `status` enum `unconverted/converted/off_books/lost` | `reveal_id` (**required**, → `information_reveals.id`), `evidence_type` enum `physical/witness/circumstantial/digital/forensic`, `evidence_description`, `discovered_by` (→ `characters.id`), `discovery_chapter`, `significance` enum `critical/important/supporting/red_herring` |
+| Required parent | None — floats free, optionally scoped to `series_root_id` (an `outline_works.id`) | **Must** already have a `reveal_id` — `handleAddRevealEvidence` throws `Information reveal with ID {id} not found` if it doesn't resolve (`src/mcps/plot-server/handlers/genre-extensions.js:341-343`) |
+| Lifecycle | `unconverted → converted` (or `off_books`/`lost`), tracked by `list_unconverted_evidence` | No lifecycle/status field at all — it's a permanent corroborating record, not something that gets "resolved" |
+| Genre framing | Written for the forensic-tech protagonist premise specifically (see file header comment) | Explicitly genre-agnostic — `evidence_type` enum leans mystery/forensic but the parent `reveal_type` enum also covers `secret`, `backstory`, `world_rule`, `relationship`, `skill` for non-mystery genres |
+
+**The trap in practice:** if you want to track "the finding my forensic-tech
+protagonist can't act on yet without burning a favor," that's outline's
+`create_evidence` — it has nowhere else to go, and plot-server's
+`add_reveal_evidence` will reject you outright (no `finding`/`who_acts_on_it`/
+`action_gap_note` fields exist there, and it *requires* a pre-existing
+`reveal_id`). Conversely, if you want to attach a corroborating physical/
+witness/digital detail to a reveal that's already logged in `plot_threads`,
+that's plot's `add_reveal_evidence` — outline's evidence chain has no
+`reveal_id` concept and can't express "this corroborates that information
+reveal."
+
+There is also a related-but-distinct overlap one level up: outline's
+`record_scene_events(event_type='reveals_fact')` and plot's
+`create_information_reveal` both model "information becoming known," just
+anchored differently (tree-node + fact vs. thread + chapter). See
+[Overlap / confusion risks](#overlap--confusion-risks) below.
+
+**No sync layer exists between any of this.** If a project uses both servers
+for evidence/reveal tracking, the two records will duplicate and drift with
+nothing to reconcile them.
+
+## Disjoint ID spaces
+
+**The core rule: never pass an `outline_works.id` to a plot-server tool
+expecting a `series_id`/`thread_id`/`reveal_id`/`chapter_id`, and never pass a
+`plot_threads.id` (or any plot-server ID) to an outline-server tool expecting
+a `work_id`.** They are different SERIAL sequences in different tables and
+nothing validates that you didn't cross the streams — you'll either get a
+confusing "not found" error or, worse, silently corrupt an unrelated row if
+the ID happens to exist in both tables by coincidence.
+
+Verified from `migrations/037_outline_server_tables.sql` and
+`migrations/039_outline_rename_cross_refs.sql`:
+
+- `outline_works.id` — own `SERIAL PRIMARY KEY`, self-referential
+  (`parent_id REFERENCES outline_works(id)`). This ID space belongs entirely
+  to outline-server; nothing in plot-server ever reads or writes it.
+- `plot_threads.id`, `information_reveals.id`, `reveal_evidence.id`,
+  `world_systems.id`, `character_system_progression.id` — each its own
+  `SERIAL PRIMARY KEY` in plot-server's schema (see
+  `src/mcps/plot-server/handlers/genre-extensions.js` and
+  `plot-thread-handlers.js` — every `INSERT ... RETURNING id` targets a
+  distinct table). Nothing in outline-server ever reads or writes these.
+
+**The one genuinely shared ID space: `characters.id`.** Both servers write
+FKs into the same canonical `characters` table — outline's
+`pov_character_id` (on `outline_works`) and `character_id` (on
+`outline_scene_events`); plot's `related_characters`/`affects_characters`/
+`discovered_by`/`character_id` (on `create_plot_thread`,
+`create_information_reveal`, `add_reveal_evidence`,
+`track_system_progression`). A character ID is safe to pass between the two
+— it's the same row in the same table either way.
+
+**The `series`/`books`/`chapters` asterisk — read this before assuming it's
+also shared:**
+
+`outline_works` has four optional cross-link columns —
+`series_id`, `book_id`, `chapter_id`, `scene_id` — added in migration 037 as
+`legacy_series_id` etc. and renamed to their bare form in migration 039
+(`ALTER TABLE outline_works RENAME COLUMN legacy_series_id TO series_id`, and
+so on). These genuinely reference the same canonical `series`, `books`,
+`chapters`, `chapter_scenes` tables that plot-server's `series_id`/
+`start_book`/`end_book` arguments also point at. So far, that sounds like a
+second shared ID space. In practice it isn't a useful one, because:
+
+- `create_work`'s handler (`works-handlers.js:16-60`) inserts whatever
+  integers you pass for `series_id`/`book_id`/`chapter_id`/`scene_id`
+  straight into the row with **no existence check** — unlike plot-server,
+  which validates `series_id` against the `series` table before every insert
+  (`plot-thread-handlers.js:25-32`).
+- No outline-server tool ever reads those columns back out. `get_outline`,
+  `get_ancestry`, `list_works`, `search_works`, and `get_scene_brief` all
+  `SELECT` specific column lists (or `SELECT *` in `get_scene_brief`, but the
+  rendered brief text never surfaces `series_id`/`book_id`/`chapter_id`/
+  `scene_id` — verified against `brief-handlers.js:158-235`). They're
+  write-only bookkeeping today.
+
+So: **don't rely on outline's `series_id`/`book_id`/`chapter_id`/`scene_id`
+cross-links to do anything beyond storage.** They're an intentional escape
+hatch (per the migration comments: "Cross-link via the optional legacy_*_id
+columns if you want to point at existing rows") but no current tool consumes
+them. If you need outline-server and plot-server to agree on "which book/
+chapter," track that correspondence yourself — don't assume the schema does
+it for you.
+
+## Overlap / confusion risks
+
+Beyond the evidence collision, three more places the two servers describe
+adjacent-sounding things:
+
+1. **Reveals.** Outline's `record_scene_events(event_type='reveals_fact')`
+   logs a fact becoming known to a character at a specific tree node. Plot's
+   `create_information_reveal` logs an information reveal against a
+   `plot_thread_id` and (optionally) a `revealed_in_chapter`. Both answer
+   "when did X become known," anchored to different spines (tree-node+fact
+   vs. thread+chapter). No cross-reference exists between an
+   `outline_facts.id` and an `information_reveals.id`.
+2. **Setup/payoff vs. thread lifecycle.** Outline's `outline_promises`
+   (single clue/foreshadow/setup planted at one node, paid off at another,
+   status `open/progressing/paid/carried/abandoned`) and plot's
+   `plot_threads` (a whole arc spanning `start_book..end_book`, status
+   `active/resolved/on_hold/abandoned`) both track "something opened that
+   must close" — but at wildly different granularity. A single-scene clue is
+   a `promise`; "the mystery of who killed X, spanning book 1-3" is a
+   `plot_thread`. Neither tool knows about the other's open items.
+3. **World-system knowledge.** `define_world_system` and
+   `track_system_progression` (plot-server) have no outline-server
+   counterpart — this is exclusively plot's territory, no ambiguity there.
+
+## Decision table
+
+| Task | Use | Tool |
+|---|---|---|
+| Add a scene / chapter / act to the manuscript structure | outline-server | `create_work` (`work_type='scene'` etc.) |
+| Get everything needed to draft a specific scene in one call | outline-server | `get_scene_brief` |
+| Register a fact a character can/can't know yet | outline-server | `create_fact` |
+| Check what a character knows at a given point in the manuscript | outline-server | `what_does_character_know_at` |
+| Plant a clue/foreshadow/setup that must pay off later in *this* book | outline-server | `create_promise` / `update_promise` |
+| Find dangling setups with no payoff | outline-server | `list_open_promises` |
+| Track a finding the protagonist can't act on yet (forensic-tech agency gap) | outline-server | `create_evidence` / `list_unconverted_evidence` |
+| Track a multi-book subplot / mystery arc across the series | plot-server | `create_plot_thread` / `update_plot_thread` |
+| Check plot threads active in a given book number | plot-server | `get_plot_threads` (filter `book_number`) |
+| Close out a series-spanning thread | plot-server | `resolve_plot_thread` |
+| Log an information reveal (evidence, secret, backstory, world-rule) tied to a plot thread | plot-server | `create_information_reveal` |
+| Attach corroborating evidence to an already-logged reveal | plot-server | `add_reveal_evidence` (requires existing `reveal_id`) |
+| Define a magic/tech/psionics system's rules for the series | plot-server | `define_world_system` |
+| Track a character's power-level progression in a world system | plot-server | `track_system_progression` |
+| Link two plot threads together (parent/child, causal, etc.) | **neither — dead code**, see below | — |
+| Look up valid values for `thread_type`, `plot_thread_statuses`, etc. | neither — use `metadata-server`'s `get_available_options` | — |
+
+## Known dead code
+
+- **`link_plot_threads` does not work.** The tool schema is fully commented
+  out (`src/mcps/plot-server/schemas/plot-tools-schema.js:83-107`), the
+  handler implementation is fully commented out
+  (`src/mcps/plot-server/handlers/plot-thread-handlers.js:403-477`), and the
+  dispatch entry is commented out
+  (`src/mcps/plot-server/index.js:142`, plus the corresponding bind at line
+  72). There is currently **no MCP-exposed way to create a
+  `plot_thread_relationships` row.** Tracked upstream in issue #69 — don't
+  reintroduce this doc's guidance as if the tool exists; it doesn't, as of
+  this analysis.
+- **`lookupSystemToolsSchema` (plot-server) is an empty array**
+  (`plot-tools-schema.js:317`, comment confirms: "Lookup tools have been
+  consolidated in metadata-server to avoid name conflicts"). If you're
+  looking for `plot_thread_types`, `plot_thread_statuses`, or similar lookup
+  vocabulary, it now lives behind `metadata-server`'s `get_available_options`
+  — not in plot-server itself, despite the still-present (empty) export.
+
+## Tool-description guidance
+
+These are recommendations for whoever next touches the schema files — this
+doc does not change server behavior or schemas itself (out of scope for this
+card).
+
+- **`create_evidence` (outline-server)** — description currently reads
+  "Register a finding the protagonist produces but cannot directly act on."
+  Consider prefixing with a disambiguator: *"Outline-tree evidence (forensic
+  agency-gap tracking). NOT for reveal corroboration — see plot-server's
+  `add_reveal_evidence` for that."*
+- **`add_reveal_evidence` (plot-server)** — description currently reads "Add
+  specific evidence to an information reveal (universal evidence tracking)."
+  The phrase "universal evidence tracking" is exactly the kind of language
+  that invites conflation with outline's evidence chain. Consider: *"Attach
+  corroborating evidence to an EXISTING information reveal (requires
+  `reveal_id`). NOT for tracking findings the protagonist can't act on yet —
+  see outline-server's `create_evidence` for that."*
+- **`create_work` (outline-server)** — the `series_id`/`book_id`/
+  `chapter_id`/`scene_id` parameters are documented only as "Optional
+  cross-link to X(id)" with no warning that nothing validates them and no
+  tool reads them back. Worth an explicit note: *"Write-only bookkeeping;
+  not validated against the target table and not surfaced by any
+  outline-server query."*
+- **`create_plot_thread` / `get_plot_threads` (plot-server)** — already
+  reasonably precise (`series_id` is validated, `book_number` filter is
+  clear). No change needed.
+
+## Corrections to the original analysis (GH #74)
+
+The GH #74 first-pass table was largely accurate and matched the source on
+re-verification (tool counts, file:line references for `index.js` tool
+registration/dispatch, the dead `link_plot_threads` code, the empty
+`lookupSystemToolsSchema`). Two points needed sharpening:
+
+1. **"Evidence is a name collision" is true at the concept level but not at
+   the MCP tool-name level.** The two servers never register a tool with the
+   literal same name — outline uses `create_evidence`/`update_evidence`/
+   `list_unconverted_evidence`; plot uses only `add_reveal_evidence` (no
+   create/update/list siblings, since it's a child record of a reveal, not a
+   standalone entity). An MCP client connected to both servers simultaneously
+   sees five distinctly-named tools, not a clash. The risk is a human or
+   agent skimming schemas and assuming "evidence" means one thing, or reusing
+   field vocabulary (`evidence_type`, `finding`) across the wrong tool by
+   habit — not a technical collision. Worth stating precisely so nobody
+   "fixes" a collision that doesn't exist at the protocol level.
+2. **The two ID spaces are not perfectly disjoint — `characters.id` is
+   genuinely shared, and outline's `series_id`/`book_id`/`chapter_id`/
+   `scene_id` cross-link columns point at the same canonical tables
+   plot-server uses (`series`, `books`, `chapters`).** The original
+   framing ("Never pass an outline_works.id where a plot tool wants a
+   series_id/chapter_id") is correct and remains the operative rule, but a
+   reader could infer from "two ID spaces" that *every* ID is
+   server-specific, which isn't quite right for `characters.id`. This doc's
+   [Disjoint ID spaces](#disjoint-id-spaces) section spells out exactly which
+   IDs cross safely (`characters.id`) and which don't (everything else),
+   plus the important caveat that outline's canonical cross-link columns are
+   currently write-only and unvalidated — a real trap, just a different one
+   than "wrong table entirely."
+
+No claim in the original analysis was found to be false; both corrections
+above are precision upgrades, not reversals.

--- a/src/config-mcps/author-server/readme.md
+++ b/src/config-mcps/author-server/readme.md
@@ -1,0 +1,27 @@
+# Author MCP Server
+
+## Purpose / when to use it
+
+Use this server to create or maintain **author** records — the top-level entity
+a series belongs to. There's no series/book-specific logic here; it's a small,
+self-contained CRUD surface for author metadata (name, bio, etc.), and unlike
+generic CRUD it's whitelisted to exactly this table with a stable, documented
+interface.
+
+This is a thin wrapper: it imports `AuthorHandlers` from
+[`src/mcps/author-server`](../../mcps/author-server) directly rather than
+duplicating logic — see [`index.js`](index.js). One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `list_authors` — list author records
+- `get_author` — get a single author by id
+- `create_author` — create an author record
+- `update_author` — update an author record
+
+## Running it
+
+`node src/single-server-runner.js author 3009` (or via the orchestrator,
+`node server.js`, which spawns it on port 3009 alongside the other core servers).

--- a/src/config-mcps/book-planning-server/readme.md
+++ b/src/config-mcps/book-planning-server/readme.md
@@ -1,8 +1,33 @@
-book_create_book
-book_update_book
-book_get_book
-book_list_books
-plot_create_plot_thread
-plot_update_plot_thread
-timeline_create_timeline_event
-assign_book_genres
+# Book Planning MCP Server
+
+## Purpose / when to use it
+
+Use this server when planning or maintaining a **book** inside a series: creating
+the book record itself, opening a book- or series-spanning plot thread, logging a
+timeline event, or assigning genres. It's the write path for book-level structure
+— not for chapters (see `chapter-planning-server`), not for scenes (see
+`scene-server`), and not for raw table CRUD (see
+[`database-admin-server`](../../mcps/database-admin-server/README.md), which is
+admin/migration only).
+
+Composed from handlers in `src/mcps/book-server`, `src/mcps/plot-server`,
+`src/mcps/timeline-server`, `src/mcps/metadata-server`, and `src/mcps/trope-server`
+— see [`index.js`](index.js) for the exact aggregation. One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `create_book`, `update_book`, `get_book`, `list_books` — book CRUD
+- `create_plot_thread`, `update_plot_thread` — open/update a plot thread scoped to
+  this book/series (see the root README's outline-vs-plot note before using —
+  don't confuse this with the `outline` server's own tree)
+- `create_timeline_event` — log a timeline event
+- `assign_book_genres` — attach genres to a book
+- `create_trope_instance`, `list_trope_instances`, `get_trope_instance` — trope
+  instances scoped to this book
+
+## Running it
+
+`node src/single-server-runner.js book-planning 3001` (or via the orchestrator,
+`node server.js`, which spawns it on port 3001 alongside the other core servers).

--- a/src/config-mcps/chapter-planning-server/readme.md
+++ b/src/config-mcps/chapter-planning-server/readme.md
@@ -1,20 +1,37 @@
-book_create_chapter
-book_update_chapter
-book_get_chapter
-book_list_chapters
-plot_create_information_reveal
-plot_add_reveal_evidence
-timeline_map_event_to_chapter
-world_track_location_usage
-world_track_element_usage
-track_organization_activity
-update_timeline_event
-update_event_mapping
-update_location
-update_world_element
-update_organization
-resolve_plot_thread
+# Chapter Planning MCP Server
 
-track_character_presence
-character_add_character_knowledge_with_chapter
-character_get_characters_who_know
+## Purpose / when to use it
+
+Use this server when planning or writing a **chapter**: creating/updating the
+chapter record, tracking which locations/world-elements/organizations get used in
+it, mapping a timeline event to it, logging a character-knowledge reveal tied to
+it, tracking a character's presence in it, or resolving a plot thread it closes
+out. It's the write path for chapter-level structure and chapter-scoped
+continuity bookkeeping — not for the book record itself (see
+`book-planning-server`), not for scene prose/word-count (see `scene-server`), and
+not for raw table CRUD (see
+[`database-admin-server`](../../mcps/database-admin-server/README.md), which is
+admin/migration only).
+
+Composed from handlers in `src/mcps/book-server` (chapters), `src/mcps/timeline-server`,
+`src/mcps/world-server`, `src/mcps/character-server`, and `src/mcps/plot-server`
+— see [`index.js`](index.js) for the exact aggregation. One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`. Note several tools are exposed
+under a prefixed alias here (e.g. `create_chapter` → `book_create_chapter`) to
+disambiguate from same-named tools in other servers:
+
+- `book_create_chapter`, `book_update_chapter`, `book_get_chapter`, `book_list_chapters` — chapter CRUD
+- `timeline_map_event_to_chapter`, `update_timeline_event`, `update_event_mapping` — timeline↔chapter mapping
+- `world_track_location_usage`, `world_track_element_usage`, `update_location`, `update_world_element` — world-building usage tracking for this chapter
+- `track_organization_activity`, `update_organization` — organization activity tracking
+- `character_add_character_knowledge_with_chapter`, `character_get_characters_who_know`, `track_character_presence` — character knowledge/presence tied to this chapter (use `track_character_presence` rather than a raw insert into `character_timeline_events` so knowledge-timing checks stay valid)
+- `plot_create_information_reveal`, `plot_add_reveal_evidence` — mystery/reveal tracking scoped to this chapter
+- `resolve_plot_thread` — close out a plot thread from this chapter
+
+## Running it
+
+`node src/single-server-runner.js chapter-planning 3003` (or via the orchestrator,
+`node server.js`, which spawns it on port 3003 alongside the other core servers).

--- a/src/config-mcps/character-planning-server/index.js
+++ b/src/config-mcps/character-planning-server/index.js
@@ -82,7 +82,7 @@ class CharacterPlanningMCPServer extends BaseMCPServer {
             tools.push({
                 ...updateCharacterSchema,
                 name: 'update_character',
-                description: 'Update character status/development for this book'
+                description: 'Update character status/development for this book — canonical write path; a raw database-admin update on the characters table bypasses this server\'s arc/continuity wiring.'
             });
         }
 

--- a/src/config-mcps/character-planning-server/readme.md
+++ b/src/config-mcps/character-planning-server/readme.md
@@ -1,10 +1,35 @@
-character_create_character
-character_update_character
-character_add_character_detail
-update_character_detail
-character_list_characters
-character_create_character_arc
-relationship_create_relationship_arc
-relationship_update_relationship_arc
-relationship_list_relationship_arcs
-relationship_track_relationship_dynamics
+# Character Planning MCP Server
+
+## Purpose / when to use it
+
+Use this server when creating or maintaining a **character**: the character
+record itself, book-specific character details, a character arc for a given book,
+or a relationship arc between two characters. It's the write path for character
+structure — not for character knowledge/continuity state during drafting (that's
+read-only in `core-continuity-server`; write-with-chapter-context lives in
+`chapter-planning-server`'s `character_add_character_knowledge_with_chapter`), and
+not for raw table CRUD (see
+[`database-admin-server`](../../mcps/database-admin-server/README.md), which is
+admin/migration only). Writing `characters` rows through raw CRUD skips this
+server's arc/relationship/knowledge wiring — a raw insert won't be visible to
+continuity or knowledge-timing checks until something resyncs it.
+
+Composed from handlers in `src/mcps/character-server` and
+`src/mcps/relationship-server` — see [`index.js`](index.js) for the exact
+aggregation. One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `list_characters`, `create_character`, `get_character`, `update_character` — character CRUD
+- `add_character_detail`, `update_character_detail` — book-specific character details
+- `check_character_knowledge` — check what a character knows (read-only guard against plot holes)
+- `create_character_arc`, `update_character_arc`, `delete_character_arc`, `list_character_arcs` — character arc for a book
+- `create_relationship_arc`, `update_relationship_arc`, `track_relationship_dynamics`, `list_relationship_arcs` — relationship arcs between characters
+
+## Running it
+
+`node src/single-server-runner.js character-planning 3004` (or via the
+orchestrator, `node server.js`, which spawns it on port 3004 alongside the other
+core servers).

--- a/src/config-mcps/core-continuity-server/index.js
+++ b/src/config-mcps/core-continuity-server/index.js
@@ -91,7 +91,7 @@ class CoreContinuityMCPServer extends BaseMCPServer {
             tools.push({
                 ...checkCharacterContinuity,
                 name: 'check_character_continuity',
-                description: 'Check character continuity across chapters'
+                description: 'Validate a character\'s state and knowledge stay consistent across a chapter range — catches contradictions a raw CRUD read can\'t.'
             });
         }
 

--- a/src/config-mcps/core-continuity-server/readme.md
+++ b/src/config-mcps/core-continuity-server/readme.md
@@ -1,8 +1,37 @@
-character_get_character
-character_get_character_details
-character_check_character_knowledge
-plot_get_plot_threads
-character_check_character_continuity
-relationship_get_relationship_arc
-relationship_get_relationship_timeline
-timeline_get_event_mappings
+# Core Continuity MCP Server
+
+## Purpose / when to use it
+
+**Read-only** server for continuity checks while drafting or reviewing: what does
+a character know, is a character's state consistent across a chapter range, what
+plot threads are open, what does a relationship look like over time, what lookup
+values/tropes exist. Run these checks *before* and *after* writing a scene or
+chapter to catch contradictions early — that's cheaper than finding them in a
+later editing pass. This server does not write anything; for the corresponding
+write operations use `character-planning-server`, `chapter-planning-server`, or
+`book-planning-server`.
+
+Composed from handlers in `src/mcps/character-server`, `src/mcps/plot-server`,
+`src/mcps/relationship-server`, `src/mcps/timeline-server`,
+`src/mcps/metadata-server`, and `src/mcps/trope-server` — see
+[`index.js`](index.js) for the exact aggregation. One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `get_character`, `get_character_details` — character lookups
+- `check_character_knowledge` — what does this character know
+- `check_character_continuity` — validate a character's state/knowledge stays
+  consistent across a `from_chapter_id`→`to_chapter_id` range; this is the check
+  a raw CRUD read can't give you, because it doesn't know what "consistent" means
+- `get_plot_threads` — open plot threads for continuity checking
+- `get_relationship_arc`, `get_relationship_timeline` — relationship state/history
+- `get_event_mappings` — timeline event ↔ chapter mappings
+- `get_available_options` — lookup vocabulary (genres, plot thread types, relationship types, story elements)
+- `get_trope`, `list_tropes`, `get_trope_instance`, `list_trope_instances` — trope definitions/instances (read-only; creation lives in `series-planning-server`/`book-planning-server`)
+
+## Running it
+
+`node src/single-server-runner.js core-continuity 3006` (or via the orchestrator,
+`node server.js`, which spawns it on port 3006 alongside the other core servers).

--- a/src/config-mcps/outline-server/readme.md
+++ b/src/config-mcps/outline-server/readme.md
@@ -11,10 +11,10 @@ bottom-up, manuscript-structure counterpart to the top-down, multi-book
 `plot_*` tools folded into `book-planning-server`/`chapter-planning-server`
 (open plot threads, series-level reveals, world systems) — **the two use
 separate ID spaces and are not interchangeable.** See the root README's
-"outline vs plot_* tools" section, and the fuller decision guide tracked in
-[#74](https://github.com/RLRyals/MCP-Writing-Servers/issues/74) /
-`docs/outline-vs-plot.md`, before assuming a tool from one accepts an id from
-the other.
+"outline vs plot_* tools" section, and the fuller decision guide at
+[`docs/outline-vs-plot.md`](../../../docs/outline-vs-plot.md) (tracked in
+[#74](https://github.com/RLRyals/MCP-Writing-Servers/issues/74)), before
+assuming a tool from one accepts an id from the other.
 
 Owns the `outline_*` tables. Composed from handlers in
 [`src/mcps/outline-server`](../../mcps/outline-server) — see

--- a/src/config-mcps/outline-server/readme.md
+++ b/src/config-mcps/outline-server/readme.md
@@ -1,0 +1,42 @@
+# Outline MCP Server
+
+## Purpose / when to use it
+
+Use this server to build and query the **per-scene story bible**: a
+series→book→act→beat→chapter→scene outline tree, the facts established along
+the way, promises (setups that must pay off), an evidence chain (findings a
+character can't act on yet), a batched log of what happened in a scene, and a
+"what does this character know as of this point" query. This is the
+bottom-up, manuscript-structure counterpart to the top-down, multi-book
+`plot_*` tools folded into `book-planning-server`/`chapter-planning-server`
+(open plot threads, series-level reveals, world systems) — **the two use
+separate ID spaces and are not interchangeable.** See the root README's
+"outline vs plot_* tools" section, and the fuller decision guide tracked in
+[#74](https://github.com/RLRyals/MCP-Writing-Servers/issues/74) /
+`docs/outline-vs-plot.md`, before assuming a tool from one accepts an id from
+the other.
+
+Owns the `outline_*` tables. Composed from handlers in
+[`src/mcps/outline-server`](../../mcps/outline-server) — see
+[`index.js`](index.js) for the exact aggregation. One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js` (21 tools):
+
+- `create_work`, `update_work`, `move_work`, `delete_work` — outline tree nodes (series/book/act/beat/chapter/scene)
+- `get_outline`, `get_ancestry`, `list_series_roots`, `list_works`, `search_works` — read the tree
+- `create_fact`, `list_facts`, `update_fact`, `delete_fact` — facts established in the story
+- `create_promise`, `update_promise`, `list_open_promises` — setups that must pay off
+- `create_evidence`, `update_evidence`, `list_unconverted_evidence` — findings a character can't act on yet
+- `record_scene_events` — batch-log what a scene does (event_type + entity id); this is the source-of-truth tool for scene content, not a raw insert into an events table
+- `what_does_character_know_at` — replay a character's knowledge state as of a given tree node
+- `get_scene_brief` — pull the staged brief for a scene
+
+## Running it
+
+`node src/single-server-runner.js outline 3013`. Not currently spawned by the
+`server.js` orchestrator's default 11-server list — run standalone via
+`single-server-runner.js`, or confirm with your deployment operator how it's
+started in this environment. It is registered in agent-facing
+[`mcp-config/mcp-config.json`](../../../mcp-config/mcp-config.json).

--- a/src/config-mcps/reporting-server/readme.md
+++ b/src/config-mcps/reporting-server/readme.md
@@ -1,0 +1,23 @@
+# Reporting MCP Server
+
+## Purpose / when to use it
+
+Use this server to generate a rolled-up **report** across series/book entities
+— an organized summary rather than raw row data. It's read-only and has a
+single tool; for the underlying entity data itself, use the domain server that
+owns it (`series-planning-server`, `book-planning-server`, etc.) or
+`core-continuity-server` for continuity-focused reads.
+
+Composed from `ReportingHandlers` in [`handlers/reporting-handlers.js`](handlers/reporting-handlers.js)
+— see [`index.js`](index.js). One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `generate_report` — generate a report of series/book entities with organized lists
+
+## Running it
+
+`node src/single-server-runner.js reporting 3008` (or via the orchestrator,
+`node server.js`, which spawns it on port 3008 alongside the other core servers).

--- a/src/config-mcps/review-server/readme.md
+++ b/src/config-mcps/review-server/readme.md
@@ -1,10 +1,30 @@
-writing_validate_chapter_structure
-writing_validate_beat_placement
-writing_check_structure_violations
-world_check_world_consistency
-set_writing_goals
-get_productivity_analytics
-writing_export_manuscript
+# Review MCP Server
 
-writing_word_count_tracking
-get_writing_progress
+## Purpose / when to use it
+
+Use this server during the **editing/revision phase**: structural and beat-
+placement validation, world-consistency checks, manuscript export, and
+writing-goal/productivity tracking. It's a mix of read-only checks and
+session/goal bookkeeping — it does not create or update chapters, characters, or
+scenes (use `chapter-planning-server`, `character-planning-server`, or
+`scene-server` for that).
+
+Composed from handlers in `src/mcps/writing-server`, `src/mcps/timeline-server`,
+`src/mcps/world-server`, and `src/mcps/trope-server` — see
+[`index.js`](index.js) for the exact aggregation. One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `validate_chapter_structure`, `validate_beat_placement`, `check_structure_violations` — structural/pacing/continuity checks
+- `word_count_tracking` — pacing/chapter-length analysis
+- `export_manuscript` — generate full or partial manuscript for review
+- `check_world_consistency` — flag world-building contradictions
+- `set_writing_goals`, `get_productivity_analytics`, `get_writing_progress` — writing-session goals and analytics
+- `get_trope_progress`, `analyze_trope_patterns` — trope tracking/analysis
+
+## Running it
+
+`node src/single-server-runner.js review 3007` (or via the orchestrator,
+`node server.js`, which spawns it on port 3007 alongside the other core servers).

--- a/src/config-mcps/scene-server/readme.md
+++ b/src/config-mcps/scene-server/readme.md
@@ -1,7 +1,32 @@
-book_create_scene
-book_update_scene
-book_get_scene
-book_list_scenes
-character_get_characters_in_chapter
-writing_word_count_tracking
-log_writing_session
+# Scene Writing MCP Server
+
+## Purpose / when to use it
+
+Use this server while actively **drafting a scene**: create/update the scene
+record, check who's supposed to appear in the chapter, validate structure/beats
+as you go, track word count, and log the writing session. This is the write path
+for scene-level prose bookkeeping — not for the chapter record itself (see
+`chapter-planning-server`), and not for raw table CRUD (see
+[`database-admin-server`](../../mcps/database-admin-server/README.md), which is
+admin/migration only).
+
+Composed from handlers in `src/mcps/book-server` (scenes), `src/mcps/character-server`,
+`src/mcps/writing-server`, and `src/mcps/trope-server` — see
+[`index.js`](index.js) for the exact aggregation. One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `create_scene`, `update_scene`, `get_scene`, `list_scenes` — scene CRUD (create as scenes are written; update with word counts/status)
+- `get_character_details`, `get_characters_in_chapter` — check who's present before/while writing
+- `check_character_continuity` — validate this scene's character state against earlier chapters
+- `validate_chapter_structure`, `validate_beat_placement`, `check_structure_violations` — structural/pacing checks
+- `word_count_tracking` — track word-count progress
+- `log_writing_session` — log a writing session
+- `implement_trope_scene`, `get_trope_scenes` — trope implementation tied to this scene
+
+## Running it
+
+`node src/single-server-runner.js scene 3005` (or via the orchestrator,
+`node server.js`, which spawns it on port 3005 alongside the other core servers).

--- a/src/config-mcps/series-planning-server/README.md
+++ b/src/config-mcps/series-planning-server/README.md
@@ -1,12 +1,37 @@
-series_create_series
-series_update_series
-series_get_series
-series_list_series
-assign_series_genres
-plot_define_world_system
-world_create_location
-world_create_organization
-world_create_world_element
-world_get_locations
-world_get_world_elements
-world_get_organizations
+# Series Planning MCP Server
+
+## Purpose / when to use it
+
+Use this server when standing up or maintaining a **series**: the series record
+itself, series-level genres, series-scoped world-building (locations,
+organizations, world elements), a world "system" definition (magic system, tech
+level, etc.), and defining a trope at the series level. It's the top-of-the-tree
+write path — book-level structure lives in `book-planning-server`, chapter-level
+in `chapter-planning-server`. Reading series-scoped world data back during
+drafting/continuity checks goes through `core-continuity-server`, not this
+server.
+
+Composed from handlers in `src/mcps/series-server`, `src/mcps/metadata-server`,
+`src/mcps/world-server`, `src/mcps/plot-server` (genre extensions only), and
+`src/mcps/trope-server` — see [`index.js`](index.js) for the exact aggregation.
+One shared DB connection.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js` — note this list previously
+drifted from the code (a stale prefixed set like `series_create_series`,
+`world_create_location`); the names below are the actual, currently callable
+tool names:
+
+- `list_series`, `create_series`, `get_series`, `update_series` — series CRUD
+- `assign_series_genres` — attach genres to a series
+- `create_location`, `get_locations` — series-scoped locations
+- `create_organization`, `get_organizations` — series-scoped organizations
+- `create_world_element`, `get_world_elements` — series-scoped world elements
+- `define_world_system` — define a world system (magic/tech/rules) for the series
+- `create_trope` — define a trope at the series level (trope *instances* are created per-book in `book-planning-server`; trope lookups are read-only in `core-continuity-server`)
+
+## Running it
+
+`node src/single-server-runner.js series-planning 3002` (or via the orchestrator,
+`node server.js`, which spawns it on port 3002 alongside the other core servers).

--- a/src/mcps/book-server/schemas/chapter-planning-schemas.js
+++ b/src/mcps/book-server/schemas/chapter-planning-schemas.js
@@ -9,7 +9,7 @@
 export const chapterPlanningSchemas = {
     create_chapter: {
         name: 'create_chapter',
-        description: 'Create chapter',
+        description: 'Create a chapter. Canonical entry point for new chapters — a raw database-admin insert on the chapters table skips chapter-scoped timeline/world/knowledge wiring that other tools depend on.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -73,7 +73,7 @@ export const chapterPlanningSchemas = {
 
     update_chapter: {
         name: 'update_chapter',
-        description: 'Update chapter',
+        description: 'Update chapter fields (status, word count, summary, etc.). Prefer this over raw database-admin CRUD so status transitions stay consistent with other chapter-scoped tracking.',
         inputSchema: {
             type: 'object',
             properties: {

--- a/src/mcps/character-server/schemas/character-tools-schema.js
+++ b/src/mcps/character-server/schemas/character-tools-schema.js
@@ -41,7 +41,7 @@ export const characterToolsSchema = [
     },
     {
         name: 'create_character',
-        description: 'Create character',
+        description: 'Create a character. Canonical entry point for new characters — a raw database-admin insert on the characters table skips this and won\'t be visible to knowledge/relationship/continuity tools.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -70,7 +70,7 @@ export const characterToolsSchema = [
     },
     {
         name: 'update_character',
-        description: 'Update character',
+        description: 'Update core character fields (name, type, status). Prefer this over raw database-admin CRUD so status changes stay consistent with arc and continuity tracking.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -191,7 +191,7 @@ export const characterDetailToolsSchema = [
 export const characterKnowledgeToolsSchema = [
     {
         name: 'add_character_knowledge',
-        description: 'Track character knowledge',
+        description: 'Record what a character knows, when, and how — maintains knowledge-state continuity. A raw table write bypasses the checks that catch "character knows something before they learned it" plot holes.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -332,7 +332,7 @@ export const characterKnowledgeToolsSchema = [
 export const characterTimelineToolsSchema = [
     {
         name: 'track_character_presence',
-        description: 'Track character in chapter',
+        description: 'Record a character\'s presence/state in a chapter or scene — feeds continuity and knowledge-timing checks. A raw insert bypasses those checks.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -385,7 +385,7 @@ export const characterTimelineToolsSchema = [
     },
     {
         name: 'check_character_continuity',
-        description: 'Check character continuity',
+        description: 'Validate a character\'s state and knowledge stay consistent across a chapter range — catches contradictions a raw CRUD read can\'t, because it has no notion of "consistent."',
         inputSchema: {
             type: 'object',
             properties: {

--- a/src/mcps/database-admin-server/README.md
+++ b/src/mcps/database-admin-server/README.md
@@ -4,6 +4,8 @@
 
 A secure MCP (Model Context Protocol) server that provides comprehensive database management including CRUD operations, batch processing, schema introspection, security controls, and backup/restore capabilities.
 
+> **Not the normal authoring path.** This server is for admin, migration, and bulk-repair work against whitelisted tables. Writing a chapter, character, scene, or plot thread through `db_insert_record`/`db_update_records` bypasses the continuity/knowledge-state/arc invariants the purpose-built domain servers enforce. For normal authoring, use those servers instead — see the [routing map in the root README](../../../README.md#which-server-for-which-task).
+
 ## 🎯 Overview
 
 The Database Admin Server enables AI assistants to safely manage database records with:


### PR DESCRIPTION
Adds the routing README + caveat banners steering agents to purpose-built domain servers over database-admin-server raw CRUD (the Full-CRUD anti-pattern), and enriches domain tool descriptions. References docs/outline-vs-plot.md — merge PR for #74 docs first if both are open.

Recovered 2026-07-13: this work was completed by an implementing agent on 2026-07-12 but only committed locally — pushed and PR'd now so it flows through the normal review pipeline.

Closes bead: mws-1783883496322-5-bc690947

🤖 Generated with [Claude Code](https://claude.com/claude-code)