### PR TITLE
fix: books.author_id/book_order schema mismatch in batch-operations tests

### DIFF
--- a/src/mcps/database-admin-server/README.md
+++ b/src/mcps/database-admin-server/README.md
@@ -264,7 +264,7 @@ node server.js
   },
   "order_by": [
     { "column": "publication_year", "direction": "DESC" },
-    { "column": "book_order", "direction": "ASC" }
+    { "column": "book_number", "direction": "ASC" }
   ],
   "limit": 20
 }

--- a/src/mcps/database-admin-server/utils/security-validator.js
+++ b/src/mcps/database-admin-server/utils/security-validator.js
@@ -11,7 +11,7 @@ export const WHITELIST = {
     // Core entities
     authors: ['id', 'name', 'bio', 'created_at', 'updated_at'],
     series: ['id', 'title', 'author_id', 'description', 'start_year', 'status', 'created_at', 'updated_at'],
-    books: ['id', 'series_id', 'title', 'author_id', 'description', 'publication_year', 'status', 'book_order', 'created_at', 'updated_at'],
+    books: ['id', 'series_id', 'title', 'description', 'publication_year', 'status', 'book_number', 'created_at', 'updated_at'],
     chapters: ['id', 'book_id', 'chapter_number', 'title', 'content', 'word_count', 'status', 'created_at', 'updated_at'],
     scenes: ['id', 'chapter_id', 'scene_number', 'title', 'content', 'word_count', 'pov_character_id', 'location_id', 'created_at', 'updated_at'],
 
@@ -81,7 +81,6 @@ export const WHITELIST = {
  * Tables that support soft delete (have deleted_at column)
  */
 export const SOFT_DELETE_TABLES = new Set([
-    'books',
     'chapters',
     'scenes',
     'characters',

--- a/tests/database-admin-server/batch-operations.test.js
+++ b/tests/database-admin-server/batch-operations.test.js
@@ -82,23 +82,20 @@ describe('Batch Operations Tests', () => {
                     {
                         series_id: testSeriesId,
                         title: 'Batch Book 1',
-                        author_id: testAuthorId,
                         description: 'First batch book',
-                        book_order: 1
+                        book_number: 1
                     },
                     {
                         series_id: testSeriesId,
                         title: 'Batch Book 2',
-                        author_id: testAuthorId,
                         description: 'Second batch book',
-                        book_order: 2
+                        book_number: 2
                     },
                     {
                         series_id: testSeriesId,
                         title: 'Batch Book 3',
-                        author_id: testAuthorId,
                         description: 'Third batch book',
-                        book_order: 3
+                        book_number: 3
                     }
                 ]
             });
@@ -136,14 +133,12 @@ describe('Batch Operations Tests', () => {
                         {
                             series_id: testSeriesId,
                             title: 'Valid Book',
-                            author_id: testAuthorId,
-                            book_order: 10
+                            book_number: 10
                         },
                         {
                             // Missing required field 'title'
                             series_id: testSeriesId,
-                            author_id: testAuthorId,
-                            book_order: 11
+                            book_number: 11
                         }
                     ]
                 });
@@ -200,16 +195,14 @@ describe('Batch Operations Tests', () => {
                     {
                         series_id: testSeriesId,
                         title: 'Update Test Book 1',
-                        author_id: testAuthorId,
                         status: 'draft',
-                        book_order: 20
+                        book_number: 20
                     },
                     {
                         series_id: testSeriesId,
                         title: 'Update Test Book 2',
-                        author_id: testAuthorId,
                         status: 'draft',
-                        book_order: 21
+                        book_number: 21
                     }
                 ]
             });
@@ -297,20 +290,17 @@ describe('Batch Operations Tests', () => {
                     {
                         series_id: testSeriesId,
                         title: 'Delete Test Book 1',
-                        author_id: testAuthorId,
-                        book_order: 30
+                        book_number: 30
                     },
                     {
                         series_id: testSeriesId,
                         title: 'Delete Test Book 2',
-                        author_id: testAuthorId,
-                        book_order: 31
+                        book_number: 31
                     },
                     {
                         series_id: testSeriesId,
                         title: 'Delete Test Book 3',
-                        author_id: testAuthorId,
-                        book_order: 32
+                        book_number: 32
                     }
                 ]
             });
@@ -321,7 +311,11 @@ describe('Batch Operations Tests', () => {
             deleteTestBookIds = response.insertedIds;
         });
 
-        it('should soft delete multiple records', async () => {
+        it('should fall back to hard delete for tables without a deleted_at column', async () => {
+            // 'books' has no deleted_at column (verified against the live schema),
+            // so it is not in SOFT_DELETE_TABLES. Requesting soft_delete: true for
+            // an unsupported table falls back to a real (hard) delete rather than
+            // erroring, since SecurityValidator.supportsSoftDelete('books') is false.
             const handler = server.getToolHandler('db_batch_delete');
             const result = await handler({
                 table: 'books',
@@ -339,7 +333,7 @@ describe('Batch Operations Tests', () => {
             assert.strictEqual(response.success, true);
             assert.strictEqual(response.deletedCount, 2);
 
-            // Verify soft delete (deleted_at should be set)
+            // Verify hard delete actually happened (no deleted_at column to soft-delete with)
             const queryHandler = server.getToolHandler('db_query_records');
             const deletedBooks = await queryHandler({
                 table: 'books',
@@ -349,9 +343,7 @@ describe('Batch Operations Tests', () => {
                 deletedBooks.content[0].text.split('\n\n').pop()
             );
 
-            // Books should still exist with deleted_at set
-            assert.strictEqual(deletedData.count, 2);
-            assert.ok(deletedData.records[0].deleted_at !== null);
+            assert.strictEqual(deletedData.count, 0);
         });
 
         it('should hard delete multiple records', async () => {
@@ -392,16 +384,13 @@ describe('Batch Operations Tests', () => {
     // =========================================
 
     describe('Performance Tests', () => {
-        it('should insert 100 records in under 2 seconds', async function() {
-            this.timeout(5000);
-
+        it('should insert 100 records in under 2 seconds', { timeout: 5000 }, async () => {
             const records = [];
             for (let i = 0; i < 100; i++) {
                 records.push({
                     series_id: testSeriesId,
                     title: `Performance Test Book ${i}`,
-                    author_id: testAuthorId,
-                    book_order: 100 + i
+                    book_number: 100 + i
                 });
             }
 
@@ -458,14 +447,12 @@ describe('Batch Operations Tests', () => {
                     {
                         series_id: testSeriesId,
                         title: 'Atomic Test Book 1',
-                        author_id: testAuthorId,
-                        book_order: 200
+                        book_number: 200
                     },
                     {
                         series_id: testSeriesId,
                         title: 'Atomic Test Book 2',
-                        author_id: testAuthorId,
-                        book_order: 201
+                        book_number: 201
                     }
                 ]
             });

--- a/tests/database-admin-server/query-builder.test.js
+++ b/tests/database-admin-server/query-builder.test.js
@@ -292,9 +292,12 @@ describe('QueryBuilder', () => {
 
     describe('buildSoftDeleteQuery', () => {
         it('should build soft DELETE query', () => {
-            const result = QueryBuilder.buildSoftDeleteQuery('books', { id: 1 });
+            // 'books' has no deleted_at column in the live schema (see
+            // security-validator.js SOFT_DELETE_TABLES), so this uses 'chapters',
+            // which does support soft delete, to exercise the query builder.
+            const result = QueryBuilder.buildSoftDeleteQuery('chapters', { id: 1 });
 
-            assert(result.text.includes('UPDATE books'));
+            assert(result.text.includes('UPDATE chapters'));
             assert(result.text.includes('SET deleted_at = CURRENT_TIMESTAMP'));
             assert(result.text.includes('updated_at = CURRENT_TIMESTAMP'));
             assert(result.text.includes('WHERE id = $1 AND deleted_at IS NULL'));

--- a/tests/database-admin-server/security-validator.test.js
+++ b/tests/database-admin-server/security-validator.test.js
@@ -239,13 +239,16 @@ describe('SecurityValidator', () => {
 
     describe('supportsSoftDelete', () => {
         it('should return true for tables with soft delete support', () => {
-            assert.strictEqual(SecurityValidator.supportsSoftDelete('books'), true);
+            assert.strictEqual(SecurityValidator.supportsSoftDelete('chapters'), true);
             assert.strictEqual(SecurityValidator.supportsSoftDelete('characters'), true);
         });
 
         it('should return false for tables without soft delete support', () => {
             assert.strictEqual(SecurityValidator.supportsSoftDelete('authors'), false);
             assert.strictEqual(SecurityValidator.supportsSoftDelete('genres'), false);
+            // 'books' has no deleted_at column in the live schema, so it was
+            // removed from SOFT_DELETE_TABLES (see mws-7r6).
+            assert.strictEqual(SecurityValidator.supportsSoftDelete('books'), false);
         });
     });
 

--- a/tests/security-phase4.test.js
+++ b/tests/security-phase4.test.js
@@ -73,7 +73,9 @@ describe('Phase 4: Security Controls & Audit Logging', () => {
 
         it('should only allow whitelisted columns for each table', () => {
             // Valid columns for 'books' table
-            expect(() => SecurityValidator.validateColumns('books', ['id', 'title', 'author_id'])).not.toThrow();
+            // ('author_id' is not a books column in the live schema -- books
+            // reach their author via series.author_id, see mws-7r6)
+            expect(() => SecurityValidator.validateColumns('books', ['id', 'title', 'book_number'])).not.toThrow();
 
             // Invalid columns for 'books' table
             expect(() => SecurityValidator.validateColumns('books', ['password'])).toThrow(/not whitelisted/);
@@ -280,13 +282,15 @@ describe('Phase 4: Security Controls & Audit Logging', () => {
 
         it('should correctly identify tables that support soft delete', () => {
             // Tables with soft delete
-            expect(SecurityValidator.supportsSoftDelete('books')).toBe(true);
             expect(SecurityValidator.supportsSoftDelete('characters')).toBe(true);
             expect(SecurityValidator.supportsSoftDelete('scenes')).toBe(true);
 
             // Tables without soft delete
             expect(SecurityValidator.supportsSoftDelete('genres')).toBe(false);
             expect(SecurityValidator.supportsSoftDelete('series_genres')).toBe(false);
+            // 'books' has no deleted_at column in the live schema, so it was
+            // removed from SOFT_DELETE_TABLES (see mws-7r6).
+            expect(SecurityValidator.supportsSoftDelete('books')).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Summary

Pre-existing failure on `main`: `tests/database-admin-server/batch-operations.test.js` had one failing case, caused by a `books.author_id` schema mismatch between the test's expectations and the actual schema.

**Diagnosis (live DB is the arbiter):** ran a read-only `\d books` against the running Postgres container. The live schema and `init.sql` agree with each other: `books` has no `author_id` column (a book reaches its author through `series.author_id`, not directly) and no `book_order` column (the real column is `book_number`). So the **test side was wrong**, not the schema -- the test was inserting `author_id`/`book_order` into `books`, which doesn't exist in either the live DB or `init.sql`.

The security-validator `WHITELIST` had the same drift baked in (`books` listed `author_id`/`book_order` as valid columns), so it's fixed too -- same root cause, same fix direction (config conforms to live schema, not the other way around).

While fixing the cascading failures this unmasked, found two more schema/test-vs-reality mismatches in the same file, all verified against the live DB the same way:

- `SOFT_DELETE_TABLES` claimed `books` supports soft delete (a `deleted_at` column), but no such column exists on the live `books` table either. Requesting `soft_delete: true` on `books` today throws a raw Postgres error (`column "deleted_at" does not exist`). Removed `books` from `SOFT_DELETE_TABLES` so batch-delete correctly falls back to a real hard delete instead of erroring, and updated the tests that asserted the old (broken) behavior.
- An unrelated Mocha-ism (`this.timeout(5000)`) in the performance test threw under Node's built-in test runner; replaced with the `{ timeout }` option `it()` actually supports.

None of this touches the live database -- only `init.sql`-adjacent config/tests, verified against a disposable, ephemeral `postgres:16` container loaded from `init.sql`.

## Files changed

- `src/mcps/database-admin-server/utils/security-validator.js` -- `WHITELIST.books` drops `author_id`, renames `book_order` -> `book_number`; `SOFT_DELETE_TABLES` drops `books`.
- `tests/database-admin-server/batch-operations.test.js` -- book records use `book_number`, no `author_id`; soft-delete test updated to reflect the real (hard-delete-fallback) behavior; performance test timeout fixed.
- `tests/database-admin-server/query-builder.test.js` -- soft-delete query-builder test now uses `chapters` (which does support soft delete) instead of `books`.
- `tests/database-admin-server/security-validator.test.js`, `tests/security-phase4.test.js` -- updated assertions to match the corrected whitelist/soft-delete config.
- `src/mcps/database-admin-server/README.md` -- example query updated to `book_number`.

## Test plan

Ran against a disposable, ephemeral Postgres container loaded from `init.sql` (never the live/shared database):

- [x] `node --test tests/database-admin-server/batch-operations.test.js` -- was 1 pass / 4 fail / 4 cancelled, now **9/9 pass**.
- [x] `node tests/database-admin-server/run-tests.js` (the legacy suite CI actually runs) -- still **188/188 pass**, unaffected.
- [x] `node --check` on every touched file (syntax sanity).

Closes bead: mws-7r6

🤖 Generated with [Claude Code](https://claude.com/claude-code)