### PR TITLE
config-mcps: add phase-based story-analysis wrapper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,33 @@ jobs:
       - name: Run plot-server tests
         run: node tests/plot-server/run-tests.js
 
+  story-analysis-server-tests:
+    name: Story Analysis Server Wrapper Tests
+    runs-on: ubuntu-latest
+    # bead mws-1783883496278-4-e2749385: config-mcps phase-based wrapper for
+    # story-analysis-server. This checks tool visibility/routing on the
+    # wrapper only (src/config-mcps/story-analysis-server/index.js) against
+    # an unreachable-but-valid DATABASE_URL (pg.Pool connects lazily, so no
+    # postgres service is needed here) -- no live DB queries are exercised.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run story-analysis-server wrapper tests
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/writing_server_test
+        run: node --test tests/story-analysis-server/story-analysis-wrapper.test.js
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest

--- a/src/config-mcps/story-analysis-server/index.js
+++ b/src/config-mcps/story-analysis-server/index.js
@@ -1,0 +1,146 @@
+// src/config-mcps/story-analysis-server/index.js
+// Phase-based MCP Server: Story Analysis
+// Tools for analyzing story dynamics, character throughlines, story
+// appreciations, and problem/solution mapping (narrative-theory-inspired).
+
+// Protect stdout from debug logging in MCP stdio mode
+if (process.env.MCP_STDIO_MODE === 'true') {
+    const originalConsoleError = console.error;
+    console.error = function () {
+        process.stderr.write(Array.from(arguments).join(' ') + '\n');
+    };
+}
+
+import { BaseMCPServer } from '../../shared/base-server.js';
+
+// Import ONLY the handler class - NOT the full server
+import { StoryAnalysisHandlers } from '../../mcps/story-analysis-server/handlers/story-analysis-handlers.js';
+
+class StoryAnalysisMCPServer extends BaseMCPServer {
+    constructor() {
+        super('story-analysis-server', '1.0.0');
+
+        // Initialize handler instance with our shared DB connection
+        this.initializeHandlers();
+
+        // Build tool list
+        this.tools = this.buildTools();
+
+        console.error(`[STORY-ANALYSIS-SERVER] Initialized with ${this.tools.length} tools using 1 DB connection`);
+    }
+
+    initializeHandlers() {
+        // Create handler instance passing our shared database
+        this.storyAnalysisHandlers = new StoryAnalysisHandlers(this.db);
+
+        console.error('[STORY-ANALYSIS-SERVER] Handlers initialized with shared DB');
+    }
+
+    buildTools() {
+        const tools = [];
+
+        // STORY ANALYSIS TOOLS
+        const storyAnalysisTools = this.storyAnalysisHandlers.getStoryAnalysisTools();
+
+        const analyzeStoryDynamics = storyAnalysisTools.find(t => t.name === 'analyze_story_dynamics');
+        if (analyzeStoryDynamics) {
+            tools.push({
+                ...analyzeStoryDynamics,
+                name: 'analyze_story_dynamics',
+                description: 'Analyze the overall story dynamics for a book (story concern, main/influence character problems, outcome, judgment, thematic elements)'
+            });
+        }
+
+        const trackCharacterThroughlines = storyAnalysisTools.find(t => t.name === 'track_character_throughlines');
+        if (trackCharacterThroughlines) {
+            tools.push({
+                ...trackCharacterThroughlines,
+                name: 'track_character_throughlines',
+                description: 'Track a character\'s throughline for a book (main character, influence character, relationship, or objective story)'
+            });
+        }
+
+        const identifyStoryAppreciations = storyAnalysisTools.find(t => t.name === 'identify_story_appreciations');
+        if (identifyStoryAppreciations) {
+            tools.push({
+                ...identifyStoryAppreciations,
+                name: 'identify_story_appreciations',
+                description: 'Identify and record a story appreciation (a narrative-theory observation about the book, with supporting evidence and confidence)'
+            });
+        }
+
+        const mapProblemSolutions = storyAnalysisTools.find(t => t.name === 'map_problem_solutions');
+        if (mapProblemSolutions) {
+            tools.push({
+                ...mapProblemSolutions,
+                name: 'map_problem_solutions',
+                description: 'Map a problem to its attempted solution at a given level (overall story, main character, influence character, or relationship), with effectiveness'
+            });
+        }
+
+        return tools;
+    }
+
+    getToolHandler(toolName) {
+        // Route to the appropriate handler based on tool name
+        const handlerMap = {
+            // Story analysis handlers
+            'analyze_story_dynamics': (args) => this.storyAnalysisHandlers.handleAnalyzeStoryDynamics(args),
+            'track_character_throughlines': (args) => this.storyAnalysisHandlers.handleTrackCharacterThroughlines(args),
+            'identify_story_appreciations': (args) => this.storyAnalysisHandlers.handleIdentifyStoryAppreciations(args),
+            'map_problem_solutions': (args) => this.storyAnalysisHandlers.handleMapProblemSolutions(args)
+        };
+
+        return handlerMap[toolName] || null;
+    }
+}
+
+export { StoryAnalysisMCPServer };
+
+// CLI runner when called directly
+import { fileURLToPath } from 'url';
+
+const normalizePath = (path) => {
+    if (!path) return '';
+    let normalizedPath = path.replace(/\\/g, '/');
+    if (!normalizedPath.startsWith('file:')) {
+        if (process.platform === 'win32') {
+            normalizedPath = `file:///${normalizedPath}`;
+        } else {
+            normalizedPath = `file://${normalizedPath}`;
+        }
+    }
+    normalizedPath = normalizedPath.replace(/^file:\/+/, 'file:///');
+    return normalizedPath;
+};
+
+const normalizedScriptPath = normalizePath(process.argv[1]);
+const normalizedCurrentModuleUrl = import.meta.url.replace(/\/{3,}/g, '///')
+    .replace(/^file:\/([^\/])/, 'file:///$1');
+
+const isDirectExecution = normalizedCurrentModuleUrl === normalizedScriptPath ||
+    decodeURIComponent(normalizedCurrentModuleUrl) === normalizedScriptPath;
+
+if (process.env.MCP_STDIO_MODE) {
+    console.error('[STORY-ANALYSIS-SERVER] Running in MCP stdio mode - starting server...');
+    try {
+        const server = new StoryAnalysisMCPServer();
+        await server.run();
+    } catch (error) {
+        console.error('[STORY-ANALYSIS-SERVER] Failed to start MCP server:', error.message);
+        console.error('[STORY-ANALYSIS-SERVER] Stack:', error.stack);
+        process.exit(1);
+    }
+} else if (isDirectExecution) {
+    console.error('[STORY-ANALYSIS-SERVER] Starting CLI runner...');
+    try {
+        const { CLIRunner } = await import('../../shared/cli-runner.js');
+        const runner = new CLIRunner(StoryAnalysisMCPServer);
+        await runner.run();
+    } catch (error) {
+        console.error('[STORY-ANALYSIS-SERVER] CLI runner failed:', error.message);
+        throw error;
+    }
+} else {
+    console.error('[STORY-ANALYSIS-SERVER] Module imported - not starting server');
+}

--- a/src/config-mcps/story-analysis-server/readme.md
+++ b/src/config-mcps/story-analysis-server/readme.md
@@ -1,0 +1,41 @@
+# Story Analysis MCP Server
+
+## Purpose / when to use it
+
+Use this server for **narrative-theory-inspired story analysis**: recording the
+overall dynamics of a book's story (concern, main/influence character problems,
+outcome, judgment, themes), tracking a character's throughline across a book,
+identifying story appreciations (evidence-backed narrative observations), and
+mapping problems to attempted solutions at the story/character/relationship
+level. It is the write path for this analysis layer — not for character
+structure itself (see `character-planning-server`) and not for continuity
+checks during drafting (see `core-continuity-server`).
+
+Composed from the single handler in `src/mcps/story-analysis-server` — see
+[`index.js`](index.js) for the exact aggregation. One shared DB connection.
+
+The four write tools INSERT/UPDATE the `story_analysis`,
+`character_throughlines`, `story_appreciations`, and `problem_solutions`
+tables. Two of the four handlers (`track_character_throughlines`,
+`identify_story_appreciations`) fall back to appending a note into
+`story_analysis.analysis_notes` if their dedicated table isn't present in the
+target database — see `src/mcps/story-analysis-server/handlers/story-analysis-handlers.js`
+for that fallback logic.
+
+## Tools
+
+Verified against `getToolHandler()` in `index.js`:
+
+- `analyze_story_dynamics` — create/update the story-level analysis for a book
+- `track_character_throughlines` — create/update a character's throughline for a book
+- `identify_story_appreciations` — record a story appreciation with supporting evidence
+- `map_problem_solutions` — map a problem to its attempted solution and effectiveness
+
+## Running it
+
+Registered in `src/http-sse-server.js` on port 3016 (multi-port SSE mode). Not
+currently added to `single-server-runner.js`'s server map or the `server.js`
+orchestrator's default server list (the same gap `npe-server` has) — run it
+directly via `node src/config-mcps/story-analysis-server/index.js` (CLI mode)
+or `MCP_STDIO_MODE=true node src/config-mcps/story-analysis-server/index.js`
+(MCP stdio mode) until it's wired into those runners.

--- a/src/http-sse-server.js
+++ b/src/http-sse-server.js
@@ -229,7 +229,21 @@ async function loadServers() {
         console.error('✗ Failed to load Kanban Server:', error.message);
     }
 
-    console.error(`\n✅ Successfully loaded ${servers.length}/13 servers\n`);
+    try {
+        // Story Analysis Server (phase-based wrapper, bead mws-1783883496278-4-e2749385)
+        const { StoryAnalysisMCPServer } = await import('./config-mcps/story-analysis-server/index.js');
+        servers.push({
+            name: 'story-analysis',
+            path: '/story-analysis',
+            serverClass: StoryAnalysisMCPServer,
+            port: 3016
+        });
+        console.error('✓ Story Analysis Server loaded');
+    } catch (error) {
+        console.error('✗ Failed to load Story Analysis Server:', error.message);
+    }
+
+    console.error(`\n✅ Successfully loaded ${servers.length}/15 servers\n`);
     return servers;
 }
 

--- a/tests/story-analysis-server/story-analysis-wrapper.test.js
+++ b/tests/story-analysis-server/story-analysis-wrapper.test.js
@@ -1,0 +1,83 @@
+// tests/story-analysis-server/story-analysis-wrapper.test.js
+// Covers bead mws-1783883496278-4-e2749385 acceptance criterion:
+// "config-mcps: add phase-based story-analysis wrapper (reference handlers,
+// don't copy)."
+//
+// The story-analysis-server config-mcp (port 3016) is a phase-scoped wrapper
+// around the StoryAnalysisHandlers class in
+// src/mcps/story-analysis-server/handlers/story-analysis-handlers.js -- see
+// src/config-mcps/story-analysis-server/index.js. This checks that the
+// wrapper registers/exposes the four analysis tools through its
+// buildTools()/getToolHandler(), without re-declaring the tool schemas.
+//
+// No live DB writes are exercised here (the prerequisite migration for
+// story_analysis / character_throughlines / story_appreciations /
+// problem_solutions merged in PR #84, but this test only checks wrapper
+// wiring/tool visibility -- pg.Pool connects lazily so no postgres service
+// is required to run it).
+
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert';
+import { StoryAnalysisMCPServer } from '../../src/config-mcps/story-analysis-server/index.js';
+import { storyAnalysisToolsSchema } from '../../src/mcps/story-analysis-server/schemas/story-analysis-tools-schema.js';
+
+describe('story-analysis-server wrapper tool visibility (mws-4)', () => {
+    let server;
+
+    after(async () => {
+        if (server && server.db && server.db.pool) {
+            await server.db.pool.end();
+        }
+    });
+
+    it('exposes the four story-analysis tools', () => {
+        server = new StoryAnalysisMCPServer();
+        const toolNames = server.tools.map(t => t.name);
+
+        assert.ok(toolNames.includes('analyze_story_dynamics'));
+        assert.ok(toolNames.includes('track_character_throughlines'));
+        assert.ok(toolNames.includes('identify_story_appreciations'));
+        assert.ok(toolNames.includes('map_problem_solutions'));
+        assert.strictEqual(server.tools.length, 4, 'wrapper should expose exactly the 4 story-analysis tools, no more/no less');
+    });
+
+    it('maps each tool to a callable handler function', () => {
+        assert.strictEqual(typeof server.getToolHandler('analyze_story_dynamics'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('track_character_throughlines'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('identify_story_appreciations'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('map_problem_solutions'), 'function');
+        assert.strictEqual(server.getToolHandler('not_a_real_tool'), null);
+    });
+
+    it('references (does not copy) the source schema -- inputSchema matches the handler-owned schema', () => {
+        for (const sourceTool of storyAnalysisToolsSchema) {
+            const wrapperTool = server.tools.find(t => t.name === sourceTool.name);
+            assert.ok(wrapperTool, `wrapper should expose ${sourceTool.name}`);
+            assert.deepStrictEqual(
+                wrapperTool.inputSchema,
+                sourceTool.inputSchema,
+                `${sourceTool.name} inputSchema should be spread from the handler's schema, not redeclared`
+            );
+        }
+    });
+
+    it('routes tool calls to the single shared StoryAnalysisHandlers instance (not a copy)', async () => {
+        assert.ok(server.storyAnalysisHandlers, 'wrapper should hold a storyAnalysisHandlers instance');
+
+        const sentinel = { content: [{ type: 'text', text: 'spy-called' }] };
+        const original = server.storyAnalysisHandlers.handleAnalyzeStoryDynamics;
+        let calledWith = null;
+        server.storyAnalysisHandlers.handleAnalyzeStoryDynamics = async (args) => {
+            calledWith = args;
+            return sentinel;
+        };
+
+        try {
+            const result = await server.getToolHandler('analyze_story_dynamics')({ book_id: 1 });
+            assert.deepStrictEqual(calledWith, { book_id: 1 }, 'wrapper should pass args through unchanged');
+            assert.strictEqual(result, sentinel, 'wrapper handler map should delegate to the shared handler instance');
+        } finally {
+            server.storyAnalysisHandlers.handleAnalyzeStoryDynamics = original;
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `src/config-mcps/story-analysis-server/index.js`, a thin phase-based wrapper matching the established pattern (modeled on `core-continuity-server`): imports only the `StoryAnalysisHandlers` class from `src/mcps/story-analysis-server/handlers/story-analysis-handlers.js` and exposes its tool schemas by reference (spread), with no schema duplication.
- Exposes the 4 story-analysis tools: `analyze_story_dynamics`, `track_character_throughlines`, `identify_story_appreciations`, `map_problem_solutions`.
- Registers the wrapper in `src/http-sse-server.js` on **port 3016** (next free port after kanban's 3015; port 3014 remains reserved per the existing comment in `src/mcps/kanban-server/index.js`).
- Adds `src/config-mcps/story-analysis-server/readme.md` documenting purpose and tool list, following the `core-continuity-server`/`character-planning-server` readme convention.
- Adds a `node:test` wrapper-visibility test (`tests/story-analysis-server/story-analysis-wrapper.test.js`) and a matching CI job in `.github/workflows/test.yml`, mirroring the `single-server-runner-tests` pattern (unreachable-but-valid `DATABASE_URL`; `pg.Pool` connects lazily so no postgres service container is needed).

This closes the gap left by the story-analysis tables forward migration merging: the wrapper now registers and lists its 4 tools without error under `MCP_STDIO_MODE`. Verified locally.

## Follow-up (not in this PR)
This adds a new port (3016) to `src/http-sse-server.js`. A companion change is needed in **MCP-Electron-App**'s docker-compose to add the matching host port mapping (`"3016:3016"`) alongside the existing `3001`-`3015` entries, so the Electron app's Docker stack can reach this server. That change is out of scope here and should be tracked/made in that repo.

## Test plan
- [x] `node -c src/config-mcps/story-analysis-server/index.js` and `node -c src/http-sse-server.js` — syntax OK
- [x] `MCP_STDIO_MODE=true node src/config-mcps/story-analysis-server/index.js` against a dummy `DATABASE_URL` — boots, registers 4 tools, no crash
- [x] `node --test tests/story-analysis-server/story-analysis-wrapper.test.js` — 4/4 passing (tool visibility, handler routing, schema-by-reference check, delegation-not-copy check)
- [x] Confirmed unrelated existing tests (`tests/plot-server`, `tests/workflow-manager-server`) still pass unaffected
- [x] New CI job added; will confirm green in Actions

Closes bead: mws-1783883496278-4-e2749385

🤖 Generated with [Claude Code](https://claude.com/claude-code)