### PR TITLE
story-analysis: add storyform read/CRUD tools (get/create/update_storyform)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Run story-analysis-server wrapper tests
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/writing_server_test
-        run: node --test tests/story-analysis-server/story-analysis-wrapper.test.js
+        run: node --test tests/story-analysis-server/story-analysis-wrapper.test.js tests/story-analysis-server/storyform-handlers.test.js
 
   lint:
     name: Lint Code

--- a/migrations/046_storyforms.sql
+++ b/migrations/046_storyforms.sql
@@ -1,0 +1,81 @@
+-- Migration: 046_storyforms
+-- Description: Canon-DB flip 01 (Dramatica storyform storage). Creates the
+-- `storyforms` table: one row per series-master storyform (book_id IS NULL)
+-- and one row per per-book storyform (book_id set). Spec:
+--   FictIonLab-Downloads/specs/2026-07-10-canon-db-migration/01-storyform-storage.md
+-- Scope is storyform-of-record level only (the ~12 core appreciations +
+-- throughline domains + rationale) -- explicitly NOT the 64-track storyweave
+-- encode / beat interleave, which stays scene-level (flip 07's outline
+-- tables).
+--
+-- `story_analysis` (migration 045) is NOT resurrected/touched here -- its
+-- shape is too thin for storyforms (see spec item 1's "decide-and-document"
+-- note). This is intentionally a separate table.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM migrations WHERE filename = '046_storyforms.sql') THEN
+        RAISE NOTICE 'Migration 046_storyforms.sql already applied, skipping.';
+        RETURN;
+    END IF;
+
+    CREATE TABLE IF NOT EXISTS storyforms (
+        id SERIAL PRIMARY KEY,
+        series_id INTEGER NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+        -- NULL book_id = the series-master storyform; a real book_id = that
+        -- book's own storyform-of-record (per the nested-storyform rule --
+        -- each book gets its own complete grand argument, constrained by
+        -- but not identical to the series master).
+        book_id INTEGER REFERENCES books(id) ON DELETE CASCADE,
+
+        -- Four-throughline casting (OS/MC/IC/RS Domains)
+        os_domain VARCHAR(100),
+        mc_domain VARCHAR(100),
+        ic_domain VARCHAR(100),
+        rs_domain VARCHAR(100),
+
+        -- Core dynamics
+        story_driver VARCHAR(50),
+        story_limit VARCHAR(50),
+        story_outcome_id INTEGER REFERENCES story_outcomes(id),
+        story_judgment_id INTEGER REFERENCES story_judgments(id),
+        story_concern_id INTEGER REFERENCES story_concerns(id),
+        mc_resolve VARCHAR(50),
+        mc_growth VARCHAR(50),
+        mc_approach VARCHAR(50),
+        mc_ps_style VARCHAR(50),
+
+        -- Per-scope "best fit" rationale (why this storyform fits canon)
+        rationale TEXT,
+
+        -- Everything beyond the core set (signpost arcs, issue/problem per
+        -- throughline, etc.) -- do NOT try to normalize all of Dramatica.
+        appreciations JSONB,
+
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- One series-master row per series (book_id IS NULL is not covered by a
+    -- plain UNIQUE(series_id, book_id) constraint, since Postgres treats
+    -- each NULL as distinct) ...
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_storyforms_series_master
+        ON storyforms(series_id) WHERE book_id IS NULL;
+
+    -- ... and one row per (series_id, book_id) for per-book storyforms.
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_storyforms_series_book
+        ON storyforms(series_id, book_id) WHERE book_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_storyforms_book_id ON storyforms(book_id);
+
+    DROP TRIGGER IF EXISTS update_storyforms_timestamp ON storyforms;
+    CREATE TRIGGER update_storyforms_timestamp
+        BEFORE UPDATE ON storyforms
+        FOR EACH ROW
+        EXECUTE FUNCTION update_timestamp();
+
+    INSERT INTO migrations (filename) VALUES ('046_storyforms.sql')
+    ON CONFLICT (filename) DO NOTHING;
+
+    RAISE NOTICE 'Migration 046_storyforms.sql completed successfully.';
+END $$;

--- a/src/config-mcps/book-planning-server/index.js
+++ b/src/config-mcps/book-planning-server/index.js
@@ -23,6 +23,7 @@ import { OrganizationHandlers } from '../../mcps/world-server/handlers/organizat
 import { PlotThreadHandlers } from '../../mcps/plot-server/handlers/plot-thread-handlers.js';
 import { LookupManagementHandlers } from '../../mcps/metadata-server/handlers/lookup-management-handlers.js';
 import { TropeHandlers } from '../../mcps/trope-server/handlers/trope-handlers.js';
+import { StoryformHandlers } from '../../mcps/story-analysis-server/handlers/storyform-handlers.js';
 
 // Import phase-specific schemas directly to reduce token usage
 import { bookPlanningSchemas } from '../../mcps/book-server/schemas/book-planning-schemas.js';
@@ -49,6 +50,7 @@ class BookPlanningMCPServer extends BaseMCPServer {
         this.plotThreadHandlers = new PlotThreadHandlers(this.db);
         this.lookupHandlers = new LookupManagementHandlers(this.db);
         this.tropeHandlers = new TropeHandlers(this.db);
+        this.storyformHandlers = new StoryformHandlers(this.db);
 
         console.error('[BOOK-PLANNING-SERVER] Phase-specific handlers initialized');
     }
@@ -157,6 +159,12 @@ class BookPlanningMCPServer extends BaseMCPServer {
             }
         });
 
+        // =============================================
+        // 7. STORYFORM TOOLS (Phase-specific) - per-book storyform read/CRUD (canon-DB flip 01)
+        // =============================================
+        this.storyformHandlers.getStoryformTools()
+            .forEach(tool => tools.push({ ...tool }));
+
         return tools;
     }
 
@@ -183,7 +191,12 @@ class BookPlanningMCPServer extends BaseMCPServer {
             // Trope instance handlers
             'create_trope_instance': (args) => this.tropeHandlers.handleCreateTropeInstance(args),
             'list_trope_instances': (args) => this.tropeHandlers.handleListTropeInstances(args),
-            'get_trope_instance': (args) => this.tropeHandlers.handleGetTropeInstance(args)
+            'get_trope_instance': (args) => this.tropeHandlers.handleGetTropeInstance(args),
+
+            // Storyform handlers (per-book storyform)
+            'create_storyform': (args) => this.storyformHandlers.handleCreateStoryform(args),
+            'update_storyform': (args) => this.storyformHandlers.handleUpdateStoryform(args),
+            'get_storyform': (args) => this.storyformHandlers.handleGetStoryform(args)
         };
 
         return handlerMap[toolName] || null;

--- a/src/config-mcps/series-planning-server/index.js
+++ b/src/config-mcps/series-planning-server/index.js
@@ -26,6 +26,7 @@ import { OrganizationHandlers } from '../../mcps/world-server/handlers/organizat
 import { WorldElementHandlers } from '../../mcps/world-server/handlers/world-element-handlers.js';
 import { GenreExtensions } from '../../mcps/plot-server/handlers/genre-extensions.js';
 import { TropeHandlers } from '../../mcps/trope-server/handlers/trope-handlers.js';
+import { StoryformHandlers } from '../../mcps/story-analysis-server/handlers/storyform-handlers.js';
 
 class SeriesPlanningMCPServer extends BaseMCPServer {
     constructor() {
@@ -55,6 +56,9 @@ class SeriesPlanningMCPServer extends BaseMCPServer {
 
         // Trope handlers
         this.tropeHandlers = new TropeHandlers(this.db);
+
+        // Storyform handlers (series-master storyform)
+        this.storyformHandlers = new StoryformHandlers(this.db);
 
         console.error('[SERIES-PLANNING-SERVER] Handlers initialized with shared DB');
     }
@@ -139,6 +143,10 @@ class SeriesPlanningMCPServer extends BaseMCPServer {
                 });
             });
 
+        // Storyform tools - series-master storyform read/CRUD (canon-DB flip 01)
+        this.storyformHandlers.getStoryformTools()
+            .forEach(tool => tools.push({ ...tool }));
+
         return tools;
     }
 
@@ -171,7 +179,12 @@ class SeriesPlanningMCPServer extends BaseMCPServer {
             'get_world_systems': this.genreExtensions.handleGetWorldSystems.bind(this.genreExtensions),
 
             // Trope handlers (create only; lookups in core-continuity)
-            'create_trope': this.tropeHandlers.handleCreateTrope.bind(this.tropeHandlers)
+            'create_trope': this.tropeHandlers.handleCreateTrope.bind(this.tropeHandlers),
+
+            // Storyform handlers (series-master storyform)
+            'create_storyform': this.storyformHandlers.handleCreateStoryform.bind(this.storyformHandlers),
+            'update_storyform': this.storyformHandlers.handleUpdateStoryform.bind(this.storyformHandlers),
+            'get_storyform': this.storyformHandlers.handleGetStoryform.bind(this.storyformHandlers)
         };
 
         return handlerMap[toolName] || null;

--- a/src/config-mcps/story-analysis-server/index.js
+++ b/src/config-mcps/story-analysis-server/index.js
@@ -15,6 +15,7 @@ import { BaseMCPServer } from '../../shared/base-server.js';
 
 // Import ONLY the handler class - NOT the full server
 import { StoryAnalysisHandlers } from '../../mcps/story-analysis-server/handlers/story-analysis-handlers.js';
+import { StoryformHandlers } from '../../mcps/story-analysis-server/handlers/storyform-handlers.js';
 
 class StoryAnalysisMCPServer extends BaseMCPServer {
     constructor() {
@@ -32,6 +33,7 @@ class StoryAnalysisMCPServer extends BaseMCPServer {
     initializeHandlers() {
         // Create handler instance passing our shared database
         this.storyAnalysisHandlers = new StoryAnalysisHandlers(this.db);
+        this.storyformHandlers = new StoryformHandlers(this.db);
 
         console.error('[STORY-ANALYSIS-SERVER] Handlers initialized with shared DB');
     }
@@ -78,6 +80,10 @@ class StoryAnalysisMCPServer extends BaseMCPServer {
             });
         }
 
+        // STORYFORM READ/CRUD TOOLS
+        const storyformTools = this.storyformHandlers.getStoryformTools();
+        storyformTools.forEach(tool => tools.push({ ...tool }));
+
         return tools;
     }
 
@@ -88,7 +94,12 @@ class StoryAnalysisMCPServer extends BaseMCPServer {
             'analyze_story_dynamics': (args) => this.storyAnalysisHandlers.handleAnalyzeStoryDynamics(args),
             'track_character_throughlines': (args) => this.storyAnalysisHandlers.handleTrackCharacterThroughlines(args),
             'identify_story_appreciations': (args) => this.storyAnalysisHandlers.handleIdentifyStoryAppreciations(args),
-            'map_problem_solutions': (args) => this.storyAnalysisHandlers.handleMapProblemSolutions(args)
+            'map_problem_solutions': (args) => this.storyAnalysisHandlers.handleMapProblemSolutions(args),
+
+            // Storyform handlers
+            'create_storyform': (args) => this.storyformHandlers.handleCreateStoryform(args),
+            'update_storyform': (args) => this.storyformHandlers.handleUpdateStoryform(args),
+            'get_storyform': (args) => this.storyformHandlers.handleGetStoryform(args)
         };
 
         return handlerMap[toolName] || null;

--- a/src/config-mcps/story-analysis-server/readme.md
+++ b/src/config-mcps/story-analysis-server/readme.md
@@ -11,16 +11,22 @@ level. It is the write path for this analysis layer — not for character
 structure itself (see `character-planning-server`) and not for continuity
 checks during drafting (see `core-continuity-server`).
 
-Composed from the single handler in `src/mcps/story-analysis-server` — see
+Composed from two handlers in `src/mcps/story-analysis-server` — see
 [`index.js`](index.js) for the exact aggregation. One shared DB connection.
 
-The four write tools INSERT/UPDATE the `story_analysis`,
+The four analysis tools INSERT/UPDATE the `story_analysis`,
 `character_throughlines`, `story_appreciations`, and `problem_solutions`
 tables. Two of the four handlers (`track_character_throughlines`,
 `identify_story_appreciations`) fall back to appending a note into
 `story_analysis.analysis_notes` if their dedicated table isn't present in the
 target database — see `src/mcps/story-analysis-server/handlers/story-analysis-handlers.js`
 for that fallback logic.
+
+The three storyform tools are the read/CRUD layer over the `storyforms`
+table (migration 046) — one row per series-master storyform (`book_id` NULL)
+or per-book storyform. See
+`src/mcps/story-analysis-server/handlers/storyform-handlers.js`. Canon-DB
+flip 01: `FictIonLab-Downloads/specs/2026-07-10-canon-db-migration/01-storyform-storage.md`.
 
 ## Tools
 
@@ -30,6 +36,9 @@ Verified against `getToolHandler()` in `index.js`:
 - `track_character_throughlines` — create/update a character's throughline for a book
 - `identify_story_appreciations` — record a story appreciation with supporting evidence
 - `map_problem_solutions` — map a problem to its attempted solution and effectiveness
+- `create_storyform` — create the storyform-of-record for a series or a specific book
+- `update_storyform` — update an existing storyform-of-record
+- `get_storyform` — read the storyform-of-record for a series or a specific book
 
 ## Running it
 

--- a/src/mcps/story-analysis-server/handlers/storyform-handlers.js
+++ b/src/mcps/story-analysis-server/handlers/storyform-handlers.js
@@ -1,0 +1,256 @@
+// src/mcps/story-analysis-server/handlers/storyform-handlers.js
+// Read/CRUD handlers for the `storyforms` table (migration 046).
+// Canon-DB flip 01 -- see
+// FictIonLab-Downloads/specs/2026-07-10-canon-db-migration/01-storyform-storage.md
+//
+// One row per scope: series-master (book_id NULL) or per-book (book_id set).
+// create_storyform / update_storyform are a CRUD pair (matching the rest of
+// this codebase's create_*/update_* convention -- see book-handlers.js):
+// create_storyform fails if a row already exists at that scope, and
+// update_storyform fails if one does not.
+
+import { storyformToolsSchema } from '../schemas/storyform-tools-schema.js';
+
+function scopeLabel(bookId) {
+    return bookId === null || bookId === undefined ? 'series master' : `book ${bookId}`;
+}
+
+export class StoryformHandlers {
+    constructor(db) {
+        this.db = db;
+    }
+
+    getStoryformTools() {
+        return storyformToolsSchema;
+    }
+
+    async validateScope(args) {
+        const errors = [];
+
+        if (!args.series_id || typeof args.series_id !== 'number' || args.series_id < 1) {
+            errors.push('series_id must be a positive number');
+        }
+
+        if (args.book_id !== undefined && args.book_id !== null) {
+            if (typeof args.book_id !== 'number' || args.book_id < 1) {
+                errors.push('book_id must be a positive number when provided');
+            }
+        }
+
+        return errors;
+    }
+
+    async resolveScope(args) {
+        const errors = await this.validateScope(args);
+        if (errors.length > 0) {
+            throw new Error(`Validation failed: ${errors.join(', ')}`);
+        }
+
+        const seriesCheck = await this.db.query('SELECT id, title FROM series WHERE id = $1', [args.series_id]);
+        if (seriesCheck.rows.length === 0) {
+            throw new Error(`Series with ID ${args.series_id} not found`);
+        }
+
+        const bookId = args.book_id ?? null;
+
+        if (bookId !== null) {
+            const bookCheck = await this.db.query('SELECT id, series_id, title FROM books WHERE id = $1', [bookId]);
+            if (bookCheck.rows.length === 0) {
+                throw new Error(`Book with ID ${bookId} not found`);
+            }
+            if (bookCheck.rows[0].series_id !== args.series_id) {
+                throw new Error(`Book ${bookId} does not belong to series ${args.series_id}`);
+            }
+        }
+
+        return { seriesTitle: seriesCheck.rows[0].title, bookId };
+    }
+
+    formatStoryform(row, seriesTitle) {
+        let output = `# Storyform: ${seriesTitle} (${scopeLabel(row.book_id)})\n\n`;
+        output += `**Storyform ID:** ${row.id}\n`;
+        output += `**Series ID:** ${row.series_id}\n`;
+        output += `**Book ID:** ${row.book_id ?? 'none (series master)'}\n\n`;
+
+        output += `## Four-Throughline Casting\n`;
+        output += `- **OS Domain:** ${row.os_domain || 'not set'}\n`;
+        output += `- **MC Domain:** ${row.mc_domain || 'not set'}\n`;
+        output += `- **IC Domain:** ${row.ic_domain || 'not set'}\n`;
+        output += `- **RS Domain:** ${row.rs_domain || 'not set'}\n\n`;
+
+        output += `## Core Dynamics\n`;
+        output += `- **Story Driver:** ${row.story_driver || 'not set'}\n`;
+        output += `- **Story Limit:** ${row.story_limit || 'not set'}\n`;
+        output += `- **Story Outcome:** ${row.outcome_name || row.story_outcome_id || 'not set'}\n`;
+        output += `- **Story Judgment:** ${row.judgment_name || row.story_judgment_id || 'not set'}\n`;
+        output += `- **Story Concern:** ${row.concern_name || row.story_concern_id || 'not set'}\n`;
+        output += `- **MC Resolve:** ${row.mc_resolve || 'not set'}\n`;
+        output += `- **MC Growth:** ${row.mc_growth || 'not set'}\n`;
+        output += `- **MC Approach:** ${row.mc_approach || 'not set'}\n`;
+        output += `- **MC Problem-Solving Style:** ${row.mc_ps_style || 'not set'}\n\n`;
+
+        if (row.rationale) {
+            output += `## Rationale\n${row.rationale}\n\n`;
+        }
+
+        if (row.appreciations) {
+            const appreciations = typeof row.appreciations === 'string'
+                ? JSON.parse(row.appreciations)
+                : row.appreciations;
+            output += `## Appreciations\n\`\`\`json\n${JSON.stringify(appreciations, null, 2)}\n\`\`\`\n`;
+        }
+
+        return output;
+    }
+
+    async handleCreateStoryform(args) {
+        try {
+            const { seriesTitle, bookId } = await this.resolveScope(args);
+
+            const existing = bookId === null
+                ? await this.db.query('SELECT id FROM storyforms WHERE series_id = $1 AND book_id IS NULL', [args.series_id])
+                : await this.db.query('SELECT id FROM storyforms WHERE series_id = $1 AND book_id = $2', [args.series_id, bookId]);
+
+            if (existing.rows.length > 0) {
+                throw new Error(`Storyform already exists for series ${args.series_id} (${scopeLabel(bookId)}) -- use update_storyform`);
+            }
+
+            const insertQuery = `
+                INSERT INTO storyforms (
+                    series_id, book_id, os_domain, mc_domain, ic_domain, rs_domain,
+                    story_driver, story_limit, story_outcome_id, story_judgment_id, story_concern_id,
+                    mc_resolve, mc_growth, mc_approach, mc_ps_style, rationale, appreciations
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+                RETURNING *
+            `;
+
+            const result = await this.db.query(insertQuery, [
+                args.series_id,
+                bookId,
+                args.os_domain || null,
+                args.mc_domain || null,
+                args.ic_domain || null,
+                args.rs_domain || null,
+                args.story_driver || null,
+                args.story_limit || null,
+                args.story_outcome_id || null,
+                args.story_judgment_id || null,
+                args.story_concern_id || null,
+                args.mc_resolve || null,
+                args.mc_growth || null,
+                args.mc_approach || null,
+                args.mc_ps_style || null,
+                args.rationale || null,
+                args.appreciations ? JSON.stringify(args.appreciations) : null
+            ]);
+
+            return {
+                content: [{
+                    type: 'text',
+                    text: `Storyform created!\n\n${this.formatStoryform(result.rows[0], seriesTitle)}`
+                }]
+            };
+        } catch (error) {
+            throw new Error(`Failed to create storyform: ${error.message}`);
+        }
+    }
+
+    async handleUpdateStoryform(args) {
+        try {
+            const { seriesTitle, bookId } = await this.resolveScope(args);
+
+            const existing = bookId === null
+                ? await this.db.query('SELECT id FROM storyforms WHERE series_id = $1 AND book_id IS NULL', [args.series_id])
+                : await this.db.query('SELECT id FROM storyforms WHERE series_id = $1 AND book_id = $2', [args.series_id, bookId]);
+
+            if (existing.rows.length === 0) {
+                throw new Error(`No storyform exists for series ${args.series_id} (${scopeLabel(bookId)}) -- use create_storyform`);
+            }
+
+            const updateQuery = `
+                UPDATE storyforms
+                SET os_domain = COALESCE($1, os_domain),
+                    mc_domain = COALESCE($2, mc_domain),
+                    ic_domain = COALESCE($3, ic_domain),
+                    rs_domain = COALESCE($4, rs_domain),
+                    story_driver = COALESCE($5, story_driver),
+                    story_limit = COALESCE($6, story_limit),
+                    story_outcome_id = COALESCE($7, story_outcome_id),
+                    story_judgment_id = COALESCE($8, story_judgment_id),
+                    story_concern_id = COALESCE($9, story_concern_id),
+                    mc_resolve = COALESCE($10, mc_resolve),
+                    mc_growth = COALESCE($11, mc_growth),
+                    mc_approach = COALESCE($12, mc_approach),
+                    mc_ps_style = COALESCE($13, mc_ps_style),
+                    rationale = COALESCE($14, rationale),
+                    appreciations = COALESCE($15, appreciations),
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = $16
+                RETURNING *
+            `;
+
+            const result = await this.db.query(updateQuery, [
+                args.os_domain || null,
+                args.mc_domain || null,
+                args.ic_domain || null,
+                args.rs_domain || null,
+                args.story_driver || null,
+                args.story_limit || null,
+                args.story_outcome_id || null,
+                args.story_judgment_id || null,
+                args.story_concern_id || null,
+                args.mc_resolve || null,
+                args.mc_growth || null,
+                args.mc_approach || null,
+                args.mc_ps_style || null,
+                args.rationale || null,
+                args.appreciations ? JSON.stringify(args.appreciations) : null,
+                existing.rows[0].id
+            ]);
+
+            return {
+                content: [{
+                    type: 'text',
+                    text: `Storyform updated!\n\n${this.formatStoryform(result.rows[0], seriesTitle)}`
+                }]
+            };
+        } catch (error) {
+            throw new Error(`Failed to update storyform: ${error.message}`);
+        }
+    }
+
+    async handleGetStoryform(args) {
+        try {
+            const { seriesTitle, bookId } = await this.resolveScope(args);
+
+            const query = `
+                SELECT sf.*, so.outcome_name, sj.judgment_name, sc.concern_name
+                FROM storyforms sf
+                LEFT JOIN story_outcomes so ON sf.story_outcome_id = so.id
+                LEFT JOIN story_judgments sj ON sf.story_judgment_id = sj.id
+                LEFT JOIN story_concerns sc ON sf.story_concern_id = sc.id
+                WHERE sf.series_id = $1 AND ${bookId === null ? 'sf.book_id IS NULL' : 'sf.book_id = $2'}
+            `;
+            const params = bookId === null ? [args.series_id] : [args.series_id, bookId];
+            const result = await this.db.query(query, params);
+
+            if (result.rows.length === 0) {
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `No storyform found for series ${args.series_id} (${scopeLabel(bookId)})`
+                    }]
+                };
+            }
+
+            return {
+                content: [{
+                    type: 'text',
+                    text: this.formatStoryform(result.rows[0], seriesTitle)
+                }]
+            };
+        } catch (error) {
+            throw new Error(`Failed to get storyform: ${error.message}`);
+        }
+    }
+}

--- a/src/mcps/story-analysis-server/index.js
+++ b/src/mcps/story-analysis-server/index.js
@@ -13,10 +13,12 @@ if (process.env.MCP_STDIO_MODE === 'true') {
 
 import { BaseMCPServer } from '../../shared/base-server.js';
 import { StoryAnalysisHandlers } from './handlers/story-analysis-handlers.js';
+import { StoryformHandlers } from './handlers/storyform-handlers.js';
 import {
     lookupSystemToolsSchema,
     storyAnalysisToolsSchema
 } from './schemas/story-analysis-tools-schema.js';
+import { storyformToolsSchema } from './schemas/storyform-tools-schema.js';
 
 class StoryAnalysisMCPServer extends BaseMCPServer {
     constructor() {
@@ -32,6 +34,7 @@ class StoryAnalysisMCPServer extends BaseMCPServer {
         // Initialize handler module
         try {
             this.storyAnalysisHandlers = new StoryAnalysisHandlers(this.db);
+            this.storyformHandlers = new StoryformHandlers(this.db);
             console.error('[STORY-ANALYSIS-SERVER] Story analysis handlers initialized');
         } catch (error) {
             console.error('[STORY-ANALYSIS-SERVER] Handler initialization failed:', error.message);
@@ -63,6 +66,11 @@ class StoryAnalysisMCPServer extends BaseMCPServer {
             this.handleTrackCharacterThroughlines = this.storyAnalysisHandlers.handleTrackCharacterThroughlines.bind(this.storyAnalysisHandlers);
             this.handleIdentifyStoryAppreciations = this.storyAnalysisHandlers.handleIdentifyStoryAppreciations.bind(this.storyAnalysisHandlers);
             this.handleMapProblemSolutions = this.storyAnalysisHandlers.handleMapProblemSolutions.bind(this.storyAnalysisHandlers);
+
+            // Bind storyform handler methods
+            this.handleCreateStoryform = this.storyformHandlers.handleCreateStoryform.bind(this.storyformHandlers);
+            this.handleUpdateStoryform = this.storyformHandlers.handleUpdateStoryform.bind(this.storyformHandlers);
+            this.handleGetStoryform = this.storyformHandlers.handleGetStoryform.bind(this.storyformHandlers);
 
             console.error('[STORY-ANALYSIS-SERVER] All handler methods bound successfully');
         } catch (error) {
@@ -98,7 +106,10 @@ class StoryAnalysisMCPServer extends BaseMCPServer {
                 ...lookupSystemToolsSchema,
 
                 // Story analysis tools
-                ...storyAnalysisToolsSchema
+                ...storyAnalysisToolsSchema,
+
+                // Storyform read/CRUD tools
+                ...storyformToolsSchema
             ];
 
             console.error(`[STORY-ANALYSIS-SERVER] Tools registered: ${tools.length} total`);
@@ -115,7 +126,12 @@ class StoryAnalysisMCPServer extends BaseMCPServer {
             'analyze_story_dynamics': this.handleAnalyzeStoryDynamics,
             'track_character_throughlines': this.handleTrackCharacterThroughlines,
             'identify_story_appreciations': this.handleIdentifyStoryAppreciations,
-            'map_problem_solutions': this.handleMapProblemSolutions
+            'map_problem_solutions': this.handleMapProblemSolutions,
+
+            // Storyform Handlers
+            'create_storyform': this.handleCreateStoryform,
+            'update_storyform': this.handleUpdateStoryform,
+            'get_storyform': this.handleGetStoryform
         };
 
         const handler = handlers[toolName];

--- a/src/mcps/story-analysis-server/schemas/storyform-tools-schema.js
+++ b/src/mcps/story-analysis-server/schemas/storyform-tools-schema.js
@@ -1,0 +1,72 @@
+// src/mcps/story-analysis-server/schemas/storyform-tools-schema.js
+// Tool schemas for the Dramatica storyform read/CRUD layer over the
+// `storyforms` table (migration 046). Canon-DB flip 01 -- see
+// FictIonLab-Downloads/specs/2026-07-10-canon-db-migration/01-storyform-storage.md
+
+const storyformCoreProperties = {
+    series_id: { type: 'integer', description: 'Series ID' },
+    book_id: {
+        type: 'integer',
+        description: 'Book ID. Omit for the series-master storyform (the whole-series grand argument); set for a specific book\'s own storyform.'
+    },
+    os_domain: { type: 'string', description: 'Overall Story throughline Domain' },
+    mc_domain: { type: 'string', description: 'Main Character throughline Domain' },
+    ic_domain: { type: 'string', description: 'Influence Character throughline Domain' },
+    rs_domain: { type: 'string', description: 'Relationship Story throughline Domain' },
+    story_driver: { type: 'string', description: 'Story Driver (Action or Decision)' },
+    story_limit: { type: 'string', description: 'Story Limit (Optionlock or Timelock)' },
+    story_outcome_id: {
+        type: 'integer',
+        description: 'FK to story_outcomes (use metadata-server get_available_options w/ option_type="story_outcomes")'
+    },
+    story_judgment_id: {
+        type: 'integer',
+        description: 'FK to story_judgments (use metadata-server get_available_options w/ option_type="story_judgments")'
+    },
+    story_concern_id: {
+        type: 'integer',
+        description: 'FK to story_concerns (use metadata-server get_available_options w/ option_type="story_concerns")'
+    },
+    mc_resolve: { type: 'string', description: 'Main Character Resolve (Change or Steadfast)' },
+    mc_growth: { type: 'string', description: 'Main Character Growth (Start or Stop)' },
+    mc_approach: { type: 'string', description: 'Main Character Approach (Do-er or Be-er)' },
+    mc_ps_style: { type: 'string', description: 'Main Character Problem-Solving Style (Linear or Holistic)' },
+    rationale: { type: 'string', description: 'Best-fit rationale: why this storyform fits the canon at this scope' },
+    appreciations: {
+        type: 'object',
+        description: 'Everything beyond the core dynamics/casting: signpost arcs, issue/problem per throughline, etc.'
+    }
+};
+
+export const storyformToolsSchema = [
+    {
+        name: 'create_storyform',
+        description: 'Create the storyform-of-record for a series (book_id omitted = series master) or a specific book (book_id set). Fails if a storyform already exists at that scope -- use update_storyform to modify it.',
+        inputSchema: {
+            type: 'object',
+            properties: storyformCoreProperties,
+            required: ['series_id']
+        }
+    },
+    {
+        name: 'update_storyform',
+        description: 'Update the storyform-of-record for a series (book_id omitted = series master) or a specific book (book_id set). Fails if no storyform exists yet at that scope -- use create_storyform first. Only the fields provided are changed.',
+        inputSchema: {
+            type: 'object',
+            properties: storyformCoreProperties,
+            required: ['series_id']
+        }
+    },
+    {
+        name: 'get_storyform',
+        description: 'Read the storyform-of-record for a series (book_id omitted = series master) or a specific book (book_id set).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                series_id: { type: 'integer', description: 'Series ID' },
+                book_id: { type: 'integer', description: 'Book ID. Omit to fetch the series-master storyform.' }
+            },
+            required: ['series_id']
+        }
+    }
+];

--- a/tests/story-analysis-server/story-analysis-wrapper.test.js
+++ b/tests/story-analysis-server/story-analysis-wrapper.test.js
@@ -10,6 +10,10 @@
 // wrapper registers/exposes the four analysis tools through its
 // buildTools()/getToolHandler(), without re-declaring the tool schemas.
 //
+// bead mws-rev added the storyform read/CRUD layer (create_storyform,
+// update_storyform, get_storyform -- StoryformHandlers, migration 046) to
+// this same wrapper, so the tool count grew from 4 to 7.
+//
 // No live DB writes are exercised here (the prerequisite migration for
 // story_analysis / character_throughlines / story_appreciations /
 // problem_solutions merged in PR #84, but this test only checks wrapper
@@ -20,6 +24,7 @@ import { describe, it, after } from 'node:test';
 import assert from 'node:assert';
 import { StoryAnalysisMCPServer } from '../../src/config-mcps/story-analysis-server/index.js';
 import { storyAnalysisToolsSchema } from '../../src/mcps/story-analysis-server/schemas/story-analysis-tools-schema.js';
+import { storyformToolsSchema } from '../../src/mcps/story-analysis-server/schemas/storyform-tools-schema.js';
 
 describe('story-analysis-server wrapper tool visibility (mws-4)', () => {
     let server;
@@ -30,7 +35,7 @@ describe('story-analysis-server wrapper tool visibility (mws-4)', () => {
         }
     });
 
-    it('exposes the four story-analysis tools', () => {
+    it('exposes the four story-analysis tools plus the three storyform tools', () => {
         server = new StoryAnalysisMCPServer();
         const toolNames = server.tools.map(t => t.name);
 
@@ -38,7 +43,10 @@ describe('story-analysis-server wrapper tool visibility (mws-4)', () => {
         assert.ok(toolNames.includes('track_character_throughlines'));
         assert.ok(toolNames.includes('identify_story_appreciations'));
         assert.ok(toolNames.includes('map_problem_solutions'));
-        assert.strictEqual(server.tools.length, 4, 'wrapper should expose exactly the 4 story-analysis tools, no more/no less');
+        assert.ok(toolNames.includes('create_storyform'));
+        assert.ok(toolNames.includes('update_storyform'));
+        assert.ok(toolNames.includes('get_storyform'));
+        assert.strictEqual(server.tools.length, 7, 'wrapper should expose exactly the 4 story-analysis + 3 storyform tools, no more/no less');
     });
 
     it('maps each tool to a callable handler function', () => {
@@ -46,11 +54,14 @@ describe('story-analysis-server wrapper tool visibility (mws-4)', () => {
         assert.strictEqual(typeof server.getToolHandler('track_character_throughlines'), 'function');
         assert.strictEqual(typeof server.getToolHandler('identify_story_appreciations'), 'function');
         assert.strictEqual(typeof server.getToolHandler('map_problem_solutions'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('create_storyform'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('update_storyform'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('get_storyform'), 'function');
         assert.strictEqual(server.getToolHandler('not_a_real_tool'), null);
     });
 
     it('references (does not copy) the source schema -- inputSchema matches the handler-owned schema', () => {
-        for (const sourceTool of storyAnalysisToolsSchema) {
+        for (const sourceTool of [...storyAnalysisToolsSchema, ...storyformToolsSchema]) {
             const wrapperTool = server.tools.find(t => t.name === sourceTool.name);
             assert.ok(wrapperTool, `wrapper should expose ${sourceTool.name}`);
             assert.deepStrictEqual(

--- a/tests/story-analysis-server/storyform-handlers.test.js
+++ b/tests/story-analysis-server/storyform-handlers.test.js
@@ -1,0 +1,215 @@
+// tests/story-analysis-server/storyform-handlers.test.js
+// Tests for StoryformHandlers (bead mws-rev): create_storyform / update_storyform /
+// get_storyform over the `storyforms` table (migration 046). Canon-DB flip 01 --
+// FictIonLab-Downloads/specs/2026-07-10-canon-db-migration/01-storyform-storage.md
+//
+// Exercises the handler against a mocked db (no live database required),
+// matching the pattern used in tests/plot-server/plot-thread-handlers.test.js.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { StoryformHandlers } from '../../src/mcps/story-analysis-server/handlers/storyform-handlers.js';
+
+class MockDatabase {
+    constructor() {
+        this.queryResults = new Map();
+        this.queries = [];
+    }
+
+    setQueryResult(queryPattern, rows) {
+        this.queryResults.set(queryPattern, { rows });
+    }
+
+    async query(text, params = []) {
+        this.queries.push({ text, params });
+        for (const [pattern, result] of this.queryResults.entries()) {
+            if (text.includes(pattern)) {
+                return typeof result === 'function' ? result(params) : result;
+            }
+        }
+        return { rows: [] };
+    }
+}
+
+function seededDb({ seriesExists = true, bookExists = true, bookSeriesId = 1, existingStoryform = false } = {}) {
+    const mockDb = new MockDatabase();
+    mockDb.setQueryResult('FROM series WHERE id = $1', seriesExists ? [{ id: 1, title: 'Wuthering Dragons' }] : []);
+    mockDb.setQueryResult('FROM books WHERE id = $1', bookExists ? [{ id: 5, series_id: bookSeriesId, title: 'Book One' }] : []);
+    mockDb.setQueryResult('WHERE series_id = $1 AND book_id IS NULL', existingStoryform ? [{ id: 10 }] : []);
+    mockDb.setQueryResult('WHERE series_id = $1 AND book_id = $2', existingStoryform ? [{ id: 11 }] : []);
+    return mockDb;
+}
+
+describe('StoryformHandlers.handleCreateStoryform', () => {
+    it('creates the series-master storyform (book_id omitted)', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('INSERT INTO storyforms', [{
+            id: 10, series_id: 1, book_id: null,
+            os_domain: 'Universe', mc_domain: 'Psychology', ic_domain: 'Physics', rs_domain: 'Mind',
+            story_driver: 'Action', story_limit: 'Optionlock',
+            story_outcome_id: null, story_judgment_id: null, story_concern_id: null,
+            mc_resolve: 'Change', mc_growth: 'Start', mc_approach: 'Do-er', mc_ps_style: 'Linear',
+            rationale: 'Series-level rationale', appreciations: null
+        }]);
+
+        const handlers = new StoryformHandlers(mockDb);
+        const result = await handlers.handleCreateStoryform({
+            series_id: 1,
+            os_domain: 'Universe',
+            mc_domain: 'Psychology',
+            ic_domain: 'Physics',
+            rs_domain: 'Mind',
+            story_driver: 'Action',
+            story_limit: 'Optionlock',
+            mc_resolve: 'Change',
+            mc_growth: 'Start',
+            mc_approach: 'Do-er',
+            mc_ps_style: 'Linear',
+            rationale: 'Series-level rationale'
+        });
+
+        assert.ok(result.content[0].text.includes('Storyform created!'));
+        assert.ok(result.content[0].text.includes('series master'));
+        assert.ok(result.content[0].text.includes('Wuthering Dragons'));
+
+        const insertCall = mockDb.queries.find(q => q.text.includes('INSERT INTO storyforms'));
+        assert.ok(insertCall, 'issued an INSERT into storyforms');
+        assert.strictEqual(insertCall.params[0], 1, 'series_id bound correctly');
+        assert.strictEqual(insertCall.params[1], null, 'book_id is NULL for the series master');
+    });
+
+    it('creates a per-book storyform (book_id set, belongs to series)', async () => {
+        const mockDb = seededDb({ bookSeriesId: 1 });
+        mockDb.setQueryResult('INSERT INTO storyforms', [{
+            id: 20, series_id: 1, book_id: 5,
+            os_domain: null, mc_domain: null, ic_domain: null, rs_domain: null,
+            story_driver: null, story_limit: null,
+            story_outcome_id: null, story_judgment_id: null, story_concern_id: null,
+            mc_resolve: null, mc_growth: null, mc_approach: null, mc_ps_style: null,
+            rationale: null, appreciations: null
+        }]);
+
+        const handlers = new StoryformHandlers(mockDb);
+        const result = await handlers.handleCreateStoryform({ series_id: 1, book_id: 5 });
+
+        assert.ok(result.content[0].text.includes('book 5'));
+        const insertCall = mockDb.queries.find(q => q.text.includes('INSERT INTO storyforms'));
+        assert.strictEqual(insertCall.params[1], 5, 'book_id bound correctly');
+    });
+
+    it('rejects when a storyform already exists at that scope', async () => {
+        const mockDb = seededDb({ existingStoryform: true });
+        const handlers = new StoryformHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateStoryform({ series_id: 1 }),
+            /already exists.*use update_storyform/
+        );
+    });
+
+    it('rejects when the series does not exist', async () => {
+        const mockDb = seededDb({ seriesExists: false });
+        const handlers = new StoryformHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateStoryform({ series_id: 999 }),
+            /Series with ID 999 not found/
+        );
+    });
+
+    it('rejects when the book does not exist', async () => {
+        const mockDb = seededDb({ bookExists: false });
+        const handlers = new StoryformHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateStoryform({ series_id: 1, book_id: 999 }),
+            /Book with ID 999 not found/
+        );
+    });
+
+    it('rejects when the book belongs to a different series', async () => {
+        const mockDb = seededDb({ bookSeriesId: 2 });
+        const handlers = new StoryformHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateStoryform({ series_id: 1, book_id: 5 }),
+            /Book 5 does not belong to series 1/
+        );
+    });
+
+    it('rejects a non-numeric series_id', async () => {
+        const mockDb = seededDb();
+        const handlers = new StoryformHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateStoryform({ series_id: 'nope' }),
+            /series_id must be a positive number/
+        );
+    });
+});
+
+describe('StoryformHandlers.handleUpdateStoryform', () => {
+    it('rejects when no storyform exists yet at that scope', async () => {
+        const mockDb = seededDb({ existingStoryform: false });
+        const handlers = new StoryformHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleUpdateStoryform({ series_id: 1, rationale: 'new take' }),
+            /No storyform exists.*use create_storyform/
+        );
+    });
+
+    it('updates an existing storyform', async () => {
+        const mockDb = seededDb({ existingStoryform: true });
+        mockDb.setQueryResult('UPDATE storyforms', [{
+            id: 10, series_id: 1, book_id: null,
+            os_domain: 'Universe', mc_domain: null, ic_domain: null, rs_domain: null,
+            story_driver: null, story_limit: null,
+            story_outcome_id: null, story_judgment_id: null, story_concern_id: null,
+            mc_resolve: null, mc_growth: null, mc_approach: null, mc_ps_style: null,
+            rationale: 'updated rationale', appreciations: null
+        }]);
+
+        const handlers = new StoryformHandlers(mockDb);
+        const result = await handlers.handleUpdateStoryform({ series_id: 1, rationale: 'updated rationale' });
+
+        assert.ok(result.content[0].text.includes('Storyform updated!'));
+        const updateCall = mockDb.queries.find(q => q.text.includes('UPDATE storyforms'));
+        assert.ok(updateCall, 'issued an UPDATE against storyforms');
+        assert.strictEqual(updateCall.params[updateCall.params.length - 1], 10, 'updates the row found for this scope');
+    });
+});
+
+describe('StoryformHandlers.handleGetStoryform', () => {
+    it('returns a not-found message when no storyform exists', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM storyforms sf', []);
+        const handlers = new StoryformHandlers(mockDb);
+
+        const result = await handlers.handleGetStoryform({ series_id: 1 });
+        assert.ok(result.content[0].text.includes('No storyform found for series 1'));
+    });
+
+    it('round-trips a storyform with resolved lookup names', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM storyforms sf', [{
+            id: 10, series_id: 1, book_id: null,
+            os_domain: 'Universe', mc_domain: 'Psychology', ic_domain: 'Physics', rs_domain: 'Mind',
+            story_driver: 'Action', story_limit: 'Optionlock',
+            story_outcome_id: 1, story_judgment_id: 1, story_concern_id: 1,
+            mc_resolve: 'Change', mc_growth: 'Start', mc_approach: 'Do-er', mc_ps_style: 'Linear',
+            rationale: 'Series-level rationale', appreciations: { signpost_1: 'setup' },
+            outcome_name: 'success', judgment_name: 'good', concern_name: 'becoming'
+        }]);
+
+        const handlers = new StoryformHandlers(mockDb);
+        const result = await handlers.handleGetStoryform({ series_id: 1 });
+
+        const text = result.content[0].text;
+        assert.ok(text.includes('Wuthering Dragons'));
+        assert.ok(text.includes('Story Outcome:** success'));
+        assert.ok(text.includes('Story Judgment:** good'));
+        assert.ok(text.includes('Story Concern:** becoming'));
+        assert.ok(text.includes('signpost_1'));
+    });
+});


### PR DESCRIPTION
## Summary

Canon-DB flip 01 remainder. Migration 045 (`story_analysis` tables) and the
phase-based wrapper shipped in earlier PRs, but the storyform-of-record
layer itself was never built: the server exposed only the 4 analysis write
tools, and the Dramatica Stage 1 read-back
(`dramatica-storyform/workflow.yaml:142-143`, in the FictIonLab-Downloads
repo) has always called a `get_storyform` tool that didn't exist anywhere.

- **Migration 046** (`migrations/046_storyforms.sql`): new `storyforms`
  table -- one row per series-master storyform (`book_id` NULL) or per-book
  storyform (`book_id` set), per the nested-storyform rule (each book gets
  its own complete grand argument, constrained by but not identical to the
  series master). Partial unique indexes enforce one series-master row and
  one row per `(series_id, book_id)`. `story_analysis` (migration 045) is
  intentionally left untouched -- its shape is too thin for storyforms.
- **`StoryformHandlers`** (`src/mcps/story-analysis-server/handlers/storyform-handlers.js`):
  `create_storyform` / `update_storyform` (standard create-fails-if-exists /
  update-fails-if-missing CRUD pair, matching this codebase's existing
  `create_book`/`update_book` convention) and `get_storyform`, all scoped by
  `series_id` + optional `book_id`. Validates the series exists and, when a
  `book_id` is given, that the book exists and actually belongs to that
  series.
- Wired into the `story-analysis-server` config-mcp (port 3016, now 7 tools)
  and, per the flip-01 spec's explicit registration step, into
  `series-planning-server` (3002, series-master scope) and
  `book-planning-server` (3001, per-book scope).

Out of scope (belongs to a different repo / different bead): the Dramatica
workflow YAML edits (flip 01 item 3) live in FictIonLab-Downloads, tracked
separately per Casey's shared-knowledge index (bead `flw-4m8`).

## Test plan

- [x] `node --test tests/story-analysis-server/story-analysis-wrapper.test.js tests/story-analysis-server/storyform-handlers.test.js` -- 15/15 passing (mocked DB, matches the updated CI job)
- [x] Migration applied cleanly to a fresh `postgres:16` container (init.sql + migration 046) and is idempotent on re-run
- [x] Full `create_storyform` → duplicate-reject → `update_storyform` → `get_storyform` round trip exercised against that real Postgres instance for both series-master and per-book scope, including FK-name resolution (outcome/judgment/concern) and the "book belongs to a different series" rejection
- [x] `series-planning-server` and `book-planning-server` wrappers load and route the 3 new tools correctly (spot-checked via a one-off script)

Closes bead: mws-rev