### PR TITLE
outline-server: validate outline_works cross-link ids + add get_works_for_book

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,29 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/writing_server_test
         run: node --test tests/story-analysis-server/story-analysis-wrapper.test.js
 
+  outline-server-tests:
+    name: Outline Server Tests
+    runs-on: ubuntu-latest
+    # bead mws-e14: outline_works cross-link FK validation (create_work +
+    # update_work) and get_works_for_book. DB is fully mocked (see
+    # tests/outline-server/), so no postgres service is needed here.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run outline-server tests
+        run: node --test tests/outline-server/works-handlers.test.js
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest

--- a/docs/outline-vs-plot.md
+++ b/docs/outline-vs-plot.md
@@ -39,21 +39,21 @@ analysis](#corrections-to-the-original-analysis-gh-74).
 | Altitude | Bottom-up: per-scene/chapter structure + drafting context | Top-down: multi-book arcs and reveals |
 | Spine table | `outline_works` (self-referential tree: `parent_id`) | `plot_threads` (flat, keyed to `series_id`, spans `start_book`/`end_book`) |
 | Primary ID | `outline_works.id` (own SERIAL sequence, own tree) | `plot_threads.id`, `information_reveals.id`, `reveal_evidence.id`, `world_systems.id`, `character_system_progression.id` (each its own SERIAL sequence) |
-| Tool count | 22 (verified: 9 works + 4 facts + 3 promises + 3 evidence + 2 scene-events + 1 brief) | 8 (verified: 4 plot-thread + 4 genre-extension; a 5th plot-thread tool exists in code but is commented out — see [Dead code](#known-dead-code)) |
+| Tool count | 23 (verified: 10 works + 4 facts + 3 promises + 3 evidence + 2 scene-events + 1 brief) | 8 (verified: 4 plot-thread + 4 genre-extension; a 5th plot-thread tool exists in code but is commented out — see [Dead code](#known-dead-code)) |
 | Also owns | facts (atomic truths), promises (clue/setup/payoff ledger), evidence-chain (finding→conversion gap), scene-events (polymorphic event log), `get_scene_brief` (one-call drafting context) | information-reveals, reveal-evidence (child of a reveal), world-systems (magic/tech rules), character-system-progression (power levels) |
 | Server class / file | `OutlineMCPServer`, `src/mcps/outline-server/index.js` | `PlotMCPServer`, `src/mcps/plot-server/index.js` |
 | Standalone MCP name | `outline-manager` | `plot-management` |
 
 ## Tool inventory (verified against source)
 
-### outline-server — 22 tools
+### outline-server — 23 tools
 
 Registered in `src/mcps/outline-server/index.js:42-51` (`getTools()`), dispatched
 `53-85` (`getToolHandler()`). Schemas: `src/mcps/outline-server/schemas/outline-tools-schema.js`.
 
 | Group | Tools | Handler file |
 |---|---|---|
-| works (9) | `create_work`, `update_work`, `move_work`, `delete_work`, `get_outline`, `get_ancestry`, `list_series_roots`, `list_works`, `search_works` | `handlers/works-handlers.js` |
+| works (10) | `create_work`, `update_work`, `move_work`, `delete_work`, `get_outline`, `get_ancestry`, `get_works_for_book`, `list_series_roots`, `list_works`, `search_works` | `handlers/works-handlers.js` |
 | facts (4) | `create_fact`, `list_facts`, `update_fact`, `delete_fact` | `handlers/facts-handlers.js` |
 | promises (3) | `create_promise`, `update_promise`, `list_open_promises` | `handlers/promises-handlers.js` |
 | evidence (3) | `create_evidence`, `update_evidence`, `list_unconverted_evidence` | `handlers/evidence-handlers.js` |
@@ -82,7 +82,7 @@ don't go looking for a file that doesn't exist.
 Neither raw server is the only way an agent sees these tools — several
 `config-mcps/*` aggregators bundle subsets under a shared DB connection:
 
-- `config-mcps/outline-server` (`outline-phase`) — re-exports **all 22**
+- `config-mcps/outline-server` (`outline-phase`) — re-exports **all 23**
   outline tools verbatim, no renaming.
 - `config-mcps/series-planning-server` — pulls in exactly one plot-server
   tool, `define_world_system`, from `genreExtensionToolsSchema`. No outline
@@ -184,27 +184,40 @@ also shared:**
 so on). These genuinely reference the same canonical `series`, `books`,
 `chapters`, `chapter_scenes` tables that plot-server's `series_id`/
 `start_book`/`end_book` arguments also point at. So far, that sounds like a
-second shared ID space. In practice it isn't a useful one, because:
+second shared ID space. It's real, but with two things to know:
 
-- `create_work`'s handler (`works-handlers.js:16-60`) inserts whatever
-  integers you pass for `series_id`/`book_id`/`chapter_id`/`scene_id`
-  straight into the row with **no existence check** — unlike plot-server,
-  which validates `series_id` against the `series` table before every insert
-  (`plot-thread-handlers.js:25-32`).
-- No outline-server tool ever reads those columns back out. `get_outline`,
-  `get_ancestry`, `list_works`, `search_works`, and `get_scene_brief` all
-  `SELECT` specific column lists (or `SELECT *` in `get_scene_brief`, but the
-  rendered brief text never surfaces `series_id`/`book_id`/`chapter_id`/
-  `scene_id` — verified against `brief-handlers.js:158-235`). They're
-  write-only bookkeeping today.
+- **RATIFIED 2026-07-15 (Rebecca's ruling on the phantom-bridge finding,
+  dev-backlog card a169f982): "MAKE IT REAL" (bead mws-e14).** As of that
+  fix, `create_work` and `update_work`
+  (`works-handlers.js` — `validateCrossLinks()`) reject any provided
+  `series_id`/`book_id`/`chapter_id`/`scene_id` that doesn't already exist in
+  its canonical table, with a clear handler-level error (`series_id 999 not
+  found in series`, etc.) — matching plot-server's existing
+  `create_plot_thread` convention (`plot-thread-handlers.js:25-32`). The
+  columns stay optional; omitting one is fine, but a value that IS supplied
+  must be real. The underlying FK constraints
+  (`outline_works_legacy_book_id_fkey` etc., `ON DELETE SET NULL`) were
+  already present since migration 037/039 — this fix adds the handler-level
+  check so callers get a clean error instead of a raw Postgres FK-violation
+  message, and extends the same validation (and the fields themselves) to
+  `update_work`, which previously couldn't touch these columns at all.
+- **`get_works_for_book(book_id)`** (added alongside the fix above) is now
+  the read path: given a canonical `books.id`, it finds the outline node(s)
+  cross-linked to that book and renders each as a nested tree (same shape as
+  `get_outline`). `get_outline`, `get_ancestry`, `list_works`, and
+  `search_works` still don't surface `series_id`/`book_id`/`chapter_id`/
+  `scene_id` in their own output — `get_works_for_book` is the one tool that
+  looks a node up BY the canonical id instead of requiring an
+  `outline_works.id` you already know.
 
-So: **don't rely on outline's `series_id`/`book_id`/`chapter_id`/`scene_id`
-cross-links to do anything beyond storage.** They're an intentional escape
-hatch (per the migration comments: "Cross-link via the optional legacy_*_id
-columns if you want to point at existing rows") but no current tool consumes
-them. If you need outline-server and plot-server to agree on "which book/
-chapter," track that correspondence yourself — don't assume the schema does
-it for you.
+So: outline's `series_id`/`book_id`/`chapter_id`/`scene_id` cross-links are
+now validated on write and have exactly one read path
+(`get_works_for_book`, book-scoped only — there's no equivalent
+`get_works_for_series`/`get_works_for_chapter`/`get_works_for_scene` yet).
+They're still an intentional escape hatch, not a full second query surface.
+If you need outline-server and plot-server to agree on "which book/chapter"
+beyond what `get_works_for_book` gives you, track that correspondence
+yourself — don't assume the schema does all of it for you.
 
 ## Overlap / confusion risks
 
@@ -235,6 +248,7 @@ adjacent-sounding things:
 | Task | Use | Tool |
 |---|---|---|
 | Add a scene / chapter / act to the manuscript structure | outline-server | `create_work` (`work_type='scene'` etc.) |
+| Render the outline tree for a canonical `books.id` | outline-server | `get_works_for_book` |
 | Get everything needed to draft a specific scene in one call | outline-server | `get_scene_brief` |
 | Register a fact a character can/can't know yet | outline-server | `create_fact` |
 | Check what a character knows at a given point in the manuscript | outline-server | `what_does_character_know_at` |
@@ -288,12 +302,11 @@ card).
   corroborating evidence to an EXISTING information reveal (requires
   `reveal_id`). NOT for tracking findings the protagonist can't act on yet —
   see outline-server's `create_evidence` for that."*
-- **`create_work` (outline-server)** — the `series_id`/`book_id`/
-  `chapter_id`/`scene_id` parameters are documented only as "Optional
-  cross-link to X(id)" with no warning that nothing validates them and no
-  tool reads them back. Worth an explicit note: *"Write-only bookkeeping;
-  not validated against the target table and not surfaced by any
-  outline-server query."*
+- **`create_work` (outline-server)** — **DONE, bead mws-e14 (2026-07-15).**
+  The `series_id`/`book_id`/`chapter_id`/`scene_id` parameters on both
+  `create_work` and `update_work` now document "Must already exist --
+  validated before insert/update", and `book_id` calls out the
+  `get_works_for_book` read path.
 - **`create_plot_thread` / `get_plot_threads` (plot-server)** — already
   reasonably precise (`series_id` is validated, `book_number` filter is
   clear). No change needed.

--- a/src/config-mcps/outline-server/index.js
+++ b/src/config-mcps/outline-server/index.js
@@ -71,6 +71,7 @@ class OutlinePhaseMCPServer extends BaseMCPServer {
             'delete_work':                this.worksHandlers.handleDeleteWork.bind(this.worksHandlers),
             'get_outline':                this.worksHandlers.handleGetOutline.bind(this.worksHandlers),
             'get_ancestry':               this.worksHandlers.handleGetAncestry.bind(this.worksHandlers),
+            'get_works_for_book':         this.worksHandlers.handleGetWorksForBook.bind(this.worksHandlers),
             'list_series_roots':          this.worksHandlers.handleListSeriesRoots.bind(this.worksHandlers),
             'list_works':                 this.worksHandlers.handleListWorks.bind(this.worksHandlers),
             'search_works':               this.worksHandlers.handleSearchWorks.bind(this.worksHandlers),

--- a/src/mcps/outline-server/handlers/works-handlers.js
+++ b/src/mcps/outline-server/handlers/works-handlers.js
@@ -4,6 +4,14 @@
 
 import { worksToolsSchema } from '../schemas/outline-tools-schema.js';
 
+// Canonical tables each outline_works cross-link column points at.
+const CROSS_LINK_TABLES = {
+    series_id: 'series',
+    book_id: 'books',
+    chapter_id: 'chapters',
+    scene_id: 'chapter_scenes'
+};
+
 export class WorksHandlers {
     constructor(db) {
         this.db = db;
@@ -11,6 +19,21 @@ export class WorksHandlers {
 
     getWorksTools() {
         return worksToolsSchema;
+    }
+
+    // Validates any provided cross-link ids (series_id/book_id/chapter_id/scene_id)
+    // against their canonical tables. Ignores undefined/null fields (optional links).
+    // Throws a clear error naming the field and id on the first miss.
+    async validateCrossLinks(links) {
+        for (const [field, table] of Object.entries(CROSS_LINK_TABLES)) {
+            const value = links[field];
+            if (value === undefined || value === null) continue;
+
+            const check = await this.db.query(`SELECT id FROM ${table} WHERE id = $1`, [value]);
+            if (check.rows.length === 0) {
+                throw new Error(`${field} ${value} not found in ${table} -- cross-links must be real ids`);
+            }
+        }
     }
 
     async handleCreateWork(args) {
@@ -27,6 +50,8 @@ export class WorksHandlers {
             if (work_type === 'series' && parent_id) {
                 throw new Error('A "series" work cannot have a parent_id.');
             }
+
+            await this.validateCrossLinks({ series_id, book_id, chapter_id, scene_id });
 
             const result = await this.db.query(
                 `INSERT INTO outline_works
@@ -61,7 +86,17 @@ export class WorksHandlers {
 
     async handleUpdateWork(args) {
         try {
-            const { work_id, title, summary, content, status, sequence, pov_character_id } = args;
+            const {
+                work_id, title, summary, content, status, sequence, pov_character_id,
+                series_id, book_id, chapter_id, scene_id
+            } = args;
+
+            await this.validateCrossLinks({
+                series_id: series_id || null,
+                book_id: book_id || null,
+                chapter_id: chapter_id || null,
+                scene_id: scene_id || null
+            });
 
             const updates = [];
             const values = [];
@@ -75,6 +110,10 @@ export class WorksHandlers {
                 updates.push(`pov_character_id = $${p++}`);
                 values.push(pov_character_id || null);
             }
+            if (series_id !== undefined)  { updates.push(`series_id = $${p++}`);  values.push(series_id || null); }
+            if (book_id !== undefined)    { updates.push(`book_id = $${p++}`);    values.push(book_id || null); }
+            if (chapter_id !== undefined) { updates.push(`chapter_id = $${p++}`); values.push(chapter_id || null); }
+            if (scene_id !== undefined)   { updates.push(`scene_id = $${p++}`);   values.push(scene_id || null); }
 
             if (updates.length === 0) {
                 return { content: [{ type: 'text', text: 'No fields to update.' }] };
@@ -148,45 +187,93 @@ export class WorksHandlers {
         }
     }
 
+    // Shared by get_outline and get_works_for_book: renders a node plus
+    // descendants to N levels deep as nested markdown lines. Returns null if
+    // work_id doesn't exist.
+    async renderTreeLines(workId, depth, includeContent) {
+        const result = await this.db.query(
+            `WITH RECURSIVE tree AS (
+                 SELECT id, parent_id, work_type, sequence, title, summary, content, status,
+                        0 AS rel_depth,
+                        ARRAY[sequence]::int[] AS path
+                   FROM outline_works WHERE id = $1
+                 UNION ALL
+                 SELECT w.id, w.parent_id, w.work_type, w.sequence, w.title, w.summary, w.content, w.status,
+                        t.rel_depth + 1,
+                        t.path || w.sequence
+                   FROM outline_works w
+                   JOIN tree t ON w.parent_id = t.id
+                  WHERE t.rel_depth < $2
+             )
+             SELECT * FROM tree ORDER BY path`,
+            [workId, depth]
+        );
+
+        if (result.rows.length === 0) return null;
+
+        const lines = [];
+        for (const r of result.rows) {
+            const indent = '  '.repeat(r.rel_depth);
+            const heading = '#'.repeat(Math.min(r.rel_depth + 1, 6));
+            lines.push(`${indent}${heading} [${r.work_type}#${r.id}] ${r.title ?? '(untitled)'} (seq ${r.sequence}, ${r.status})`);
+            if (r.summary) lines.push(`${indent}_${r.summary}_`);
+            if (includeContent && r.content) lines.push(`${indent}${r.content}`);
+            lines.push('');
+        }
+        return lines;
+    }
+
     async handleGetOutline(args) {
         try {
             const { work_id, depth = 2, include_content = true } = args;
 
-            const result = await this.db.query(
-                `WITH RECURSIVE tree AS (
-                     SELECT id, parent_id, work_type, sequence, title, summary, content, status,
-                            0 AS rel_depth,
-                            ARRAY[sequence]::int[] AS path
-                       FROM outline_works WHERE id = $1
-                     UNION ALL
-                     SELECT w.id, w.parent_id, w.work_type, w.sequence, w.title, w.summary, w.content, w.status,
-                            t.rel_depth + 1,
-                            t.path || w.sequence
-                       FROM outline_works w
-                       JOIN tree t ON w.parent_id = t.id
-                      WHERE t.rel_depth < $2
-                 )
-                 SELECT * FROM tree ORDER BY path`,
-                [work_id, depth]
-            );
-
-            if (result.rows.length === 0) {
+            const lines = await this.renderTreeLines(work_id, depth, include_content);
+            if (lines === null) {
                 return { content: [{ type: 'text', text: `No work found with ID ${work_id}.` }] };
-            }
-
-            const lines = [];
-            for (const r of result.rows) {
-                const indent = '  '.repeat(r.rel_depth);
-                const heading = '#'.repeat(Math.min(r.rel_depth + 1, 6));
-                lines.push(`${indent}${heading} [${r.work_type}#${r.id}] ${r.title ?? '(untitled)'} (seq ${r.sequence}, ${r.status})`);
-                if (r.summary) lines.push(`${indent}_${r.summary}_`);
-                if (include_content && r.content) lines.push(`${indent}${r.content}`);
-                lines.push('');
             }
 
             return { content: [{ type: 'text', text: lines.join('\n') }] };
         } catch (err) {
             throw new Error(`get_outline failed: ${err.message}`);
+        }
+    }
+
+    async handleGetWorksForBook(args) {
+        try {
+            const { book_id, depth = 2, include_content = true } = args;
+
+            if (!book_id || typeof book_id !== 'number' || book_id < 1) {
+                throw new Error('book_id must be a positive number');
+            }
+
+            const bookCheck = await this.db.query('SELECT id, title FROM books WHERE id = $1', [book_id]);
+            if (bookCheck.rows.length === 0) {
+                throw new Error(`Book with ID ${book_id} not found`);
+            }
+
+            const roots = await this.db.query(
+                `SELECT id, work_type, title FROM outline_works WHERE book_id = $1 ORDER BY work_type, sequence, id`,
+                [book_id]
+            );
+
+            if (roots.rows.length === 0) {
+                return { content: [{ type: 'text', text:
+                    `No outline nodes are cross-linked to book_id ${book_id} ("${bookCheck.rows[0].title}") yet.`
+                }] };
+            }
+
+            const sections = [];
+            for (const root of roots.rows) {
+                const lines = await this.renderTreeLines(root.id, depth, include_content);
+                sections.push((lines || []).join('\n'));
+            }
+
+            return { content: [{ type: 'text', text:
+                `${roots.rows.length} outline node(s) cross-linked to book_id ${book_id} ("${bookCheck.rows[0].title}"):\n\n` +
+                sections.join('\n---\n\n')
+            }] };
+        } catch (err) {
+            throw new Error(`get_works_for_book failed: ${err.message}`);
         }
     }
 

--- a/src/mcps/outline-server/index.js
+++ b/src/mcps/outline-server/index.js
@@ -59,6 +59,7 @@ class OutlineMCPServer extends BaseMCPServer {
             'delete_work':                this.worksHandlers.handleDeleteWork.bind(this.worksHandlers),
             'get_outline':                this.worksHandlers.handleGetOutline.bind(this.worksHandlers),
             'get_ancestry':               this.worksHandlers.handleGetAncestry.bind(this.worksHandlers),
+            'get_works_for_book':         this.worksHandlers.handleGetWorksForBook.bind(this.worksHandlers),
             'list_series_roots':          this.worksHandlers.handleListSeriesRoots.bind(this.worksHandlers),
             'list_works':                 this.worksHandlers.handleListWorks.bind(this.worksHandlers),
             'search_works':               this.worksHandlers.handleSearchWorks.bind(this.worksHandlers),

--- a/src/mcps/outline-server/schemas/outline-tools-schema.js
+++ b/src/mcps/outline-server/schemas/outline-tools-schema.js
@@ -20,17 +20,17 @@ export const worksToolsSchema = [
                 content: { type: 'string', description: 'Long-form outline text at this zoom level' },
                 status: { type: 'string', description: 'planned, outlined, drafted, abandoned, etc.' },
                 pov_character_id: { type: 'integer', description: 'POV character (FK to characters.id). Usually set on scene nodes.' },
-                series_id: { type: 'integer', description: 'Optional cross-link to series(id)' },
-                book_id: { type: 'integer', description: 'Optional cross-link to books(id)' },
-                chapter_id: { type: 'integer', description: 'Optional cross-link to chapters(id)' },
-                scene_id: { type: 'integer', description: 'Optional cross-link to chapter_scenes(id)' }
+                series_id: { type: 'integer', description: 'Optional cross-link to series(id). Must already exist -- validated before insert.' },
+                book_id: { type: 'integer', description: 'Optional cross-link to books(id). Must already exist -- validated before insert. Read back via get_works_for_book.' },
+                chapter_id: { type: 'integer', description: 'Optional cross-link to chapters(id). Must already exist -- validated before insert.' },
+                scene_id: { type: 'integer', description: 'Optional cross-link to chapter_scenes(id). Must already exist -- validated before insert.' }
             },
             required: ['work_type','sequence']
         }
     },
     {
         name: 'update_work',
-        description: 'Update an outline node\'s title, summary, content, status, sequence, or POV character. Setting status to "abandoned" is the soft-delete convention.',
+        description: 'Update an outline node\'s title, summary, content, status, sequence, POV character, or canonical cross-links. Setting status to "abandoned" is the soft-delete convention.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -40,7 +40,11 @@ export const worksToolsSchema = [
                 content: { type: 'string' },
                 status: { type: 'string' },
                 sequence: { type: 'integer' },
-                pov_character_id: { type: 'integer', description: 'Pass null/0 to clear' }
+                pov_character_id: { type: 'integer', description: 'Pass null/0 to clear' },
+                series_id: { type: 'integer', description: 'Cross-link to series(id). Must already exist -- validated before update. Pass null/0 to clear.' },
+                book_id: { type: 'integer', description: 'Cross-link to books(id). Must already exist -- validated before update. Pass null/0 to clear.' },
+                chapter_id: { type: 'integer', description: 'Cross-link to chapters(id). Must already exist -- validated before update. Pass null/0 to clear.' },
+                scene_id: { type: 'integer', description: 'Cross-link to chapter_scenes(id). Must already exist -- validated before update. Pass null/0 to clear.' }
             },
             required: ['work_id']
         }
@@ -133,6 +137,19 @@ export const worksToolsSchema = [
                 work_id: { type: 'integer' }
             },
             required: ['work_id']
+        }
+    },
+    {
+        name: 'get_works_for_book',
+        description: 'Find the outline node(s) cross-linked to a canonical book_id (books.id) and render each as a nested outline (same shape as get_outline). The read path for "render an outline from the DB by book" -- unlike get_outline, this looks a node up BY the canonical book_id instead of requiring an outline_works.id you already know.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                book_id: { type: 'integer', description: 'Canonical books(id) to look up' },
+                depth: { type: 'integer', description: 'How many levels of children to include under each matching node (default 2)' },
+                include_content: { type: 'boolean', description: 'Include long-form content field? (default true)' }
+            },
+            required: ['book_id']
         }
     }
 ];

--- a/tests/outline-server/works-handlers.test.js
+++ b/tests/outline-server/works-handlers.test.js
@@ -1,0 +1,211 @@
+// tests/outline-server/works-handlers.test.js
+// Tests for WorksHandlers (bead mws-e14): outline_works cross-link FK
+// validation in create_work/update_work ("MAKE IT REAL" ruling on the
+// outline_works phantom-bridge finding, dev-backlog card a169f982) and the
+// new get_works_for_book read path. Exercises the handler against a mocked
+// db (no live database required), matching the pattern used in
+// tests/plot-server/plot-thread-handlers.test.js.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { WorksHandlers } from '../../src/mcps/outline-server/handlers/works-handlers.js';
+
+class MockDatabase {
+    constructor() {
+        this.queryResults = new Map();
+        this.queries = [];
+    }
+
+    setQueryResult(queryPattern, rows) {
+        this.queryResults.set(queryPattern, { rows });
+    }
+
+    async query(text, params = []) {
+        this.queries.push({ text, params });
+        for (const [pattern, result] of this.queryResults.entries()) {
+            if (text.includes(pattern)) {
+                return typeof result === 'function' ? result(params) : result;
+            }
+        }
+        return { rows: [] };
+    }
+}
+
+function seededDb() {
+    const mockDb = new MockDatabase();
+    mockDb.setQueryResult('FROM series WHERE id = $1', [{ id: 1 }]);
+    mockDb.setQueryResult('FROM books WHERE id = $1', [{ id: 2, title: 'Book One' }]);
+    mockDb.setQueryResult('FROM chapters WHERE id = $1', [{ id: 3 }]);
+    mockDb.setQueryResult('FROM chapter_scenes WHERE id = $1', [{ id: 4 }]);
+    mockDb.setQueryResult('INSERT INTO outline_works', [{
+        id: 10, parent_id: null, work_type: 'series', sequence: 0, title: 'Series', status: 'planned'
+    }]);
+    return mockDb;
+}
+
+describe('WorksHandlers.handleCreateWork cross-link validation', () => {
+    it('creates a work when all provided cross-links exist', async () => {
+        const mockDb = seededDb();
+        const handlers = new WorksHandlers(mockDb);
+
+        const result = await handlers.handleCreateWork({
+            work_type: 'series', sequence: 0, title: 'Series',
+            series_id: 1, book_id: 2, chapter_id: 3, scene_id: 4
+        });
+
+        assert.ok(result.content[0].text.includes('Created outline work'));
+        const insertCall = mockDb.queries.find(q => q.text.includes('INSERT INTO outline_works'));
+        assert.ok(insertCall, 'issued an INSERT into outline_works');
+    });
+
+    it('creates a work when no cross-links are provided (still optional)', async () => {
+        const mockDb = seededDb();
+        const handlers = new WorksHandlers(mockDb);
+
+        const result = await handlers.handleCreateWork({ work_type: 'series', sequence: 0, title: 'Series' });
+        assert.ok(result.content[0].text.includes('Created outline work'));
+
+        const fkChecks = mockDb.queries.filter(q => /FROM (series|books|chapters|chapter_scenes) WHERE id/.test(q.text));
+        assert.strictEqual(fkChecks.length, 0, 'no FK existence checks issued when no cross-links are provided');
+    });
+
+    it('rejects an unknown series_id', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM series WHERE id = $1', []);
+        const handlers = new WorksHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateWork({ work_type: 'series', sequence: 0, series_id: 999 }),
+            /series_id 999 not found in series/
+        );
+    });
+
+    it('rejects an unknown book_id', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM books WHERE id = $1', []);
+        const handlers = new WorksHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateWork({ work_type: 'book', sequence: 0, parent_id: 1, book_id: 999 }),
+            /book_id 999 not found in books/
+        );
+    });
+
+    it('rejects an unknown chapter_id', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM chapters WHERE id = $1', []);
+        const handlers = new WorksHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateWork({ work_type: 'chapter', sequence: 0, parent_id: 1, chapter_id: 999 }),
+            /chapter_id 999 not found in chapters/
+        );
+    });
+
+    it('rejects an unknown scene_id', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM chapter_scenes WHERE id = $1', []);
+        const handlers = new WorksHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleCreateWork({ work_type: 'scene', sequence: 0, parent_id: 1, scene_id: 999 }),
+            /scene_id 999 not found in chapter_scenes/
+        );
+    });
+});
+
+describe('WorksHandlers.handleUpdateWork cross-link validation', () => {
+    it('validates and applies a provided book_id', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('UPDATE outline_works SET', [{ id: 5, work_type: 'book', title: 'Book One', status: 'planned' }]);
+        const handlers = new WorksHandlers(mockDb);
+
+        const result = await handlers.handleUpdateWork({ work_id: 5, book_id: 2 });
+        assert.ok(result.content[0].text.includes('Updated work'));
+
+        const updateCall = mockDb.queries.find(q => q.text.includes('UPDATE outline_works SET'));
+        assert.ok(updateCall.text.includes('book_id = $'), 'update statement includes book_id');
+        assert.ok(updateCall.params.includes(2), 'book_id value bound');
+    });
+
+    it('rejects an unknown book_id on update', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM books WHERE id = $1', []);
+        const handlers = new WorksHandlers(mockDb);
+
+        await assert.rejects(
+            handlers.handleUpdateWork({ work_id: 5, book_id: 999 }),
+            /book_id 999 not found in books/
+        );
+    });
+
+    it('clears book_id with 0 without requiring it to exist', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM books WHERE id = $1', []); // would fail existence if checked
+        mockDb.setQueryResult('UPDATE outline_works SET', [{ id: 5, work_type: 'book', title: 'Book One', status: 'planned' }]);
+        const handlers = new WorksHandlers(mockDb);
+
+        const result = await handlers.handleUpdateWork({ work_id: 5, book_id: 0 });
+        assert.ok(result.content[0].text.includes('Updated work'));
+
+        const updateCall = mockDb.queries.find(q => q.text.includes('UPDATE outline_works SET'));
+        const bookIdParamIndex = updateCall.text.match(/book_id = \$(\d+)/)[1] - 1;
+        assert.strictEqual(updateCall.params[bookIdParamIndex], null, 'book_id cleared to NULL');
+    });
+
+    it('leaves cross-links untouched when not provided', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('UPDATE outline_works SET', [{ id: 5, work_type: 'book', title: 'Book One', status: 'planned' }]);
+        const handlers = new WorksHandlers(mockDb);
+
+        await handlers.handleUpdateWork({ work_id: 5, title: 'New Title' });
+        const updateCall = mockDb.queries.find(q => q.text.includes('UPDATE outline_works SET'));
+        assert.ok(!updateCall.text.includes('book_id'), 'book_id not touched when omitted');
+    });
+});
+
+describe('WorksHandlers.handleGetWorksForBook', () => {
+    it('rejects a non-numeric book_id', async () => {
+        const mockDb = seededDb();
+        const handlers = new WorksHandlers(mockDb);
+        await assert.rejects(
+            handlers.handleGetWorksForBook({ book_id: 'nope' }),
+            /book_id must be a positive number/
+        );
+    });
+
+    it('rejects an unknown book_id', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM books WHERE id = $1', []);
+        const handlers = new WorksHandlers(mockDb);
+        await assert.rejects(
+            handlers.handleGetWorksForBook({ book_id: 999 }),
+            /Book with ID 999 not found/
+        );
+    });
+
+    it('reports when no outline nodes are cross-linked to the book yet', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM outline_works WHERE book_id = $1', []);
+        const handlers = new WorksHandlers(mockDb);
+
+        const result = await handlers.handleGetWorksForBook({ book_id: 2 });
+        assert.ok(result.content[0].text.includes('No outline nodes are cross-linked to book_id 2'));
+    });
+
+    it('renders the tree for each matching outline root', async () => {
+        const mockDb = seededDb();
+        mockDb.setQueryResult('FROM outline_works WHERE book_id = $1', [{ id: 10, work_type: 'book', title: 'Book One' }]);
+        mockDb.setQueryResult('WITH RECURSIVE tree AS', [
+            { id: 10, parent_id: null, work_type: 'book', sequence: 0, title: 'Book One', summary: null, content: null, status: 'planned', rel_depth: 0 },
+            { id: 11, parent_id: 10, work_type: 'chapter', sequence: 1, title: 'Chapter 1', summary: null, content: null, status: 'planned', rel_depth: 1 }
+        ]);
+        const handlers = new WorksHandlers(mockDb);
+
+        const result = await handlers.handleGetWorksForBook({ book_id: 2 });
+        const text = result.content[0].text;
+        assert.ok(text.includes('1 outline node(s) cross-linked to book_id 2'));
+        assert.ok(text.includes('[book#10] Book One'));
+        assert.ok(text.includes('[chapter#11] Chapter 1'));
+    });
+});


### PR DESCRIPTION
## Summary

Rebecca's ruling 2026-07-15 on the `outline_works` phantom-bridge finding (dev-backlog card `a169f982`): option (a) **MAKE IT REAL**. `series_id`/`book_id`/`chapter_id`/`scene_id` on `outline_works` stay optional, but when provided they must be real ids. `docs/outline-vs-plot.md` had documented `create_work` as inserting whatever integers you pass with **no existence check** — unlike plot-server's `create_plot_thread`, which validates `series_id` before every insert.

- `create_work` / `update_work` (`src/mcps/outline-server/handlers/works-handlers.js`) now validate any provided cross-link id against its canonical table (`series`/`books`/`chapters`/`chapter_scenes`) before writing, via a new `validateCrossLinks()` helper, with a clear handler-level error (`book_id 999 not found in books -- cross-links must be real ids`) instead of a raw Postgres FK-violation message. `update_work` previously couldn't touch these four columns at all (they weren't even in its schema/destructure) — it now can, including clearing one back to NULL with `0`/`null`, matching the existing `pov_character_id` convention.
- The underlying FK constraints (`outline_works_legacy_book_id_fkey` etc., `ON DELETE SET NULL`) already existed since migrations 037/039 — verified against a throwaway `postgres:16` container, so **no new migration was needed**, only the missing handler-level check.
- Adds **`get_works_for_book(book_id)`**: the missing read path. Looks up the outline node(s) cross-linked to a canonical `books.id` and renders each as a nested tree (same shape as `get_outline`, via a shared `renderTreeLines()` helper extracted from it) — instead of requiring an `outline_works.id` you already know. Registered in both the standalone `outline-manager` server and the `outline-phase` config-mcp (23 tools now, was 22).
- Updates `docs/outline-vs-plot.md` (tool counts, the "series/books/chapters asterisk" section, the decision table, and the now-resolved `create_work` tool-description-guidance bullet) so it reflects the fix instead of the finding it originally reported.

## Test plan

- [x] `node --test tests/outline-server/works-handlers.test.js` -- 14/14 passing (mocked DB)
- [x] Verified against a fresh `postgres:16` container (init.sql + migrations 037-039): confirmed the FK constraints already exist, then exercised the real handler end-to-end -- a bad `series_id`/`book_id` is rejected with the clean handler message (not a raw pg FK error), a valid series → book → chapter fixture creates cleanly, `update_work` rejects a bad `book_id`, and `get_works_for_book` renders the correct nested tree for the book
- [x] Sanity-loaded the `outline-phase` config-mcp wrapper and confirmed it exposes 23 tools including `get_works_for_book` with a working handler

Closes bead: mws-e14