### PR TITLE
kanban-server: fix create_card metadata drop + retry-idempotency

### DIFF
--- a/migrations/047_kanban_cards_pr_ref_unique.sql
+++ b/migrations/047_kanban_cards_pr_ref_unique.sql
@@ -1,0 +1,36 @@
+-- Migration: 047_kanban_cards_pr_ref_unique
+-- Description: bead mws-9e9 defect 2 -- create_card is not idempotent under
+-- client retry. Live evidence: two byte-identical cards created 1
+-- MILLISECOND apart (card ids 63758992.../b12c0bac..., same
+-- created_by='claude-code:factory-dispatch'), the shape of two concurrent
+-- inserts racing a plain SELECT-then-INSERT dedupe check (a check-then-act
+-- guard in application code cannot close this window -- both callers can run
+-- the SELECT before either commits the INSERT). A partial unique index lets
+-- Postgres itself reject the second insert atomically; card-handlers.js
+-- handleCreateCard then falls back to SELECTing the winner on conflict.
+--
+-- Scoped to (board_id, metadata->>pr_ref) WHERE status <> 'done' AND
+-- metadata->>pr_ref IS NOT NULL: a card without a pr_ref never dedupes on
+-- this key (falls back to the best-effort title+window check in the
+-- handler), and once the original card reaches 'done' a fresh card with the
+-- same pr_ref (e.g. a reopened PR) is allowed through again.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM migrations WHERE filename = '047_kanban_cards_pr_ref_unique.sql') THEN
+        RAISE NOTICE 'Migration 047_kanban_cards_pr_ref_unique.sql already applied, skipping.';
+        RETURN;
+    END IF;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_kanban_cards_board_pr_ref_not_done
+        ON fictionlab.kanban_cards (board_id, (metadata->>'pr_ref'))
+        WHERE status <> 'done' AND metadata->>'pr_ref' IS NOT NULL;
+
+    COMMENT ON INDEX fictionlab.idx_kanban_cards_board_pr_ref_not_done IS
+        'Retry-safe create_card dedupe key (bead mws-9e9): at most one non-done card per board may carry a given metadata.pr_ref. Enforced via ON CONFLICT in handleCreateCard, not just relied on as a bare constraint.';
+
+    INSERT INTO migrations (filename) VALUES ('047_kanban_cards_pr_ref_unique.sql')
+    ON CONFLICT (filename) DO NOTHING;
+
+    RAISE NOTICE 'Migration 047_kanban_cards_pr_ref_unique.sql completed successfully.';
+END $$;

--- a/src/mcps/kanban-server/handlers/card-handlers.js
+++ b/src/mcps/kanban-server/handlers/card-handlers.js
@@ -212,7 +212,8 @@ export class CardHandlers {
             issue_ref,
             created_by = 'rebecca',
             due_at,
-            review_policy
+            review_policy,
+            metadata
         } = args || {};
 
         if (!title) {
@@ -236,29 +237,83 @@ export class CardHandlers {
         // "never downgrade" is enforced by update_card not exposing
         // review_policy as a patchable field (see update_card below).
         const resolvedReviewPolicy = review_policy || inferReviewPolicy({ labels, spec_ref, issue_ref, title, body });
+        const resolvedMetadata = metadata || {};
 
-        const result = await this.db.query(
-            `INSERT INTO fictionlab.kanban_cards
-                (board_id, title, body, status, assignee, priority, labels, spec_ref, issue_ref, review_policy, created_by, due_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-             RETURNING *`,
-            [
-                resolvedBoardId,
-                title,
-                body || null,
-                status,
-                assignee || null,
-                priority,
-                labels,
-                spec_ref || null,
-                issue_ref || null,
-                resolvedReviewPolicy,
-                created_by,
-                due_at || null
-            ]
-        );
+        const insertParams = [
+            resolvedBoardId,
+            title,
+            body || null,
+            status,
+            assignee || null,
+            priority,
+            labels,
+            spec_ref || null,
+            issue_ref || null,
+            resolvedReviewPolicy,
+            created_by,
+            due_at || null,
+            resolvedMetadata
+        ];
+        const insertColumns = `(board_id, title, body, status, assignee, priority, labels, spec_ref, issue_ref, review_policy, created_by, due_at, metadata)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`;
 
-        const card = result.rows[0];
+        let card;
+        if (resolvedMetadata.pr_ref) {
+            // Retry-shaped duplicate guard (mws-9e9 defect 2): a plain
+            // SELECT-then-INSERT check cannot close the race window (two
+            // concurrent callers can both pass the SELECT before either
+            // commits its INSERT -- this is exactly the twin-card evidence
+            // the bead was filed from, 1ms apart). metadata.pr_ref is the
+            // merge-watcher's primary match key, so this is enforced with a
+            // real partial unique index (migration 047) + ON CONFLICT, which
+            // Postgres arbitrates atomically across concurrent inserts.
+            const insertResult = await this.db.query(
+                `INSERT INTO fictionlab.kanban_cards ${insertColumns}
+                 ON CONFLICT (board_id, (metadata->>'pr_ref'))
+                    WHERE status <> 'done' AND metadata->>'pr_ref' IS NOT NULL
+                    DO NOTHING
+                 RETURNING *`,
+                insertParams
+            );
+
+            if (insertResult.rows.length > 0) {
+                card = insertResult.rows[0];
+            } else {
+                // Lost the race (or this genuinely is a retry): another
+                // non-done card already holds this board+pr_ref. Return it
+                // as-is -- no activity log, no second 'created' entry.
+                const existing = await this.db.query(
+                    `SELECT * FROM fictionlab.kanban_cards
+                     WHERE board_id = $1 AND status <> 'done' AND metadata->>'pr_ref' = $2
+                     ORDER BY created_at LIMIT 1`,
+                    [resolvedBoardId, resolvedMetadata.pr_ref]
+                );
+                return { card: existing.rows[0] };
+            }
+        } else {
+            // No pr_ref to dedupe on atomically. Best-effort fallback: same
+            // board+status+title created in the last few seconds is almost
+            // certainly a retry, not a deliberate second card. This window
+            // IS racy under true concurrent double-fire (unlike the pr_ref
+            // path above, which a real unique index protects) -- it only
+            // guards the common sequential-retry case.
+            const recentDuplicate = await this.db.query(
+                `SELECT * FROM fictionlab.kanban_cards
+                 WHERE board_id = $1 AND status = $2 AND title = $3
+                   AND created_at > NOW() - INTERVAL '5 seconds'
+                 ORDER BY created_at LIMIT 1`,
+                [resolvedBoardId, status, title]
+            );
+            if (recentDuplicate.rows.length > 0) {
+                return { card: recentDuplicate.rows[0] };
+            }
+
+            const insertResult = await this.db.query(
+                `INSERT INTO fictionlab.kanban_cards ${insertColumns} RETURNING *`,
+                insertParams
+            );
+            card = insertResult.rows[0];
+        }
 
         await logActivity(this.db, {
             boardId: resolvedBoardId,

--- a/src/mcps/kanban-server/schemas/kanban-tools-schema.js
+++ b/src/mcps/kanban-server/schemas/kanban-tools-schema.js
@@ -94,6 +94,10 @@ export const kanbanToolsSchema = [
                     type: 'string',
                     enum: ['auto-done', 'review-required'],
                     description: 'Optional override for callers that already know the risk class; otherwise defaulted from title/body/labels/refs.'
+                },
+                metadata: {
+                    type: 'object',
+                    description: "Arbitrary key/value bag, e.g. { pr_ref: 'owner/repo#N' } -- the merge-watcher's primary match key. If a non-done card already exists on this board with the same metadata.pr_ref, that existing card is returned instead of inserting a duplicate (retry-safe)."
                 }
             },
             required: ['title']

--- a/test/kanban-server/smoke-test.js
+++ b/test/kanban-server/smoke-test.js
@@ -498,6 +498,69 @@ async function main() {
             'list_cards due_filter=overdue excludes a done card even with a past due_at',
             !overdueAfterDoneRes.cards.some((c) => c.id === overdueCardId)
         );
+
+        // --- mws-9e9: create_card metadata round-trip + retry-shaped dedupe ---
+
+        // Regression test: create_card with metadata.pr_ref, read back, assert non-empty.
+        const metaCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'PR-linked review card',
+            metadata: { pr_ref: 'RLRyals/MCP-Writing-Servers#999', bead_id: 'mws-9e9' }
+        });
+        const metaCardId = metaCardRes.card.id;
+        check(
+            'create_card round-trips metadata.pr_ref',
+            metaCardRes.card.metadata?.pr_ref === 'RLRyals/MCP-Writing-Servers#999',
+            JSON.stringify(metaCardRes.card.metadata)
+        );
+        check(
+            'create_card round-trips metadata.bead_id',
+            metaCardRes.card.metadata?.bead_id === 'mws-9e9'
+        );
+
+        // Retry-shaped duplicate create: same board + same metadata.pr_ref,
+        // non-done -> must return the existing card, no second row.
+        const retryCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'PR-linked review card',
+            metadata: { pr_ref: 'RLRyals/MCP-Writing-Servers#999', bead_id: 'mws-9e9' }
+        });
+        check(
+            'create_card retry with same board+pr_ref returns the existing card, not a new one',
+            retryCardRes.card.id === metaCardId
+        );
+
+        const pr999CountRes = await pool.query(
+            `SELECT id, title, status, metadata, created_at FROM fictionlab.kanban_cards WHERE board_id = $1 AND metadata->>'pr_ref' = $2`,
+            [testBoardId, 'RLRyals/MCP-Writing-Servers#999']
+        );
+        check(
+            'no second row was inserted for the retried pr_ref',
+            pr999CountRes.rows.length === 1,
+            JSON.stringify(pr999CountRes.rows)
+        );
+
+        const pr999ActivityCountRes = await pool.query(
+            `SELECT COUNT(*) FROM fictionlab.kanban_activity WHERE card_id = $1 AND action = 'created'`,
+            [metaCardId]
+        );
+        check(
+            'kanban_activity gets no duplicate create entry for the retried pr_ref',
+            parseInt(pr999ActivityCountRes.rows[0].count, 10) === 1
+        );
+
+        // Once the original card is done, a new pr_ref create is a fresh card
+        // (dedupe only guards non-done cards).
+        await callTool(client, 'move_card', { card_id: metaCardId, to_status: 'done', actor: 'rebecca' });
+        const afterDoneCardRes = await callTool(client, 'create_card', {
+            board_id: testBoardId,
+            title: 'PR-linked review card (reopened)',
+            metadata: { pr_ref: 'RLRyals/MCP-Writing-Servers#999', bead_id: 'mws-9e9' }
+        });
+        check(
+            'create_card with same pr_ref makes a fresh card once the prior one is done',
+            afterDoneCardRes.card.id !== metaCardId
+        );
     } finally {
         await client.close();
         // Cascade-delete the ephemeral test board (columns/cards/comments/links/activity all go with it).


### PR DESCRIPTION
## Summary
- `create_card` silently dropped the `metadata` parameter (never read from args, never inserted — defaulted to `{}` at the DB level), forcing every caller into a create-then-`update_card` dance to set `metadata.pr_ref`, the merge-watcher's primary match key.
- Added a race-safe retry dedupe guard for `create_card`: a plain SELECT-then-INSERT check can't close the race window. While reproducing the bead's "twin cards 1ms apart" evidence I confirmed the real trigger is `stdio-adapter.js` double-instantiating `KanbanMCPServer` (filed separately as `mws-xi7`, out of scope here) — every stdio tool call is executed twice. Given that, the guard needed to be atomic: a partial unique index on `(board_id, metadata->>'pr_ref') WHERE status <> 'done'` (migration `047_kanban_cards_pr_ref_unique.sql`), with `handleCreateCard` doing `INSERT ... ON CONFLICT DO NOTHING` and falling back to selecting the winning row. Verified this holds under the live double-execution bug.
- No-`pr_ref` creates fall back to a best-effort (non-atomic) same-board+status+title-within-5s check, documented as such.

## Test plan
- [x] `node test/kanban-server/smoke-test.js` — 73/73 pass, including new cases: metadata round-trips, retry with same `pr_ref` returns the existing card (no second row, no duplicate `kanban_activity` "created" entry), and a fresh card is allowed once the original reaches `done`.
- [x] `node test/kanban-server/card-search-test.js` — 14/14 pass (no regression).
- [x] `node test/kanban-server/concurrent-claim-test.js` — 20/20 iterations pass (no regression).
- [x] Migration `047_kanban_cards_pr_ref_unique.sql` applied to the live dev DB.

Closes bead: mws-9e9