### PR TITLE
orchestrator: spawn outline-server + expose missing character/timeline tools (mws-bpu)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ USER nodejs:1001
 # 3001: book-planning, 3002: series-planning, 3003: chapter-planning
 # 3004: character-planning, 3005: scene, 3006: core-continuity
 # 3007: review, 3008: reporting, 3009: author, 3010: database-admin
-EXPOSE 3001 3002 3003 3004 3005 3006 3007 3008 3009 3010 3011 3012
+EXPOSE 3001 3002 3003 3004 3005 3006 3007 3008 3009 3010 3011 3012 3013
 
 # Health check - verifies the HTTP/SSE server is responsive
 # Checks all critical services including database-admin on port 3010

--- a/server.js
+++ b/server.js
@@ -22,7 +22,8 @@ const servers = [
     { name: 'reporting', port: 3008 },
     { name: 'author', port: 3009 },
     { name: 'database-admin', port: 3010 },
-    { name: 'workflow-manager', port: 3012 }
+    { name: 'workflow-manager', port: 3012 },
+    { name: 'outline', port: 3013 }
 ];
 
 // Store child process references
@@ -60,6 +61,7 @@ function log(serverName, message, level = 'info') {
         'author': colors.cyan,
         'database-admin': colors.green,
         'workflow-manager': colors.yellow,
+        'outline': colors.red,
         'orchestrator': colors.bright + colors.white
     };
 

--- a/src/config-mcps/book-planning-server/index.js
+++ b/src/config-mcps/book-planning-server/index.js
@@ -130,6 +130,24 @@ class BookPlanningMCPServer extends BaseMCPServer {
             });
         }
 
+        const listTimelineEvents = timelineTools.find(t => t.name === 'list_timeline_events');
+        if (listTimelineEvents) {
+            tools.push({
+                ...listTimelineEvents,
+                name: 'list_timeline_events',
+                description: `${listTimelineEvents.description}`
+            });
+        }
+
+        const deleteTimelineEvent = timelineTools.find(t => t.name === 'delete_timeline_event');
+        if (deleteTimelineEvent) {
+            tools.push({
+                ...deleteTimelineEvent,
+                name: 'delete_timeline_event',
+                description: `${deleteTimelineEvent.description}`
+            });
+        }
+
         // =============================================
         // 5. METADATA TOOLS (Phase-specific)
         // =============================================
@@ -184,6 +202,8 @@ class BookPlanningMCPServer extends BaseMCPServer {
 
             // Timeline handlers
             'create_timeline_event': (args) => this.timelineEventHandlers.handleCreateTimelineEvent(args),
+            'list_timeline_events': (args) => this.timelineEventHandlers.handleListTimelineEvents(args),
+            'delete_timeline_event': (args) => this.timelineEventHandlers.handleDeleteTimelineEvent(args),
 
             // Metadata handlers
             'assign_book_genres': (args) => this.lookupHandlers.handleAssignBookGenres(args),

--- a/src/config-mcps/character-planning-server/index.js
+++ b/src/config-mcps/character-planning-server/index.js
@@ -104,10 +104,28 @@ class CharacterPlanningMCPServer extends BaseMCPServer {
             });
         }
 
+        const deleteCharacterDetailSchema = characterDetailToolsSchema.find(t => t.name === 'delete_character_detail');
+        if (deleteCharacterDetailSchema) {
+            tools.push({
+                ...deleteCharacterDetailSchema,
+                name: 'delete_character_detail',
+                description: 'Delete an existing character detail'
+            });
+        }
+
         // =============================================
         //  CHARACTER KNOWLEDGE TOOLS (Phase-specific)
         // =============================================
         const characterKnowledgeTools = this.characterKnowledgeHandlers.getCharacterKnowledgeTools();
+
+        const addCharacterKnowledge = characterKnowledgeTools.find(t => t.name === 'add_character_knowledge');
+        if (addCharacterKnowledge) {
+            tools.push({
+                ...addCharacterKnowledge,
+                name: 'add_character_knowledge',
+                description: 'Record what a character knows, when, and how (book/character-scoped; use add_character_knowledge_with_chapter for chapter-scoped tracking)'
+            });
+        }
 
         const checkCharacterKnowledge = characterKnowledgeTools.find(t => t.name === 'check_character_knowledge');
         if (checkCharacterKnowledge) {
@@ -234,6 +252,8 @@ class CharacterPlanningMCPServer extends BaseMCPServer {
             'update_character': (args) => this.characterHandlers.handleUpdateCharacter(args),
             'add_character_detail': (args) => this.characterDetailHandlers.handleAddCharacterDetail(args),
             'update_character_detail': (args) => this.characterDetailHandlers.handleUpdateCharacterDetail(args),
+            'delete_character_detail': (args) => this.characterDetailHandlers.handleDeleteCharacterDetail(args),
+            'add_character_knowledge': (args) => this.characterKnowledgeHandlers.handleAddCharacterKnowledge(args),
             'check_character_knowledge': (args) => this.characterKnowledgeHandlers.handleCheckCharacterKnowledge(args),
             'update_character_knowledge': (args) => this.characterKnowledgeHandlers.handleUpdateCharacterKnowledge(args),
             'delete_character_knowledge': (args) => this.characterKnowledgeHandlers.handleDeleteCharacterKnowledge(args),

--- a/tests/book-planning-server/book-planning-wrapper.test.js
+++ b/tests/book-planning-server/book-planning-wrapper.test.js
@@ -1,0 +1,44 @@
+// tests/book-planning-server/book-planning-wrapper.test.js
+// Covers bead mws-bpu acceptance criterion: expose the timeline read/delete
+// tools that already existed on the unwrapped
+// src/mcps/timeline-server/handlers/timeline-event-handlers.js but were
+// never registered on any config-mcps phase wrapper.
+//
+// The book-planning-server config-mcp (port 3001) already exposed
+// create_timeline_event; this checks that list_timeline_events and
+// delete_timeline_event (siblings from the same TimelineEventHandlers
+// instance) are now exposed through buildTools()/getToolHandler() too.
+//
+// No live DB writes are exercised here -- pg.Pool connects lazily so no
+// postgres service is required to run it.
+
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert';
+import { BookPlanningMCPServer } from '../../src/config-mcps/book-planning-server/index.js';
+
+describe('book-planning-server wrapper tool visibility (mws-bpu)', () => {
+    let server;
+
+    after(async () => {
+        if (server && server.db && server.db.pool) {
+            await server.db.pool.end();
+        }
+    });
+
+    it('exposes list_timeline_events and delete_timeline_event alongside create_timeline_event', () => {
+        server = new BookPlanningMCPServer();
+        const toolNames = server.tools.map(t => t.name);
+
+        assert.ok(toolNames.includes('create_timeline_event'), 'wrapper should still expose create_timeline_event');
+        assert.ok(toolNames.includes('list_timeline_events'), 'wrapper should expose list_timeline_events');
+        assert.ok(toolNames.includes('delete_timeline_event'), 'wrapper should expose delete_timeline_event');
+
+        assert.strictEqual(typeof server.getToolHandler('list_timeline_events'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('delete_timeline_event'), 'function');
+    });
+
+    it('delete_timeline_event requires a confirmation flag', () => {
+        const deleteEvent = server.tools.find(t => t.name === 'delete_timeline_event');
+        assert.deepStrictEqual(deleteEvent.inputSchema.required, ['event_id', 'confirm_deletion']);
+    });
+});

--- a/tests/character-server/character-planning-wrapper.test.js
+++ b/tests/character-server/character-planning-wrapper.test.js
@@ -8,6 +8,11 @@
 // new update_character_knowledge / delete_character_knowledge tools (and the
 // already-registered arc tools) are exposed through that wrapper's
 // buildTools()/getToolHandler(), not just on the raw character-server.
+//
+// bead mws-bpu added delete_character_detail and the book/character-scoped
+// add_character_knowledge (sibling of update/delete_character_knowledge,
+// which were already exposed) -- both existed only on the unwrapped
+// src/mcps/character-server/index.js before this.
 
 import { describe, it, after } from 'node:test';
 import assert from 'node:assert';
@@ -45,6 +50,22 @@ describe('character-planning-server wrapper tool visibility (mws-6)', () => {
         assert.strictEqual(typeof server.getToolHandler('update_character_arc'), 'function');
         assert.strictEqual(typeof server.getToolHandler('delete_character_arc'), 'function');
         assert.strictEqual(typeof server.getToolHandler('list_character_arcs'), 'function');
+    });
+
+    it('exposes delete_character_detail and add_character_knowledge (mws-bpu)', () => {
+        const toolNames = server.tools.map(t => t.name);
+
+        assert.ok(toolNames.includes('delete_character_detail'), 'wrapper should expose delete_character_detail');
+        assert.ok(toolNames.includes('add_character_knowledge'), 'wrapper should expose add_character_knowledge');
+
+        assert.strictEqual(typeof server.getToolHandler('delete_character_detail'), 'function');
+        assert.strictEqual(typeof server.getToolHandler('add_character_knowledge'), 'function');
+
+        const deleteDetail = server.tools.find(t => t.name === 'delete_character_detail');
+        assert.deepStrictEqual(deleteDetail.inputSchema.required, ['character_id', 'category', 'attribute']);
+
+        const addKnowledge = server.tools.find(t => t.name === 'add_character_knowledge');
+        assert.deepStrictEqual(addKnowledge.inputSchema.required, ['character_id', 'knowledge_category', 'knowledge_item']);
     });
 
     it('new schemas carry a usable inputSchema (id-based identification)', () => {


### PR DESCRIPTION
## Summary
- server.js's 11-server spawn list never included outline-server, so its facts/works tools (create/list/update/delete_fact, create/update/list_work(s), get_outline) were unreachable via the orchestrator, even though `src/single-server-runner.js` already had the `'outline'` -> `OutlinePhaseMCPServer` mapping and `docker-compose.yml` already reserved port 3013 for it. Added `{ name: 'outline', port: 3013 }` to server.js's spawn list (+ log color entry) and added 3013 to the Dockerfile's `EXPOSE` list to match docker-compose.yml.
- Confirmed-or-exposed the tool gaps named in the bead, all of which had working handler/schema implementations on the unwrapped `src/mcps/*` servers but were never registered on any `src/config-mcps/*` phase wrapper actually spawned for clients:
  - `delete_character_detail` and the book/character-scoped `add_character_knowledge` (sibling of the already-exposed `update_character_knowledge`/`delete_character_knowledge`) -> added to `character-planning-server`.
  - `list_timeline_events` and `delete_timeline_event` (siblings of the already-exposed `create_timeline_event`) -> added to `book-planning-server`.
- No tools needed to stay internal-only — all four had a natural home next to an already-exposed sibling tool using the same handler instance, so nothing required a "stays internal" writeup.
- Note: `src/http-sse-server.js` (the actual entrypoint the Docker image runs, per `Dockerfile`'s `CMD`) already had outline/kanban/story-analysis wired up correctly; this PR fixes the separate `server.js` child-process orchestrator path named explicitly in the bead's scope, which had drifted out of sync with it.

## Live verification (acceptance criterion: "answers on the assigned port in the running stack")
Spawned `outline` (3113), `book-planning` (3101), and `character-planning` (3104) directly via `single-server-runner.js` (the same script `server.js` spawns, on scratch ports to avoid colliding with the already-running docker stack) and hit them over real HTTP:

```
$ curl -s -X POST http://localhost:3113/mcp -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | jq -r '.result.tools[].name'
create_work
update_work
delete_work
...
create_fact
list_facts
update_fact
delete_fact
...
get_outline
...

$ curl -s -X POST http://localhost:3101/mcp -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | jq -r '.result.tools[].name'
...
create_timeline_event
list_timeline_events
delete_timeline_event
...

$ curl -s -X POST http://localhost:3104/mcp -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | jq -r '.result.tools[].name'
...
delete_character_detail
add_character_knowledge
...

$ curl -s -X POST http://localhost:3101/mcp -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_timeline_events","arguments":{"series_id":999999}}}'
{"jsonrpc":"2.0","id":2,"result":{"event_count":0,"events":[]}}
```

All three test servers were stopped after verification.

## Test plan
- [x] `node --test tests/character-server/character-planning-wrapper.test.js tests/book-planning-server/book-planning-wrapper.test.js` — new + existing wrapper-visibility assertions pass
- [x] `node test/single-server-runner/route-precedence-test.js` — unaffected, still green
- [x] `node tests/plot-server/run-tests.js`, `node --test tests/story-analysis-server/*.test.js`, `node --test tests/outline-server/works-handlers.test.js` — unaffected, still green
- [x] `node tests/kanban-server/*.test.js`, `node test/kanban-server/stdio-single-instance-test.js`, `node tests/workflow-manager-server/definition-handlers.test.js` — unaffected, still green
- [x] `node --check` on all touched `.js` files

Closes bead: mws-bpu