### PR TITLE
docker-compose: publish kanban (3015) + story-analysis (3016) ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 # Complete production stack with:
 # - PostgreSQL database with optimized settings
 # - PgBouncer connection pooling
-# - MCP Writing Servers (13 servers on ports 3001-3013)
+# - MCP Writing Servers (15 servers on ports 3001-3013, 3015-3016)
 # - Prometheus monitoring
 # - Grafana dashboards
 # - Health checks and auto-restart
@@ -126,6 +126,8 @@ services:
       - "3011:3011"  # npe
       - "3012:3012"  # workflow-manager
       - "3013:3013"  # outline
+      - "3015:3015"  # kanban
+      - "3016:3016"  # story-analysis
     depends_on:
       pgbouncer:
         condition: service_healthy


### PR DESCRIPTION
## Problem
The mcp-servers service's `ports:` block in docker-compose.yml stopped at `3013:3013` (outline), omitting kanban (3015) and story-analysis (3016). Both servers are already registered in the in-process HTTP-SSE multi-server manager (src/http-sse-server.js:220-225 and :232-239) and work fine under stdio mode, but were unreachable from the host in Docker despite running inside the container.

## Fix
Added `"3015:3015"` (kanban) and `"3016:3016"` (story-analysis) to the mcp-servers service's ports block, alongside the existing 3001-3013 range. Also updated the header comment's server/port-range summary for accuracy.

## Validation
- `docker compose config` resolves cleanly and the rendered config confirms both 3015 and 3016 are published (in addition to 3001-3013).
- Confirmed port numbers against the source of truth (src/http-sse-server.js): kanban=3015, story-analysis=3016 — matches the new compose entries.
- Attempted a full `docker compose up` + curl of /health on 3015/3016 per the acceptance criteria, but this environment's pgbouncer dependency (`bitnami/pgbouncer:latest`) fails to pull — `docker.io/bitnami/pgbouncer:latest: not found`. This is a pre-existing, unrelated image-resolution issue (docker-compose.yml:60, untouched by this change) blocking the full stack from starting locally, not something introduced by this fix. No change to stdio mode or the in-process HTTP-SSE registration — this is a docker-compose port-publish fix only.

Closes bead: mws-4it