### PR TITLE
db: gate SSL on DB_SSL/PGSSLMODE instead of NODE_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ INCLUDE_AUTHOR_SERVER=true
 # ==========================================
 NODE_ENV=development
 
+# Database SSL (opt-in only -- do NOT infer from NODE_ENV)
+# pgbouncer (edoburu/pgbouncer) ships with client_tls_sslmode=disable and no
+# TLS certs by default, so it rejects SSL negotiation. Leave unset/disabled
+# unless pgbouncer has been provisioned with real TLS certs.
+# Set to true/require/verify-ca/verify-full once TLS is configured.
+# DB_SSL=require
+
 # ==========================================
 # Typing Mind Static Web Server (Optional)
 # ==========================================

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -638,6 +638,7 @@ MCP_AUTH_TOKEN=your-secure-token
 ### Optional Variables
 
 ```env
+DB_SSL=require              # opt-in only; pgbouncer has no TLS certs by default, leave unset unless configured
 LOG_LEVEL=info              # debug, info, warn, error
 LOG_FORMAT=json             # json, text
 POSTGRES_SHARED_BUFFERS=256MB

--- a/src/db.js
+++ b/src/db.js
@@ -16,6 +16,18 @@ const { Pool } = pg;
 /** Singleton pool instance */
 let _pool = null;
 
+// SSL is opt-in via DB_SSL/PGSSLMODE, not inferred from NODE_ENV: pgbouncer
+// (edoburu/pgbouncer, see mws-58d) ships with client_tls_sslmode=disable and no
+// certs, so forcing SSL whenever NODE_ENV=production breaks every pooled
+// connection (mws-qz0). Set DB_SSL=true/require once TLS is actually provisioned.
+function resolveSslConfig() {
+  const mode = (process.env.DB_SSL || process.env.PGSSLMODE || '').toLowerCase();
+  if (['true', '1', 'require', 'verify-ca', 'verify-full'].includes(mode)) {
+    return { rejectUnauthorized: false };
+  }
+  return false;
+}
+
 /**
  * Create (or replace) the shared database pool.
  * Call once at application startup.
@@ -35,7 +47,7 @@ export function createPool(config = {}) {
     max: config.max || 20,
     idleTimeoutMillis: config.idleTimeoutMillis || 30000,
     connectionTimeoutMillis: config.connectionTimeoutMillis || 5000,
-    ssl: config.ssl ?? (process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false),
+    ssl: config.ssl ?? resolveSslConfig(),
   };
 
   // If connectionString is set, it takes precedence — remove individual fields

--- a/src/shared/database.js
+++ b/src/shared/database.js
@@ -30,6 +30,18 @@ if (!process.env.DATABASE_URL) {
     }
 }
 
+// SSL is opt-in via DB_SSL/PGSSLMODE, not inferred from NODE_ENV: pgbouncer
+// (edoburu/pgbouncer, see mws-58d) ships with client_tls_sslmode=disable and no
+// certs, so forcing SSL whenever NODE_ENV=production breaks every pooled
+// connection (mws-qz0). Set DB_SSL=true/require once TLS is actually provisioned.
+function resolveSslConfig() {
+    const mode = (process.env.DB_SSL || process.env.PGSSLMODE || '').toLowerCase();
+    if (['true', '1', 'require', 'verify-ca', 'verify-full'].includes(mode)) {
+        return { rejectUnauthorized: false };
+    }
+    return false;
+}
+
 export class DatabaseManager {
     constructor() {
         try {
@@ -57,7 +69,7 @@ export class DatabaseManager {
 
             this.pool = new Pool({
                 connectionString: process.env.DATABASE_URL,
-                ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+                ssl: resolveSslConfig(),
                 // Connection pool optimization (reduced for PGBouncer compatibility)
                 // When using PGBouncer, each application instance should use fewer connections
                 // since PGBouncer handles connection multiplexing


### PR DESCRIPTION
## Summary
- `src/shared/database.js` and `src/db.js` both forced `ssl:{rejectUnauthorized:false}` whenever `NODE_ENV==='production'`. Since docker-compose.yml defaults `NODE_ENV` to `production` and pgbouncer (edoburu/pgbouncer, mws-58d) has no TLS certs and `client_tls_sslmode=disable`, node-postgres throws `The server does not support SSL connections` on any deployment that doesn't override `NODE_ENV` via `.env`.
- SSL is now opt-in via an explicit `DB_SSL` or `PGSSLMODE` env var (accepts `true`/`require`/`verify-ca`/`verify-full`), defaulting to disabled — matching MCP-Electron-App's `database-connection.ts`, which sets no `ssl` key at all.
- Documented the new `DB_SSL` var in `.env.example` and `docs/DEPLOYMENT.md`.

This is fix option 1 from the bead (the smaller change vs. provisioning real TLS certs for pgbouncer).

## Test plan
- [x] `node --check` on both edited files
- [x] Manual verification: `createPool()`/`DatabaseManager` construct `ssl: false` with `NODE_ENV=production` and no `DB_SSL`/`PGSSLMODE` set
- [x] Manual verification: `DB_SSL=require`/`DB_SSL=true`/`PGSSLMODE=verify-full` all still produce `ssl: {rejectUnauthorized:false}`
- [ ] Container smoke test against the pooled `DATABASE_URL` with `NODE_ENV=production` (not run here — no live pgbouncer/postgres in this environment)

Closes bead: mws-qz0