### PR TITLE
fix(author,series,book,chapter): return structured JSON with updated_at

### DIFF
--- a/src/mcps/author-server/handlers/author-handlers.js
+++ b/src/mcps/author-server/handlers/author-handlers.js
@@ -26,18 +26,15 @@ export class AuthorHandlers {
             const result = await this.db.query(query);
 
             return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Found ${result.rows.length} authors:\n\n` +
-                              result.rows.map(author =>
-                                  `ID: ${author.id}\n` +
-                                  `Name: ${author.name}\n` +
-                                  `Birth Year: ${author.birth_year || 'Unknown'}\n` +
-                                  `Bio: ${author.bio || 'No biography available'}\n`
-                              ).join('\n---\n\n')
-                    }
-                ]
+                authors: result.rows.map(author => ({
+                    id: author.id,
+                    name: author.name,
+                    email: author.email,
+                    birth_year: author.birth_year,
+                    bio: author.bio,
+                    created_at: author.created_at,
+                    updated_at: author.updated_at
+                }))
             };
         } catch (error) {
             throw new Error(`Failed to list authors: ${error.message}`);
@@ -52,29 +49,24 @@ export class AuthorHandlers {
 
             if (result.rows.length === 0) {
                 return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `No author found with ID: ${author_id}`
-                        }
-                    ]
+                    error: 'not_found',
+                    author_id,
+                    message: `No author found with ID: ${author_id}`
                 };
             }
 
             const author = result.rows[0];
 
             return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Author Details:\n\n` +
-                              `ID: ${author.id}\n` +
-                              `Name: ${author.name}\n` +
-                              `Email: ${author.email}\n` +
-                              `Birth Year: ${author.birth_year || 'Unknown'}\n` +
-                              `Bio: ${author.bio || 'No biography available'}\n`
-                    }
-                ]
+                author: {
+                    id: author.id,
+                    name: author.name,
+                    email: author.email,
+                    birth_year: author.birth_year,
+                    bio: author.bio,
+                    created_at: author.created_at,
+                    updated_at: author.updated_at
+                }
             };
         } catch (error) {
             throw new Error(`Failed to get author: ${error.message}`);
@@ -154,28 +146,24 @@ export class AuthorHandlers {
 
             if (result.rows.length === 0) {
                 return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `No author found with ID: ${author_id}`
-                        }
-                    ]
+                    error: 'not_found',
+                    author_id,
+                    message: `No author found with ID: ${author_id}`
                 };
             }
 
             const author = result.rows[0];
 
             return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Updated author successfully!\n\n` +
-                              `ID: ${author.id}\n` +
-                              `Name: ${author.name}\n` +
-                              `Birth Year: ${author.birth_year || 'Unknown'}\n` +
-                              `Bio: ${author.bio || 'No biography available'}\n`
-                    }
-                ]
+                author: {
+                    id: author.id,
+                    name: author.name,
+                    email: author.email,
+                    birth_year: author.birth_year,
+                    bio: author.bio,
+                    created_at: author.created_at,
+                    updated_at: author.updated_at
+                }
             };
         } catch (error) {
             throw new Error(`Failed to update author: ${error.message}`);

--- a/src/mcps/book-server/handlers/book-handlers.js
+++ b/src/mcps/book-server/handlers/book-handlers.js
@@ -80,55 +80,53 @@ export class BookHandlers {
             query += ' ORDER BY s.title, b.book_number';
             
             const result = await this.db.query(query, params);
-            
-            let booksText = `Found ${result.rows.length} books:\n\n`;
-            
+
+            const books = [];
             for (const book of result.rows) {
-                booksText += `ID: ${book.id}\n`;
-                booksText += `Title: ${book.title}\n`;
-                booksText += `Series: ${book.series_title} (#${book.book_number})\n`;
-                booksText += `Author: ${book.author_name}\n`;
-                booksText += `Status: ${book.status}\n`;
-                booksText += `Published: ${book.publication_year || 'Unknown'}\n`;
-                
+                const bookData = {
+                    id: book.id,
+                    title: book.title,
+                    series_id: book.series_id,
+                    series_title: book.series_title,
+                    book_number: book.book_number,
+                    author_name: book.author_name,
+                    status: book.status,
+                    publication_year: book.publication_year,
+                    target_word_count: book.target_word_count,
+                    actual_word_count: book.actual_word_count,
+                    page_count: book.page_count,
+                    isbn: book.isbn,
+                    description: book.description,
+                    genre_names: book.genre_names || [],
+                    created_at: book.created_at,
+                    updated_at: book.updated_at
+                };
+
                 if (include_stats) {
                     // Get chapter count and total word count
                     const statsQuery = `
-                        SELECT 
+                        SELECT
                             COUNT(*) as chapter_count,
                             COALESCE(SUM(word_count), 0) as total_words
-                        FROM chapters 
+                        FROM chapters
                         WHERE book_id = $1
                     `;
                     const statsResult = await this.db.query(statsQuery, [book.id]);
                     const stats = statsResult.rows[0];
-                    
-                    booksText += `Chapters: ${stats.chapter_count}\n`;
-                    booksText += `Current Words: ${stats.total_words}\n`;
-                    booksText += `Target Words: ${book.target_word_count || 'Not specified'}\n`;
-                    if (book.target_word_count && stats.total_words > 0) {
-                        const progress = Math.round((stats.total_words / book.target_word_count) * 100);
-                        booksText += `Progress: ${progress}%\n`;
-                    }
+
+                    bookData.stats = {
+                        chapter_count: parseInt(stats.chapter_count) || 0,
+                        total_words: parseInt(stats.total_words) || 0,
+                        progress_percent: (book.target_word_count && stats.total_words > 0)
+                            ? Math.round((stats.total_words / book.target_word_count) * 100)
+                            : null
+                    };
                 }
-                
-                booksText += `Pages: ${book.page_count || 'Unknown'}\n`;
-                booksText += `ISBN: ${book.isbn || 'Not specified'}\n`;
-                booksText += `Description: ${book.description || 'No description available'}\n`;
-                
-                if (book.genre_names && book.genre_names.length > 0) {
-                    booksText += `Genre Tags: ${book.genre_names.join(', ')}\n`;
-                }
-                
-                booksText += '\n---\n\n';
+
+                books.push(bookData);
             }
-            
-            return {
-                content: [{
-                    type: 'text',
-                    text: booksText
-                }]
-            };
+
+            return { books };
         } catch (error) {
             throw new Error(`Failed to list books: ${error.message}`);
         }
@@ -148,66 +146,49 @@ export class BookHandlers {
                 WHERE b.id = $1
             `;
             const result = await this.db.query(query, [book_id]);
-            
+
             if (result.rows.length === 0) {
                 return {
-                    content: [{
-                        type: 'text',
-                        text: `No book found with ID: ${book_id}`
-                    }]
+                    error: 'not_found',
+                    book_id,
+                    message: `No book found with ID: ${book_id}`
                 };
             }
-            
-            const book = result.rows[0];
-            
-            let bookText = `Book Details:\n\n`;
-            bookText += `ID: ${book.id}\n`;
-            bookText += `Title: ${book.title}\n`;
-            bookText += `Series: ${book.series_title} (#${book.book_number})\n`;
-            bookText += `Author: ${book.author_name}\n`;
-            bookText += `Status: ${book.status}\n`;
-            bookText += `Target Word Count: ${book.target_word_count || 'Not specified'}\n`;
-            bookText += `Current Word Count: ${book.actual_word_count || 0}\n`;
-            bookText += `Published: ${book.publication_year || 'Unknown'}\n`;
-            bookText += `Pages: ${book.page_count || 'Unknown'}\n`;
-            bookText += `ISBN: ${book.isbn || 'Not specified'}\n`;
-            
-            if (book.cover_image_url) {
-                bookText += `Cover Image: ${book.cover_image_url}\n`;
-            }
 
-            if (book.genre_names && book.genre_names.length > 0) {
-                bookText += `Genre Tags: ${book.genre_names.join(', ')}\n`;
-            }
-            
-            bookText += `Description: ${book.description || 'No description available'}\n`;
+            const book = result.rows[0];
+
+            const bookData = {
+                id: book.id,
+                title: book.title,
+                series_id: book.series_id,
+                series_title: book.series_title,
+                book_number: book.book_number,
+                author_name: book.author_name,
+                status: book.status,
+                target_word_count: book.target_word_count,
+                actual_word_count: book.actual_word_count || 0,
+                publication_year: book.publication_year,
+                page_count: book.page_count,
+                isbn: book.isbn,
+                cover_image_url: book.cover_image_url,
+                genre_names: book.genre_names || [],
+                description: book.description,
+                created_at: book.created_at,
+                updated_at: book.updated_at
+            };
 
             if (include_chapters) {
                 const chaptersQuery = `
                     SELECT id, chapter_number, title, word_count, status
-                    FROM chapters 
-                    WHERE book_id = $1 
+                    FROM chapters
+                    WHERE book_id = $1
                     ORDER BY chapter_number
                 `;
                 const chaptersResult = await this.db.query(chaptersQuery, [book_id]);
-                
-                if (chaptersResult.rows.length > 0) {
-                    bookText += `\nChapters (${chaptersResult.rows.length}):\n`;
-                    chaptersResult.rows.forEach(chapter => {
-                        bookText += `  ${chapter.chapter_number}. ${chapter.title || 'Untitled'} `;
-                        bookText += `(${chapter.word_count || 0} words, ${chapter.status})\n`;
-                    });
-                } else {
-                    bookText += `\nNo chapters created yet.\n`;
-                }
+                bookData.chapters = chaptersResult.rows;
             }
-            
-            return {
-                content: [{
-                    type: 'text',
-                    text: bookText
-                }]
-            };
+
+            return { book: bookData };
         } catch (error) {
             throw new Error(`Failed to get book: ${error.message}`);
         }
@@ -349,10 +330,9 @@ export class BookHandlers {
 
                 if (result.rows.length === 0) {
                     return {
-                        content: [{
-                            type: 'text',
-                            text: `No book found with ID: ${book_id}`
-                        }]
+                        error: 'not_found',
+                        book_id,
+                        message: `No book found with ID: ${book_id}`
                     };
                 }
             }
@@ -393,18 +373,25 @@ export class BookHandlers {
             const book = bookResult.rows[0];
 
             return {
-                content: [{
-                    type: 'text',
-                    text: `Updated book successfully!\n\n` +
-                          `ID: ${book.id}\n` +
-                          `Title: ${book.title}\n` +
-                          `Series: ${book.series_title || 'Unknown'} (#${book.book_number})\n` +
-                          `Author: ${book.author_name || 'Unknown'}\n` +
-                          `Status: ${book.status}\n` +
-                          `Target Word Count: ${book.target_word_count || 'Not specified'}\n` +
-                          `Current Word Count: ${book.actual_word_count || 0}\n` +
-                          `Genre Tags: ${book.genre_names && book.genre_names.length > 0 ? book.genre_names.join(', ') : 'None'}\n` 
-                }]
+                book: {
+                    id: book.id,
+                    title: book.title,
+                    series_id: book.series_id,
+                    series_title: book.series_title,
+                    book_number: book.book_number,
+                    author_name: book.author_name,
+                    status: book.status,
+                    target_word_count: book.target_word_count,
+                    actual_word_count: book.actual_word_count || 0,
+                    publication_year: book.publication_year,
+                    page_count: book.page_count,
+                    isbn: book.isbn,
+                    cover_image_url: book.cover_image_url,
+                    genre_names: book.genre_names || [],
+                    description: book.description,
+                    created_at: book.created_at,
+                    updated_at: book.updated_at
+                }
             };
         } catch (error) {
             throw new Error(`Failed to update book: ${error.message}`);

--- a/src/mcps/book-server/handlers/chapter-handlers.js
+++ b/src/mcps/book-server/handlers/chapter-handlers.js
@@ -148,36 +148,35 @@ export class ChapterHandlers {
             `;
             
             const result = await this.db.query(query, params);
-            
+
             if (result.rows.length === 0) {
                 return {
-                    content: [{
-                        type: 'text',
-                        text: `No chapter found with ID: ${chapter_id}`
-                    }]
+                    error: 'not_found',
+                    chapter_id,
+                    message: `No chapter found with ID: ${chapter_id}`
                 };
             }
-            
+
             const chapter = result.rows[0];
-            
+
             // Get book title for display
             const bookQuery = 'SELECT title FROM books WHERE id = $1';
             const bookResult = await this.db.query(bookQuery, [chapter.book_id]);
             const bookTitle = bookResult.rows[0]?.title || 'Unknown';
-            
-            let responseText = `Updated chapter successfully!\n\n`;
-            responseText += `ID: ${chapter.id}\n`;
-            responseText += `Book: ${bookTitle}\n`;
-            responseText += `Chapter: ${chapter.chapter_number}${chapter.title ? ` - ${chapter.title}` : ''}\n`;
-            responseText += `Status: ${chapter.status}\n`;
-            responseText += `Word Count: ${chapter.word_count || 0}\n`;
-            responseText += `Target: ${chapter.target_word_count || 'Not specified'}\n`;
-            
+
             return {
-                content: [{
-                    type: 'text',
-                    text: responseText
-                }]
+                chapter: {
+                    id: chapter.id,
+                    book_id: chapter.book_id,
+                    book_title: bookTitle,
+                    chapter_number: chapter.chapter_number,
+                    title: chapter.title,
+                    status: chapter.status,
+                    word_count: chapter.word_count || 0,
+                    target_word_count: chapter.target_word_count,
+                    created_at: chapter.created_at,
+                    updated_at: chapter.updated_at
+                }
             };
         } catch (error) {
             throw new Error(`Failed to update chapter: ${error.message}`);
@@ -198,87 +197,54 @@ export class ChapterHandlers {
             `;
             
             const result = await this.db.query(query, [chapter_id]);
-            
+
             if (result.rows.length === 0) {
                 return {
-                    content: [{
-                        type: 'text',
-                        text: `No chapter found with ID: ${chapter_id}`
-                    }]
+                    error: 'not_found',
+                    chapter_id,
+                    message: `No chapter found with ID: ${chapter_id}`
                 };
             }
-            
+
             const chapter = result.rows[0];
-            
-            let chapterText = `Chapter Details:\n\n`;
-            chapterText += `ID: ${chapter.id}\n`;
-            chapterText += `Book: ${chapter.book_title}\n`;
-            chapterText += `Chapter: ${chapter.chapter_number}${chapter.title ? ` - ${chapter.title}` : ''}\n`;
-            
-            if (chapter.subtitle) {
-                chapterText += `Subtitle: ${chapter.subtitle}\n`;
-            }
-            
-            chapterText += `Status: ${chapter.status}\n`;
-            chapterText += `Word Count: ${chapter.word_count || 0}\n`;
-            chapterText += `Target Words: ${chapter.target_word_count || 'Not specified'}\n`;
-            
-            if (chapter.pov_character_name) {
-                chapterText += `POV Character: ${chapter.pov_character_name}\n`;
-            }
-            
-            if (chapter.primary_location) {
-                chapterText += `Primary Location: ${chapter.primary_location}\n`;
-            }
-            
-            if (chapter.story_time_start) {
-                chapterText += `Timeline: ${chapter.story_time_start}`;
-                if (chapter.story_time_end) {
-                    chapterText += ` - ${chapter.story_time_end}`;
-                }
-                if (chapter.story_duration) {
-                    chapterText += ` (Duration: ${chapter.story_duration})`;
-                }
-                chapterText += `\n`;
-            }
-            
-            if (chapter.summary) {
-                chapterText += `Summary: ${chapter.summary}\n`;
-            }
-            
-            if (chapter.author_notes) {
-                chapterText += `Author Notes: ${chapter.author_notes}\n`;
-            }
-            
-            if (chapter.writing_notes) {
-                chapterText += `Writing Notes: ${chapter.writing_notes}\n`;
-            }
+
+            const chapterData = {
+                id: chapter.id,
+                book_id: chapter.book_id,
+                book_title: chapter.book_title,
+                chapter_number: chapter.chapter_number,
+                title: chapter.title,
+                subtitle: chapter.subtitle,
+                status: chapter.status,
+                word_count: chapter.word_count || 0,
+                target_word_count: chapter.target_word_count,
+                pov_character_id: chapter.pov_character_id,
+                pov_character_name: chapter.pov_character_name,
+                primary_location: chapter.primary_location,
+                story_time_start: chapter.story_time_start,
+                story_time_end: chapter.story_time_end,
+                story_duration: chapter.story_duration,
+                summary: chapter.summary,
+                author_notes: chapter.author_notes,
+                writing_notes: chapter.writing_notes,
+                created_at: chapter.created_at,
+                updated_at: chapter.updated_at
+            };
 
             if (include_scenes) {
                 const scenesQuery = `
                     SELECT id, scene_number, scene_title, word_count, location
-                    FROM chapter_scenes 
-                    WHERE chapter_id = $1 
+                    FROM chapter_scenes
+                    WHERE chapter_id = $1
                     ORDER BY scene_number
                 `;
                 const scenesResult = await this.db.query(scenesQuery, [chapter_id]);
-                
-                if (scenesResult.rows.length > 0) {
-                    chapterText += `\nScenes (${scenesResult.rows.length}):\n`;
-                    scenesResult.rows.forEach(scene => {
-                        chapterText += `  Scene ${scene.scene_number}${scene.scene_title ? `: ${scene.scene_title}` : ''} `;
-                        chapterText += `(${scene.word_count || 0} words)`;
-                        if (scene.location) chapterText += ` @ ${scene.location}`;
-                        chapterText += `\n`;
-                    });
-                } else {
-                    chapterText += `\nNo scenes created yet.\n`;
-                }
+                chapterData.scenes = scenesResult.rows;
             }
 
             if (include_characters) {
                 const charactersQuery = `
-                    SELECT ch.name, ccp.presence_type, ccp.importance_level, 
+                    SELECT ch.name, ccp.presence_type, ccp.importance_level,
                            ccp.physical_state, ccp.emotional_state
                     FROM character_chapter_presence ccp
                     JOIN characters ch ON ccp.character_id = ch.id
@@ -286,30 +252,10 @@ export class ChapterHandlers {
                     ORDER BY ccp.importance_level, ch.name
                 `;
                 const charactersResult = await this.db.query(charactersQuery, [chapter_id]);
-                
-                if (charactersResult.rows.length > 0) {
-                    chapterText += `\nCharacter Presence (${charactersResult.rows.length}):\n`;
-                    charactersResult.rows.forEach(char => {
-                        chapterText += `  ${char.name} (${char.presence_type}`;
-                        if (char.importance_level) chapterText += `, ${char.importance_level}`;
-                        chapterText += `)`;
-                        if (char.physical_state || char.emotional_state) {
-                            const states = [char.physical_state, char.emotional_state].filter(Boolean);
-                            chapterText += ` - ${states.join(', ')}`;
-                        }
-                        chapterText += `\n`;
-                    });
-                } else {
-                    chapterText += `\nNo character presence tracked yet.\n`;
-                }
+                chapterData.character_presence = charactersResult.rows;
             }
-            
-            return {
-                content: [{
-                    type: 'text',
-                    text: chapterText
-                }]
-            };
+
+            return { chapter: chapterData };
         } catch (error) {
             throw new Error(`Failed to get chapter: ${error.message}`);
         }
@@ -338,67 +284,52 @@ export class ChapterHandlers {
             query += ' ORDER BY c.chapter_number';
             
             const result = await this.db.query(query, params);
-            
+
             if (result.rows.length === 0) {
                 return {
-                    content: [{
-                        type: 'text',
-                        text: `No chapters found for book ID: ${book_id}`
-                    }]
+                    book_id,
+                    chapters: [],
+                    message: `No chapters found for book ID: ${book_id}`
                 };
             }
-            
+
             // Get book title
             const bookQuery = 'SELECT title FROM books WHERE id = $1';
             const bookResult = await this.db.query(bookQuery, [book_id]);
             const bookTitle = bookResult.rows[0]?.title || 'Unknown';
-            
-            let chaptersText = `Chapters for "${bookTitle}" (${result.rows.length} chapters):\n\n`;
-            
+
+            const chapters = [];
             for (const chapter of result.rows) {
-                chaptersText += `Id: ${chapter.id}\n`;
-                chaptersText += `  Chapter ${chapter.chapter_number}${chapter.title ? `: ${chapter.title}` : ' (Untitled)'}\n`;
-                chaptersText += `  Status: ${chapter.status}\n`;
-                chaptersText += `  Words: ${chapter.word_count || 0}`;
-                
-                if (chapter.target_word_count) {
-                    const progress = Math.round(((chapter.word_count || 0) / chapter.target_word_count) * 100);
-                    chaptersText += ` / ${chapter.target_word_count} (${progress}%)`;
-                }
-                chaptersText += `\n`;
-                
-                if (chapter.pov_character_name) {
-                    chaptersText += `  POV: ${chapter.pov_character_name}\n`;
-                }
-                
-                if (chapter.primary_location) {
-                    chaptersText += `  Location: ${chapter.primary_location}\n`;
-                }
-                
+                const chapterData = {
+                    id: chapter.id,
+                    chapter_number: chapter.chapter_number,
+                    title: chapter.title,
+                    status: chapter.status,
+                    word_count: chapter.word_count || 0,
+                    target_word_count: chapter.target_word_count,
+                    pov_character_name: chapter.pov_character_name,
+                    primary_location: chapter.primary_location,
+                    summary: chapter.summary,
+                    created_at: chapter.created_at,
+                    updated_at: chapter.updated_at
+                };
+
                 if (include_stats) {
                     // Get scene count
                     const sceneCountQuery = 'SELECT COUNT(*) as scene_count FROM chapter_scenes WHERE chapter_id = $1';
                     const sceneCountResult = await this.db.query(sceneCountQuery, [chapter.id]);
-                    const sceneCount = sceneCountResult.rows[0].scene_count;
-                    
-                    chaptersText += `  Scenes: ${sceneCount}\n`;
+                    chapterData.scene_count = parseInt(sceneCountResult.rows[0].scene_count) || 0;
                 }
-                
-                if (chapter.summary) {
-                    const shortSummary = chapter.summary.length > 100 
-                        ? chapter.summary.substring(0, 100) + '...' 
-                        : chapter.summary;
-                    chaptersText += `  Summary: ${shortSummary}\n`;
-                }
-                
-                chaptersText += `\n`;
+
+                chapters.push(chapterData);
             }
-            
+
             return {
-                content: [{
-                    type: 'text',
-                    text: chaptersText
-                }]
+                book: {
+                    id: book_id,
+                    title: bookTitle
+                },
+                chapters
             };
         } catch (error) {
             throw new Error(`Failed to list chapters: ${error.message}`);

--- a/src/mcps/series-server/handlers/series-handlers.js
+++ b/src/mcps/series-server/handlers/series-handlers.js
@@ -44,21 +44,18 @@ export class SeriesHandlers {
             }));
 
             return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Found ${seriesWithAuthors.length} series:\n\n` +
-                              seriesWithAuthors.map(series =>
-                                  `ID: ${series.id}\n` +
-                                  `Title: ${series.title}\n` +
-                                  `Author: ${series.author_name}\n` +
-                                  `Genres: ${series.genre_names?.length > 0 ? series.genre_names.join(', ') : 'None'}\n` +
-                                  `Status: ${series.status || 'Unknown'}\n` +
-                                  `Start Year: ${series.start_year || 'Unknown'}\n` +
-                                  `Description: ${series.description || 'No description available'}\n`
-                              ).join('\n---\n\n')
-                    }
-                ]
+                series: seriesWithAuthors.map(series => ({
+                    id: series.id,
+                    title: series.title,
+                    author_id: series.author_id,
+                    author_name: series.author_name,
+                    genre_names: series.genre_names || [],
+                    status: series.status,
+                    start_year: series.start_year,
+                    description: series.description,
+                    created_at: series.created_at,
+                    updated_at: series.updated_at
+                }))
             };
         } catch (error) {
             console.error('[SERIES-HANDLERS] handleListSeries error:', error);
@@ -84,12 +81,9 @@ export class SeriesHandlers {
 
             if (result.rows.length === 0) {
                 return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `No series found with ID: ${series_id}`
-                        }
-                    ]
+                    error: 'not_found',
+                    series_id,
+                    message: `No series found with ID: ${series_id}`
                 };
             }
 
@@ -100,19 +94,18 @@ export class SeriesHandlers {
             const authorName = authorResult.rows[0]?.name || 'Unknown';
 
             return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Series Details:\n\n` +
-                              `ID: ${series.id}\n` +
-                              `Title: ${series.title}\n` +
-                              `Author: ${authorName}\n` +
-                              `Genres: ${series.genre_names?.length > 0 ? series.genre_names.join(', ') : 'None'}\n` +
-                              `Status: ${series.status || 'Unknown'}\n` +
-                              `Start Year: ${series.start_year || 'Unknown'}\n` +
-                              `Description: ${series.description || 'No description available'}\n`
-                    }
-                ]
+                series: {
+                    id: series.id,
+                    title: series.title,
+                    author_id: series.author_id,
+                    author_name: authorName,
+                    genre_names: series.genre_names || [],
+                    status: series.status,
+                    start_year: series.start_year,
+                    description: series.description,
+                    created_at: series.created_at,
+                    updated_at: series.updated_at
+                }
             };
         } catch (error) {
             throw new Error(`Failed to get series: ${error.message}`);
@@ -227,12 +220,9 @@ export class SeriesHandlers {
 
                 if (result.rows.length === 0) {
                     return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: `No series found with ID: ${series_id}`
-                            }
-                        ]
+                        error: 'not_found',
+                        series_id,
+                        message: `No series found with ID: ${series_id}`
                     };
                 }
             }
@@ -264,19 +254,18 @@ export class SeriesHandlers {
             const authorName = authorResult.rows[0]?.name || 'Unknown';
 
             return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Updated series successfully!\n\n` +
-                              `ID: ${series.id}\n` +
-                              `Title: ${series.title}\n` +
-                              `Author: ${authorName}\n` +
-                              `Genres: ${series.genre_names?.length > 0 ? series.genre_names.join(', ') : 'None'}\n` +
-                              `Status: ${series.status || 'Not specified'}\n` +
-                              `Start Year: ${series.start_year || 'Not specified'}\n` +
-                              `Description: ${series.description || 'No description available'}\n`
-                    }
-                ]
+                series: {
+                    id: series.id,
+                    title: series.title,
+                    author_id: series.author_id,
+                    author_name: authorName,
+                    genre_names: series.genre_names || [],
+                    status: series.status,
+                    start_year: series.start_year,
+                    description: series.description,
+                    created_at: series.created_at,
+                    updated_at: series.updated_at
+                }
             };
         } catch (error) {
             if (error.code === '23503') { // Foreign key violation


### PR DESCRIPTION
## Summary
- `list_authors`/`get_author`/`update_author`, `list_series`/`get_series`/`update_series`, `list_books`/`get_book`/`update_book`, and `update_chapter`/`get_chapter`/`list_chapters` now return plain structured JSON data objects (matching the scene/kanban server response shape) instead of hand-assembled prose text blobs.
- Every row returned by these handlers now includes `id`/`created_at`/`updated_at`, closing the same JSON/updated_at gap already fixed for scene handlers in e20c292 (mws-1by) -- this was filed as a follow-up (mws-ogi) at the time.
- `create_*` and `delete_*` handlers are intentionally left as prose, matching e20c292's scope (no truncation pattern was found in these handlers, only the JSON/updated_at gap).
- No dispatcher changes needed: `base-server.js`'s `formatSuccess()` already JSON-stringifies any non-string handler return into the MCP `content` envelope.

## Test plan
- [x] `node --check` on all 4 changed files
- [x] Manual smoke test against a live local Postgres (author/series/book/chapter create -> list/get/update -> verify JSON shape + `updated_at` bump on update -> not-found paths return `{error:'not_found', ...}`) -- all passed, temp script removed before commit
- [x] Verified (via research agent) that no other code in the repo (config-mcps wrappers, HTTP/SSE transport, other handlers, tests) parses these tools' responses as `.content[0].text` prose -- the dispatcher wraps everything uniformly regardless of return shape

Closes bead: mws-ogi